### PR TITLE
fix(reader): stop the note popup growing scrollbars of its own

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/components/FootnotePopupSizing.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/FootnotePopupSizing.test.tsx
@@ -7,6 +7,9 @@ import { act, cleanup, render } from '@testing-library/react';
 // commit and threw that measurement away.
 
 const PARAGRAPH_HEIGHT = 152;
+// The popup box carries a 1px border on each side, and the paragraph is
+// measured for the room inside it, so the box is that much taller (#5999).
+const POPUP_HEIGHT = PARAGRAPH_HEIGHT + 2;
 
 const h = vi.hoisted(() => ({
   viewSettings: { vertical: false, scrolled: false },
@@ -82,7 +85,6 @@ vi.mock('@/utils/event', () => ({
 import FootnotePopup from '@/app/reader/components/FootnotePopup';
 import { BookDoc } from '@/libs/document';
 
-const footnoteBox = () => document.querySelector<HTMLElement>('.footnote-content');
 const popupContainer = () => document.querySelector<HTMLElement>('#popup-container');
 
 // Just enough of a foliate view for the popup's before-render/render wiring.
@@ -153,7 +155,7 @@ describe('footnote popup built from a data/alt attribute', () => {
       });
     });
 
-    expect(footnoteBox()?.style.height).toBe(`${PARAGRAPH_HEIGHT}px`);
+    expect(popupContainer()?.style.height).toBe(`${POPUP_HEIGHT}px`);
   });
 });
 

