### PR TITLE
fix(opds): import the publication date, not the calibre added-date

### DIFF
--- a/apps/readest-app/src/__tests__/utils/opds-feed.test.ts
+++ b/apps/readest-app/src/__tests__/utils/opds-feed.test.ts
@@ -337,4 +337,67 @@ describe('OPDS feed parsing', () => {
       expect(feed.publications![0]!.metadata.updated).toBeUndefined();
     });
   });
+  // Regression tests for https://github.com/readest/readest/issues/6003
+  //
+  // calibre and Calibre-Web mean opposite things by Atom <published>:
+  //
+  //   calibre (srv/opds.py)      <published> = mi.timestamp (date ADDED),
+  //                              <dcterms:date> = mi.pubdate (the real one)
+  //   Calibre-Web (feed.xml)     <published> = Books.pubdate (the real one),
+  //                              no Dublin Core date at all
+  //
+  // So the Dublin Core dates have to outrank <published>, which is also what
+  // RFC 4287 implies: atom:published is when the ENTRY was published to the
+  // feed, not when the book was published. Getting this backwards made every
+  // calibre download import its added-date as the publication date once
+  // #5477 let feed metadata win over the file's own metadata.
+  describe('publication date precedence (#6003)', () => {
+    const entryOf = (body: string) =>
+      parseXML(
+        `<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom"
+       xmlns:dc="http://purl.org/dc/elements/1.1/"
+       xmlns:dcterms="http://purl.org/dc/terms/">
+  <title>Dune</title>
+  <id>urn:uuid:1234</id>
+  <updated>2026-08-30T12:00:00+00:00</updated>
+  ${body}
+</entry>`,
+      ).documentElement;
+
+    const publishedOf = (body: string) =>
+      (getPublication(entryOf(body)) as OPDSPublication).metadata.published;
+
+    it("prefers calibre's dcterms:date over the added-date in atom:published", () => {
+      expect(
+        publishedOf(`<published>2026-08-30T12:00:00+00:00</published>
+  <dcterms:date>1965-08-01T00:00:00+00:00</dcterms:date>`),
+      ).toBe('1965-08-01T00:00:00+00:00');
+    });
+
+    it('prefers dc:date over atom:published', () => {
+      expect(
+        publishedOf(`<published>2026-08-30T12:00:00+00:00</published>
+  <dc:date>1965-08-01T00:00:00+00:00</dc:date>`),
+      ).toBe('1965-08-01T00:00:00+00:00');
+    });
+
+    it('still prefers dcterms:issued above everything else', () => {
+      expect(
+        publishedOf(`<published>2026-08-30T12:00:00+00:00</published>
+  <dcterms:issued>1965-08-01T00:00:00+00:00</dcterms:issued>
+  <dcterms:date>1970-01-01T00:00:00+00:00</dcterms:date>`),
+      ).toBe('1965-08-01T00:00:00+00:00');
+    });
+
+    it('falls back to atom:published when no Dublin Core date is offered (Calibre-Web)', () => {
+      expect(publishedOf('<published>1965-08-01T00:00:00+00:00</published>')).toBe(
+        '1965-08-01T00:00:00+00:00',
+      );
+    });
+
+    it('leaves published undefined when the entry carries no date at all', () => {
+      expect(publishedOf('')).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
Fixes #6003. readest/foliate-js#88 is **merged**; this pins it.

## Problem

Books downloaded from a **calibre** OPDS catalog get calibre's **"Date" column (the date the book was added to the library)** as their publication date instead of `pubdate`, so sorting by publication date is wrong for every OPDS import. The catalog browsing view shows the same wrong date before any download.

Reported by u/sfgeekygir1: https://www.reddit.com/r/Calibre/comments/1w20i2y/

## Root cause

The two calibre-family servers mean opposite things by Atom `<published>`:

| Server | `atom:published` | Dublin Core date | `dcterms:issued` |
| --- | --- | --- | --- |
| **calibre**, own content server (`src/calibre/srv/opds.py`) | `mi.timestamp` - **date ADDED** | `<dcterms:date>` = `mi.pubdate` - the real one | never emitted |
| **Calibre-Web** (`cps/templates/feed.xml`) | `Books.pubdate` - **the real one** | not emitted | never emitted |

`getPublication()` in foliate-js ordered them `dcterms:issued`, `atom:published`, `filterDC('date')`. For calibre, step 2 matches the added-date and the real pubdate at step 3 is never reached.

readest/foliate-js#66 already targeted this bug (its description names the symptom exactly) but hoisted only `dcterms:issued`, which calibre's own server never emits, so it did not reach calibre. That is what 0.12.6 ships, which is why the reporter still sees it there.

**Why 0.12.1 is the version the reporter names.** The parser bug was display-only until ffdcfca0a (#5477, for #5270, first released in v0.12.1) made feed metadata win over the file's metadata. Before it, the imported book kept the date from the EPUB's own OPF and the library was right; after it, the bad feed value started overwriting correct OPF dates. Worth noting for follow-up: #5270 asked for the cover plus curated `<title>`/`<author>`, and #5477's commit message lists what it meant to carry ("title, author, publisher, language, subjects, identifier, description"). `published` is not in that list but `getOPDSBookMetadata()` maps it anyway.

## Change

Picks up readest/foliate-js#88, which reads the Dublin Core dates above `atom:published`:

```js
published: (children.find(filterDCTERMS('issued'))
        ?? children.find(filterDC('date'))
        ?? children.find(filter('published')))?.textContent ?? undefined,
```

`filterDC` covers both `dc:date` and `dcterms:date`, so every row of the table is satisfied: calibre resolves to `dcterms:date`, and Calibre-Web, having no Dublin Core date, still falls through to `atom:published`. The `dcterms:issued` catalog #66 was written for is unaffected. RFC 4287 agrees on principle: `atom:published` is when the **entry** was published to the feed, not the book.

Submodule bump is `ca3f118..799ab10`, the current foliate-js `main`. #88 was squash-merged, so the pin is the squash commit, not the branch SHA.

Heads up on scope: pinning to `main` also carries **readest/foliate-js#87** ("commit the page turn on drag distance, not release velocity alone"), which landed between the old pin and #88. It is unrelated to OPDS and cannot be excluded without diverging the pin from `main`. Full suite is green with it, but it is a reader-behaviour change riding in on an OPDS fix, so it is worth a look before merge, or split it into its own re-pin if you would rather land the two separately.

## Tests

Adds the date-precedence tests the parser never had, in `src/__tests__/utils/opds-feed.test.ts`, covering all five cases: calibre's `dcterms:date` beating `atom:published`, `dc:date` beating it, `dcterms:issued` still winning outright (guards #66), the Calibre-Web `atom:published` fallback, and the no-date case. The absence of these is how both foliate-js#10 and #66 shipped wrong.

Red before the submodule bump (2 failures), green after (18/18).

## Verification

- `pnpm test`: 10640 passed, 16 skipped, 0 failed (re-run after the re-pin to the merged `main`, so #87 is covered)
- `pnpm lint` (tsc + biome): clean
- `pnpm format:check`: clean
- No `src-tauri/` or koplugin changes, so the Rust and Lua gates do not apply.

## Note for the reporter

Already-imported books keep the bad date; this only affects new downloads and "Download Again" re-imports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OPDS publication-date handling by prioritizing issued dates, followed by standard publication dates and Atom dates.
  * Correctly handles feeds with missing publication dates.
  * Improved compatibility with date formats from Calibre and Calibre-Web.
  * Publication dates should now appear more consistently in OPDS library listings.

* **Tests**
  * Added regression coverage for publication-date precedence and missing-date scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->