--- a/apps/readest-app/src/__tests__/app/reader/components/footnote-popup-overflow.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/footnote-popup-overflow.browser.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * Layout of the footnote/note popup box, measured with real CSS.
+ *
+ * The popup must never grow its own scrollbars around content that already
+ * fits (#5999), and the "Jump to Location" chrome must sit where the note's
+ * last line runs out rather than over its opening words (#5998).
+ *
+ * `Popup` applies the requested width/height to `#popup-container` as a
+ * border-box and draws a 1px border, so its content box is 2px smaller on each
+ * axis. FootnotePopup used to hand the same numbers to `.footnote-content`,
+ * which then overflowed by 2px in both directions. `overflow-y-auto` on the
+ * container makes `overflow-x` compute to `auto` as well (a `visible` value
+ * next to a non-`visible` one becomes `auto`), so the reader saw a vertical
+ * *and* a horizontal scrollbar wrapped around the one the popup document
+ * already has.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+
+import '@/styles/globals.css';
+
+const h = vi.hoisted(() => ({
+  viewSettings: { vertical: false, rtl: false, scrolled: false },
+  dispatchFootnote: (() => {}) as (detail: unknown) => void,
+  onLinkClick: { current: null as ((event: Event) => void) | null },
+  handlers: [] as EventTarget[],
+}));
+
+vi.mock('@/context/EnvContext', () => ({ useEnv: () => ({ appService: { isMobile: false } }) }));
+vi.mock('@/hooks/useTranslation', () => ({ useTranslation: () => (s: string) => s }));
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    getView: () => ({ goTo: () => {} }),
+    getViewSettings: () => h.viewSettings,
+  }),
+}));
+vi.mock('@/store/bookDataStore', () => {
+  const store = (selector?: (s: unknown) => unknown) =>
+    selector ? selector({ booksData: {} }) : { getBookData: () => ({ book: {} }) };
+  store.getState = () => ({ booksData: {} });
+  return { useBookDataStore: store };
+});
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: { getState: () => ({ settings: {} }) },
+}));
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: { getState: () => ({ isDarkMode: false }) },
+  getThemeCode: () => ({}),
+}));
+vi.mock('@/store/customFontStore', () => ({
+  useCustomFontStore: () => ({ getLoadedFonts: () => [] }),
+}));
+vi.mock('@/app/reader/hooks/useFoliateEvents', () => ({
+  useFoliateEvents: (_view: unknown, handlers?: { onLinkClick?: (event: Event) => void }) => {
+    h.onLinkClick.current = handlers?.onLinkClick ?? null;
+  },
+}));
+vi.mock('@/app/reader/utils/footnoteHeuristics', () => ({
+  shouldCheckAsFootnote: () => false,
+  isLinkTargetVisible: () => true,
+}));
+vi.mock('@/app/reader/utils/annotatorUtil', () => ({ drawAnnotationOverlay: () => {} }));
+vi.mock('@/utils/style', () => ({
+  getStyles: () => '',
+  getFootnoteStyles: () => '',
+  getThemeCode: () => ({ bg: '#fff', fg: '#000' }),
+}));
+vi.mock('@/styles/fonts', () => ({
+  mountAdditionalFonts: () => {},
+  mountCustomFont: () => {},
+}));
+vi.mock('foliate-js/footnotes.js', () => {
+  class FootnoteHandler extends EventTarget {
+    constructor() {
+      super();
+      h.handlers.push(this);
+    }
+    handle() {
+      return Promise.resolve();
+    }
+  }
+  return { FootnoteHandler };
+});
+vi.mock('@/utils/event', () => ({
+  eventDispatcher: {
+    on: (name: string, cb: (e: CustomEvent) => void) => {
+      if (name === 'footnote-popup') h.dispatchFootnote = (detail) => cb({ detail } as CustomEvent);
+    },
+    off: () => {},
+    dispatch: () => {},
+  },
+}));
+
+import FootnotePopup from '@/app/reader/components/FootnotePopup';
+import { BookDoc } from '@/libs/document';
+
+const popupContainer = () => document.querySelector<HTMLElement>('#popup-container')!;
+
+let cell: HTMLElement;
+let anchor: HTMLElement;
+
+/** Drive a link click in the book through to a rendered, document-backed popup. */
+const openLinkedFootnote = () => {
+  const href = 'text/part0012.xhtml#appendix-c';
+  const view = document.createElement('div');
+  Object.defineProperty(view, 'renderer', {
+    value: { viewSize: 220, setAttribute: () => {}, setStyles: () => {} },
+  });
+  act(() => {
+    h.onLinkClick.current?.(
+      new CustomEvent('link', { detail: { a: anchor, href }, cancelable: true }),
+    );
+  });
+  const handler = h.handlers.at(-1)!;
+  act(() => {
+    handler.dispatchEvent(new CustomEvent('before-render', { detail: { view } }));
+    handler.dispatchEvent(
+      new CustomEvent('render', { detail: { view, href, index: 3, extract: null } }),
+    );
+    view.dispatchEvent(new CustomEvent('relocate', { detail: {} }));
+  });
+};
+
+beforeEach(() => {
+  h.viewSettings = { vertical: false, rtl: false, scrolled: false };
+  h.handlers.length = 0;
+  h.onLinkClick.current = null;
+  // The book cell fills the test frame, with the note reference near its
+  // top-left corner so a popup has room to open on either axis.
+  cell = document.createElement('div');
+  cell.id = 'gridcell-book-1';
+  cell.style.cssText = 'position:fixed;inset:0;';
+  anchor = document.createElement('a');
+  anchor.textContent = 'nota 3';
+  anchor.style.cssText = 'position:absolute;left:40px;top:120px;';
+  cell.appendChild(anchor);
+  document.body.appendChild(cell);
+});
+
+afterEach(() => {
+  cell.remove();
+  cleanup();
+});
+
+describe('footnote popup box (#5999)', () => {
+  test('a short note leaves the popup with no scrollbars of its own', () => {
+    render(<FootnotePopup bookKey='book-1' bookDoc={{} as BookDoc} />);
+    act(() => {
+      h.dispatchFootnote({
+        bookKey: 'book-1',
+        element: anchor,
+        footnote: 'nota 3 - Orme di Dante in Italia, tradotto da Egidio Gorra.',
+      });
+    });
+
+    const popup = popupContainer();
+    expect(popup.getAttribute('aria-hidden')).toBe('false');
+    expect(popup.scrollWidth).toBeLessThanOrEqual(popup.clientWidth);
+    expect(popup.scrollHeight).toBeLessThanOrEqual(popup.clientHeight);
+  });
+
+  test('a vertical-layout note leaves the popup with no scrollbars of its own', () => {
+    h.viewSettings = { vertical: true, rtl: false, scrolled: false };
+    render(<FootnotePopup bookKey='book-1' bookDoc={{} as BookDoc} />);
+    act(() => {
+      h.dispatchFootnote({
+        bookKey: 'book-1',
+        element: anchor,
+        footnote: 'nota 3 - Orme di Dante in Italia, tradotto da Egidio Gorra.',
+      });
+    });
+
+    const popup = popupContainer();
+    expect(popup.getAttribute('aria-hidden')).toBe('false');
+    expect(popup.scrollWidth).toBeLessThanOrEqual(popup.clientWidth);
+    expect(popup.scrollHeight).toBeLessThanOrEqual(popup.clientHeight);
+  });
+
+  // Sizing the popup box to the measured content size left the document itself
+  // 2px short of what it asked for, so the scrollbar simply moved one level in:
+  // foliate's own scroll container grew one. The box has to be the measurement
+  // plus the border it is drawn with.
+  test('gives the popup document the full size it measured', () => {
+    render(<FootnotePopup bookKey='book-1' bookDoc={{} as BookDoc} />);
+    openLinkedFootnote(); // the stub renderer reports a viewSize of 220
+
+    const content = document.querySelector<HTMLElement>('.footnote-content')!;
+    expect(content.clientHeight).toBe(220);
+  });
+
+  // At most one scrollbar, ever: a note too long for the box scrolls along its
+  // block axis, and the other axis stays clipped rather than being promoted
+  // from `visible` to `auto` behind the block-axis scroll.
+  test('a note too long for the box scrolls on one axis only', () => {
+    render(<FootnotePopup bookKey='book-1' bookDoc={{} as BookDoc} />);
+    act(() => {
+      h.dispatchFootnote({
+        bookKey: 'book-1',
+        element: anchor,
+        footnote: 'Questa nota e volutamente lunga. '.repeat(120),
+      });
+    });
+
+    const popup = popupContainer();
+    expect(popup.getAttribute('aria-hidden')).toBe('false');
+    expect(popup.scrollHeight).toBeGreaterThan(popup.clientHeight);
+    expect(popup.scrollWidth).toBeLessThanOrEqual(popup.clientWidth);
+    expect(getComputedStyle(popup).overflowX).toBe('hidden');
+  });
+});
+
+// Anchored at the top of the box, the button sat squarely on the note's first
+// line. The last line is where a paragraph runs ragged, so the bottom corner
+// on the side the text ends on is the one that hides the least (#5998).
+describe('jump-to-location button placement (#5998)', () => {
+  const jumpButton = () => document.querySelector<HTMLElement>('[aria-label="Jump to Location"]')!;
+
+  const cornerOfPopup = () => {
+    const popup = popupContainer().getBoundingClientRect();
+    const button = jumpButton().getBoundingClientRect();
+    const center = { x: (button.left + button.right) / 2, y: (button.top + button.bottom) / 2 };
+    return {
+      vertical: center.y > (popup.top + popup.bottom) / 2 ? 'bottom' : 'top',
+      horizontal: center.x > (popup.left + popup.right) / 2 ? 'right' : 'left',
+    };
+  };
+
+  test('sits in the bottom-right corner for a left-to-right book', () => {
+    render(<FootnotePopup bookKey='book-1' bookDoc={{} as BookDoc} />);
+    openLinkedFootnote();
+
+    expect(cornerOfPopup()).toEqual({ vertical: 'bottom', horizontal: 'right' });
+  });
+
+  test('sits in the bottom-left corner for a right-to-left book', () => {
+    h.viewSettings = { vertical: false, rtl: true, scrolled: false };
+    render(<FootnotePopup bookKey='book-1' bookDoc={{} as BookDoc} />);
+    openLinkedFootnote();
+
+    expect(cornerOfPopup()).toEqual({ vertical: 'bottom', horizontal: 'left' });
+  });
+
+  test('sits in the bottom-left corner for a vertical-layout book', () => {
+    h.viewSettings = { vertical: true, rtl: false, scrolled: false };
+    render(<FootnotePopup bookKey='book-1' bookDoc={{} as BookDoc} />);
+    openLinkedFootnote();
+
+    expect(cornerOfPopup()).toEqual({ vertical: 'bottom', horizontal: 'left' });
+  });
+});

--- a/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
+++ b/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
@@ -39,6 +39,18 @@ interface FootnotePopupProps {
 
 const popupWidth = 360;
 const popupHeight = 88;
+// `#popup-container` sizes itself as a border box and draws a 1px border, so
+// the content it holds gets `2 * popupBorder` less than the popup size handed
+// to it. Sizing the content to the popup size instead overflowed the box by
+// those two pixels on both axes, and `overflow-y-auto` promotes `overflow-x`
+// to `auto` too, so the popup wrapped its document in a spurious vertical and
+// horizontal scrollbar (#5999).
+const popupBorder = 1;
+// Every size the popup computes comes from measuring content — the paginator's
+// `viewSize`, the height of the synthesized paragraph — but the number handed
+// to `Popup` is the outer box. Grow the measurement by the border, or the
+// content ends up 2px short of the room it asked for and scrolls for it.
+const popupSizeForContent = (contentSize: number) => contentSize + 2 * popupBorder;
 
 const chromeButtonClassName = clsx(
   'btn btn-ghost btn-circle eink-bordered text-base-content bg-base-200/80 hover:bg-base-200',
@@ -181,9 +193,10 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     const { renderer } = view;
     if (!renderer) return 0;
     const vertical = getViewSettings(bookKey)!.vertical;
+    const box = popupSizeForContent(renderer.viewSize);
     const size = vertical
-      ? clipPopupWith(Math.min(getResponsivePopupSize(renderer.viewSize, true), getMaxWidth()))
-      : clipPopupHeight(Math.min(getResponsivePopupSize(renderer.viewSize, false), getMaxHeight()));
+      ? clipPopupWith(Math.min(getResponsivePopupSize(box, true), getMaxWidth()))
+      : clipPopupHeight(Math.min(getResponsivePopupSize(box, false), getMaxHeight()));
     if (vertical) setResponsiveWidth(size);
     else setResponsiveHeight(size);
     return size;
@@ -544,20 +557,25 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       elem.textContent = footnote;
       elem.setAttribute('style', `padding: 1em; hanging-punctuation: allow-end last;`);
       elem.style.visibility = 'hidden';
+      // Measure the text in the room the popup actually gives it — the seed
+      // less the container border — so the paragraph wraps identically once
+      // mounted (#5999).
       if (viewSettings.vertical) {
-        elem.style.height = `${seed.height}px`;
+        elem.style.height = `${seed.height - 2 * popupBorder}px`;
       } else {
-        elem.style.width = `${seed.width}px`;
+        elem.style.width = `${seed.width - 2 * popupBorder}px`;
       }
       document.body.appendChild(elem);
       const popupSize = elem.getBoundingClientRect();
       if (viewSettings.vertical) {
-        setResponsiveWidth(getResponsivePopupSize(popupSize.width, true));
+        setResponsiveWidth(getResponsivePopupSize(popupSizeForContent(popupSize.width), true));
       } else {
-        setResponsiveHeight(getResponsivePopupSize(popupSize.height, false));
+        setResponsiveHeight(getResponsivePopupSize(popupSizeForContent(popupSize.height), false));
       }
       document.body.removeChild(elem);
 
+      elem.style.width = '';
+      elem.style.height = '';
       elem.style.visibility = 'visible';
       footnoteRef.current.replaceChildren(elem);
       setGridRect(rect);
@@ -686,10 +704,20 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
         height={responsiveHeight}
         position={showPopup ? popupPosition! : undefined}
         trianglePosition={showPopup ? trianglePosition! : undefined}
-        className='select-text overflow-y-auto'
+        // Scroll along the note's block axis and clip the other one. A note
+        // that wraps can never need a horizontal scrollbar, but leaving that
+        // axis `visible` promotes it to `auto` (CSS resolves `visible` to
+        // `auto` next to a non-`visible` value), so any stray pixel of
+        // cross-axis overflow bought a second scrollbar (#5999).
+        className={clsx(
+          'select-text',
+          viewSettings.vertical
+            ? 'overflow-x-auto overflow-y-hidden'
+            : 'overflow-y-auto overflow-x-hidden',
+        )}
         onDismiss={handleDismissPopup}
       >
-        {(canGoBack || sourceHref) && (
+        {canGoBack && (
           // The chrome floats over the text rather than pushing it down, so
           // the strip must not swallow taps meant for the words beneath it.
           <div
@@ -700,42 +728,39 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
                 : 'end-2 start-2 top-2 h-8 flex-row items-start',
             )}
           >
-            {canGoBack && (
-              <button
-                type='button'
-                onClick={handleBack}
-                aria-label={_('Back')}
-                title={_('Back')}
-                className={clsx(chromeButtonClassName, 'pointer-events-auto')}
-              >
-                <MdArrowBack size={size18} />
-              </button>
-            )}
-            {sourceHref && (
-              <button
-                type='button'
-                onClick={handleGoToSource}
-                aria-label={_('Jump to Location')}
-                title={_('Jump to Location')}
-                className={clsx(
-                  chromeButtonClassName,
-                  'pointer-events-auto',
-                  !viewSettings.vertical && 'ms-auto',
-                )}
-              >
-                <MdOutlineArrowOutward size={size18} />
-              </button>
-            )}
+            <button
+              type='button'
+              onClick={handleBack}
+              aria-label={_('Back')}
+              title={_('Back')}
+              className={clsx(chromeButtonClassName, 'pointer-events-auto')}
+            >
+              <MdArrowBack size={size18} />
+            </button>
           </div>
         )}
-        <div
-          className='footnote-content'
-          ref={footnoteRef}
-          style={{
-            width: `${responsiveWidth}px`,
-            height: `${responsiveHeight}px`,
-          }}
-        ></div>
+        {sourceHref && (
+          // Park it where the note's last line runs out instead of over its
+          // opening words (#5998). Physical sides, not logical ones: the corner
+          // follows the book's own direction, which the popup's `dir` (the UI
+          // language) does not track.
+          <button
+            type='button'
+            onClick={handleGoToSource}
+            aria-label={_('Jump to Location')}
+            title={_('Jump to Location')}
+            className={clsx(
+              chromeButtonClassName,
+              'absolute bottom-2 z-10',
+              viewSettings.vertical || viewSettings.rtl ? 'left-2' : 'right-2',
+            )}
+          >
+            <MdOutlineArrowOutward size={size18} />
+          </button>
+        )}
+        {/* Fill the popup's content box rather than restating its border-box
+            size, which overflowed it by the border on both axes (#5999). */}
+        <div className='footnote-content h-full w-full' ref={footnoteRef}></div>
       </Popup>
     </div>
   );


### PR DESCRIPTION
Closes #5999. Closes #5998.

## The bug

<img width="380" alt="reported" src="https://github.com/user-attachments/assets/8fc8324d-ee13-424e-8f14-af55c2535906" />

A note popup wrapped its document in a second vertical scrollbar plus a horizontal one, even for text that fits, and the jump-to-location button sat on the note's opening words.

## Root cause

Every size the popup computes is a measurement of **content** — the paginator's `viewSize`, the height of the paragraph synthesized from a `data`/`alt` attribute. The number handed to `Popup`, though, sizes `#popup-container` as a **border box**, and that box draws a 1px border. The content was always given two pixels less than it asked for.

`.footnote-content` restated the popup's own width and height, putting it 2px past the content box on both axes. `overflow-y-auto` then promoted `overflow-x` from `visible` to `auto` (CSS resolves `visible` to `auto` beside a non-`visible` value), so both scrollbars appeared around the one the popup document already has.

Correcting only the content div moves the problem one level in: foliate's own `#container` then reports the 2px of overflow and draws a full-width scrollbar for it, which also steals 15px of width and forces an extra wrapped line.

## The fix

- `.footnote-content` fills the content box (`h-full w-full`) instead of restating the border-box numbers.
- `popupSizeForContent(n) = n + 2 * popupBorder` grows every content measurement by the border it will be drawn with, used by both `fitPopupToContent` and the alt-attribute path.
- The popup pins its scroll to the note's block axis (`overflow-y-auto overflow-x-hidden`, reversed for vertical books), so the cross axis can never be promoted.
- The jump-to-location button moves to the popup's bottom corner: `right-2` normally, `left-2` when the book is vertical or RTL. Physical sides on purpose — the corner follows the book's direction, which `start`/`end` (the UI language) does not track.

## Verification

`src/__tests__/app/reader/components/footnote-popup-overflow.browser.test.tsx` renders the real component with real CSS under vitest browser mode; each of the 7 cases fails without its part of the fix.

Driven in Chrome against a real book:

| | before | after |
|---|---|---|
| short note | popup `client 358x81 / scroll 358x83`, both scrollbars | no overflow on either axis |
| same note, first patch only | inner `#container` `client 343x81 / scroll 343x83` -> 15px scrollbar | `innerScrollers: []`, note fits on one line |
| note too long for the box | - | popup does not scroll; exactly one scroller, foliate's `#container` `client 250 / scroll 368` |
| jump button | top-right, over the text | bottom-right, clear of the ragged last line |

`pnpm test` 10635 passed, `pnpm test:browser` 51/51 files, `pnpm lint` and `pnpm format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved footnote and note popup sizing to account for borders and measured content.
  * Prevented unwanted scrolling in the cross-axis while preserving scrolling for oversized notes.
  * Ensured popup content fills the available space correctly.
  * Positioned the “Jump to Location” button consistently across left-to-right, right-to-left, and vertical layouts.
  * Hid navigation controls when back navigation is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->