### PR TITLE
fix(reader): write a new note on the selection, not in the sidebar

### DIFF
--- a/apps/readest-app/e2e/pages/ReaderPage.ts
+++ b/apps/readest-app/e2e/pages/ReaderPage.ts
@@ -48,8 +48,9 @@ export class ReaderPage extends BasePage {
     this.dictionaryPopup = page.locator('.popup-container:has([data-testid="dict-title"])');
     this.translatorPopup = page.locator('.popup-container:has(h1:text-is("Original Text"))');
     this.proofreadPopup = page.locator('.popup-container:has-text("Selected text:")');
-    // Attached notes are written in the left Annotations panel: Annotate drops
-    // the new annotation straight into BooknoteItem's inline editor.
+    // Annotate opens the note editor on the selection itself — inside the
+    // toolbar popup at desktop widths, in a bottom sheet on phones. The
+    // sidebar's own inline editor shares the test id; only one is ever open.
     this.noteEditor = page.locator('[data-testid="booknote-note-editor"]');
     this.annotationItems = page.locator('li.booknote-item[role="button"]');
     // The app-drawn range-edit handles (the selection / annotation range

--- a/apps/readest-app/e2e/tests/annotation.spec.ts
+++ b/apps/readest-app/e2e/tests/annotation.spec.ts
@@ -103,6 +103,38 @@ test.describe('Annotation', () => {
   // range editor: app-drawn handles in a fixed overlay painted after the lookup
   // popups, so they floated on top of the dictionary (#5815). A lookup hides
   // them; they come back only with the toolbar.
+  // #5815 unmounts the handles for the lookup popups, but the reason they were
+  // ever on top is that both layers were z-50 in one stacking context, so the
+  // tie broke on DOM order and the range editors are rendered last. Any surface
+  // that forgets to join that gate — the note editor did — gets handles drawn
+  // over it. Pin the layer order itself, read off the live DOM.
+  test('draws the range-edit handles below the popup layer', async ({ openBook }) => {
+    const reader = await openBook();
+
+    await reader.selectText();
+    await reader.highlightSelection();
+    await reader.dismissPopup();
+    await reader.clickHighlight();
+
+    await expect(reader.annotationPopup).toBeVisible();
+    await expect(reader.rangeHandles).toHaveCount(2);
+
+    const layers = await reader.page.evaluate(() => {
+      const handleLayer = document
+        .querySelector('[data-testid="selection-handle"]')
+        ?.closest('div.fixed');
+      const popup = document.querySelector('.selection-popup');
+      return {
+        handles: handleLayer ? getComputedStyle(handleLayer).zIndex : null,
+        popup: popup ? getComputedStyle(popup).zIndex : null,
+      };
+    });
+
+    expect(layers.handles).not.toBeNull();
+    expect(layers.popup).not.toBeNull();
+    expect(Number(layers.handles)).toBeLessThan(Number(layers.popup));
+  });
+
   test('hides the range-edit handles while the dictionary popup is open (#5815)', async ({
     openBook,
   }) => {

--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2507,7 +2507,6 @@
   "{{count}} Annotations_few": "{{count}} تعليقات توضيحية",
   "{{count}} Annotations_many": "{{count}} تعليقًا توضيحيًا",
   "{{count}} Annotations_other": "{{count}} تعليق توضيحي",
-  "Insert into Notebook": "إدراج في المفكرة",
   "Reading": "قيد القراءة",
   "Notion Sync": "مزامنة Notion",
   "Notes synced to Notion": "تمت مزامنة الملاحظات إلى Notion",

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "নোটসহ",
   "{{count}} Annotations_one": "{{count}} টীকা",
   "{{count}} Annotations_other": "{{count}} টীকা",
-  "Insert into Notebook": "নোটবুকে যোগ করুন",
   "Reading": "পড়া হচ্ছে",
   "Notion Sync": "Notion সিঙ্ক",
   "Notes synced to Notion": "নোট Notion-এ সিঙ্ক হয়েছে",

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2202,7 +2202,6 @@
   "Notebook draft copied to clipboard": "ཟིན་དེབ་ཀྱི་སྔོན་བྲིས་འདྲ་བཤུས་ལྡེ་མིག་ཏུ་བྱས་ཟིན།",
   "With notes": "ཟིན་བྲིས་ཡོད་པ།",
   "{{count}} Annotations_other": "མཆན་ {{count}}",
-  "Insert into Notebook": "ཟིན་དེབ་ནང་འཇུག་པ།",
   "Reading": "ཀློག་བཞིན་པ།",
   "Notion Sync": "Notion མཐུན་སྒྲིག",
   "Notes synced to Notion": "ཟིན་བྲིས་རྣམས་ Notion ལ་མཐུན་སྒྲིག་བྱས་ཟིན།",

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "Mit Notizen",
   "{{count}} Annotations_one": "{{count}} Anmerkung",
   "{{count}} Annotations_other": "{{count}} Anmerkungen",
-  "Insert into Notebook": "In Notizbuch einfügen",
   "Reading": "Wird gelesen",
   "Notion Sync": "Notion-Synchronisierung",
   "Notes synced to Notion": "Notizen mit Notion synchronisiert",

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "Με σημειώσεις",
   "{{count}} Annotations_one": "{{count}} σχολιασμός",
   "{{count}} Annotations_other": "{{count}} σχολιασμοί",
-  "Insert into Notebook": "Εισαγωγή στο σημειωματάριο",
   "Reading": "Σε ανάγνωση",
   "Notion Sync": "Συγχρονισμός Notion",
   "Notes synced to Notion": "Οι σημειώσεις συγχρονίστηκαν στο Notion",

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2324,7 +2324,6 @@
   "{{count}} Annotations_one": "{{count}} anotación",
   "{{count}} Annotations_many": "{{count}} anotaciones",
   "{{count}} Annotations_other": "{{count}} anotaciones",
-  "Insert into Notebook": "Insertar en el cuaderno",
   "Reading": "Leyendo",
   "Notion Sync": "Sincronización con Notion",
   "Notes synced to Notion": "Notas sincronizadas con Notion",

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "با یادداشت",
   "{{count}} Annotations_one": "{{count}} یادداشت",
   "{{count}} Annotations_other": "{{count}} یادداشت",
-  "Insert into Notebook": "درج در دفترچه یادداشت",
   "Reading": "در حال خواندن",
   "Notion Sync": "همگام‌سازی Notion",
   "Notes synced to Notion": "یادداشت‌ها با Notion همگام‌سازی شد",

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2324,7 +2324,6 @@
   "{{count}} Annotations_one": "{{count}} annotation",
   "{{count}} Annotations_many": "{{count}} annotations",
   "{{count}} Annotations_other": "{{count}} annotations",
-  "Insert into Notebook": "Insérer dans le carnet de notes",
   "Reading": "En cours de lecture",
   "Notion Sync": "Synchronisation Notion",
   "Notes synced to Notion": "Notes synchronisées avec Notion",

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2324,7 +2324,6 @@
   "{{count}} Annotations_one": "{{count}} הערה",
   "{{count}} Annotations_two": "{{count}} הערות",
   "{{count}} Annotations_other": "{{count}} הערות",
-  "Insert into Notebook": "הוסף למחברת",
   "Reading": "בקריאה",
   "Notion Sync": "סנכרון Notion",
   "Notes synced to Notion": "ההערות סונכרנו ל-Notion",

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "नोट्स सहित",
   "{{count}} Annotations_one": "{{count}} टिप्पणी",
   "{{count}} Annotations_other": "{{count}} टिप्पणियाँ",
-  "Insert into Notebook": "नोटबुक में डालें",
   "Reading": "पढ़ रहे हैं",
   "Notion Sync": "Notion सिंक",
   "Notes synced to Notion": "नोट्स Notion में सिंक हो गए",

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "Jegyzettel",
   "{{count}} Annotations_one": "{{count}} megjegyzés",
   "{{count}} Annotations_other": "{{count}} megjegyzés",
-  "Insert into Notebook": "Beszúrás a jegyzetfüzetbe",
   "Reading": "Olvasás alatt",
   "Notion Sync": "Notion-szinkronizálás",
   "Notes synced to Notion": "A jegyzetek szinkronizálva a Notionbe",

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2202,7 +2202,6 @@
   "Notebook draft copied to clipboard": "Draf Buku Catatan disalin ke papan klip",
   "With notes": "Dengan catatan",
   "{{count}} Annotations_other": "{{count}} anotasi",
-  "Insert into Notebook": "Sisipkan ke Buku Catatan",
   "Reading": "Sedang dibaca",
   "Notion Sync": "Sinkronisasi Notion",
   "Notes synced to Notion": "Catatan disinkronkan ke Notion",

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2324,7 +2324,6 @@
   "{{count}} Annotations_one": "{{count}} annotazione",
   "{{count}} Annotations_many": "{{count}} annotazioni",
   "{{count}} Annotations_other": "{{count}} annotazioni",
-  "Insert into Notebook": "Inserisci nel quaderno",
   "Reading": "In lettura",
   "Notion Sync": "Sincronizzazione Notion",
   "Notes synced to Notion": "Note sincronizzate con Notion",

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2202,7 +2202,6 @@
   "Notebook draft copied to clipboard": "ノートの下書きをクリップボードにコピーしました",
   "With notes": "メモ付き",
   "{{count}} Annotations_other": "{{count}} 件の注釈",
-  "Insert into Notebook": "ノートに挿入",
   "Reading": "読書中",
   "Notion Sync": "Notion 同期",
   "Notes synced to Notion": "ノートを Notion に同期しました",

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "შენიშვნებით",
   "{{count}} Annotations_one": "{{count}} ანოტაცია",
   "{{count}} Annotations_other": "{{count}} ანოტაცია",
-  "Insert into Notebook": "რვეულში ჩასმა",
   "Reading": "იკითხება",
   "Notion Sync": "Notion-ის სინქრონიზაცია",
   "Notes synced to Notion": "შენიშვნები სინქრონიზებულია Notion-თან",

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2202,7 +2202,6 @@
   "Notebook draft copied to clipboard": "노트북 초안이 클립보드에 복사되었습니다",
   "With notes": "메모 있음",
   "{{count}} Annotations_other": "주석 {{count}}개",
-  "Insert into Notebook": "노트북에 삽입",
   "Reading": "읽는 중",
   "Notion Sync": "Notion 동기화",
   "Notes synced to Notion": "노트를 Notion에 동기화했습니다",

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2202,7 +2202,6 @@
   "Notebook draft copied to clipboard": "Draf Buku Nota disalin ke papan klip",
   "With notes": "Dengan nota",
   "{{count}} Annotations_other": "{{count}} anotasi",
-  "Insert into Notebook": "Sisipkan ke Buku Nota",
   "Reading": "Sedang dibaca",
   "Notion Sync": "Penyegerakan Notion",
   "Notes synced to Notion": "Nota disegerakkan ke Notion",

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "Met notities",
   "{{count}} Annotations_one": "{{count}} aantekening",
   "{{count}} Annotations_other": "{{count}} aantekeningen",
-  "Insert into Notebook": "Invoegen in notitieblok",
   "Reading": "Wordt gelezen",
   "Notion Sync": "Notion-synchronisatie",
   "Notes synced to Notion": "Notities gesynchroniseerd met Notion",

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2385,7 +2385,6 @@
   "{{count}} Annotations_few": "{{count}} adnotacje",
   "{{count}} Annotations_many": "{{count}} adnotacji",
   "{{count}} Annotations_other": "{{count}} adnotacji",
-  "Insert into Notebook": "Wstaw do notatnika",
   "Reading": "W trakcie czytania",
   "Notion Sync": "Synchronizacja z Notion",
   "Notes synced to Notion": "Notatki zsynchronizowane z Notion",

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2324,7 +2324,6 @@
   "{{count}} Annotations_one": "{{count}} anotação",
   "{{count}} Annotations_many": "{{count}} anotações",
   "{{count}} Annotations_other": "{{count}} anotações",
-  "Insert into Notebook": "Inserir no caderno",
   "Reading": "Lendo",
   "Notion Sync": "Sincronização do Notion",
   "Notes synced to Notion": "Notas sincronizadas com o Notion",

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2324,7 +2324,6 @@
   "{{count}} Annotations_one": "{{count}} anotação",
   "{{count}} Annotations_many": "{{count}} anotações",
   "{{count}} Annotations_other": "{{count}} anotações",
-  "Insert into Notebook": "Inserir no caderno",
   "Reading": "A ler",
   "Notion Sync": "Sincronização do Notion",
   "Notes synced to Notion": "Notas sincronizadas com o Notion",

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2324,7 +2324,6 @@
   "{{count}} Annotations_one": "{{count}} adnotare",
   "{{count}} Annotations_few": "{{count}} adnotări",
   "{{count}} Annotations_other": "{{count}} de adnotări",
-  "Insert into Notebook": "Inserează în carnețel",
   "Reading": "În curs de citire",
   "Notion Sync": "Sincronizare Notion",
   "Notes synced to Notion": "Notițe sincronizate cu Notion",

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2385,7 +2385,6 @@
   "{{count}} Annotations_few": "{{count}} аннотации",
   "{{count}} Annotations_many": "{{count}} аннотаций",
   "{{count}} Annotations_other": "{{count}} аннотаций",
-  "Insert into Notebook": "Вставить в блокнот",
   "Reading": "Читаю",
   "Notion Sync": "Синхронизация с Notion",
   "Notes synced to Notion": "Заметки синхронизированы с Notion",

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "සටහන් සමඟ",
   "{{count}} Annotations_one": "{{count}} අනුසටහන",
   "{{count}} Annotations_other": "{{count}} අනුසටහන්",
-  "Insert into Notebook": "සටහන් පොතට ඇතුළු කරන්න",
   "Reading": "කියවමින්",
   "Notion Sync": "Notion සමමුහූර්තකරණය",
   "Notes synced to Notion": "සටහන් Notion වෙත සමමුහූර්ත කරන ලදී",

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2385,7 +2385,6 @@
   "{{count}} Annotations_two": "{{count}} opombi",
   "{{count}} Annotations_few": "{{count}} opombe",
   "{{count}} Annotations_other": "{{count}} opomb",
-  "Insert into Notebook": "Vstavi v beležnico",
   "Reading": "V branju",
   "Notion Sync": "Sinhronizacija z Notion",
   "Notes synced to Notion": "Zapiski sinhronizirani z Notion",

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "Med anteckningar",
   "{{count}} Annotations_one": "{{count}} anteckning",
   "{{count}} Annotations_other": "{{count}} anteckningar",
-  "Insert into Notebook": "Infoga i anteckningsboken",
   "Reading": "Läser",
   "Notion Sync": "Notion-synkronisering",
   "Notes synced to Notion": "Anteckningar synkroniserade till Notion",

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "குறிப்புகளுடன்",
   "{{count}} Annotations_one": "{{count}} சிறுகுறிப்பு",
   "{{count}} Annotations_other": "{{count}} சிறுகுறிப்புகள்",
-  "Insert into Notebook": "குறிப்பேட்டில் செருகவும்",
   "Reading": "படிக்கிறேன்",
   "Notion Sync": "Notion ஒத்திசைவு",
   "Notes synced to Notion": "குறிப்புகள் Notion இல் ஒத்திசைக்கப்பட்டன",

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2202,7 +2202,6 @@
   "Notebook draft copied to clipboard": "คัดลอกฉบับร่างสมุดบันทึกไปยังคลิปบอร์ดแล้ว",
   "With notes": "มีบันทึกย่อ",
   "{{count}} Annotations_other": "คำอธิบายประกอบ {{count}} รายการ",
-  "Insert into Notebook": "แทรกลงในสมุดบันทึก",
   "Reading": "กำลังอ่าน",
   "Notion Sync": "การซิงค์ Notion",
   "Notes synced to Notion": "ซิงค์บันทึกไปยัง Notion แล้ว",

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "Notlu",
   "{{count}} Annotations_one": "{{count}} açıklama",
   "{{count}} Annotations_other": "{{count}} açıklama",
-  "Insert into Notebook": "Not defterine ekle",
   "Reading": "Okunuyor",
   "Notion Sync": "Notion Senkronizasyonu",
   "Notes synced to Notion": "Notlar Notion ile senkronize edildi",

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2385,7 +2385,6 @@
   "{{count}} Annotations_few": "{{count}} анотації",
   "{{count}} Annotations_many": "{{count}} анотацій",
   "{{count}} Annotations_other": "{{count}} анотацій",
-  "Insert into Notebook": "Вставити в нотатник",
   "Reading": "Читаю",
   "Notion Sync": "Синхронізація з Notion",
   "Notes synced to Notion": "Нотатки синхронізовано з Notion",

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2263,7 +2263,6 @@
   "With notes": "Eslatmali",
   "{{count}} Annotations_one": "{{count}} izoh",
   "{{count}} Annotations_other": "{{count}} ta izoh",
-  "Insert into Notebook": "Daftarga qoʻshish",
   "Reading": "Oʻqilmoqda",
   "Notion Sync": "Notion sinxronizatsiyasi",
   "Notes synced to Notion": "Eslatmalar Notion'ga sinxronlandi",

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2202,7 +2202,6 @@
   "Notebook draft copied to clipboard": "Đã sao chép bản nháp sổ ghi chép vào bảng ghi",
   "With notes": "Có ghi chú",
   "{{count}} Annotations_other": "{{count}} chú thích",
-  "Insert into Notebook": "Chèn vào sổ ghi chép",
   "Reading": "Đang đọc",
   "Notion Sync": "Đồng bộ Notion",
   "Notes synced to Notion": "Đã đồng bộ ghi chú lên Notion",

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2217,7 +2217,6 @@
   "Notebook draft copied to clipboard": "笔记本草稿已复制到剪贴板",
   "With notes": "含笔记",
   "{{count}} Annotations_other": "{{count}} 条注释",
-  "Insert into Notebook": "插入到笔记本",
   "Reading": "在读",
   "Invalid Notion database ID or URL": "无效的 Notion 数据库 ID 或 URL",
   "This Notion database has multiple data sources. Paste a data source ID instead.": "此 Notion 数据库包含多个数据源。请改为粘贴数据源 ID。",

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2217,7 +2217,6 @@
   "Notebook draft copied to clipboard": "筆記本草稿已複製到剪貼板",
   "With notes": "含筆記",
   "{{count}} Annotations_other": "{{count}} 則註解",
-  "Insert into Notebook": "插入到筆記本",
   "Reading": "閱讀中",
   "Invalid Notion database ID or URL": "無效的 Notion 資料庫 ID 或 URL",
   "This Notion database has multiple data sources. Paste a data source ID instead.": "此 Notion 資料庫包含多個資料來源。請改為貼上資料來源 ID。",

--- a/apps/readest-app/src/__tests__/app/reader/components/sidebar/BooknoteItem.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/sidebar/BooknoteItem.test.tsx
@@ -15,8 +15,6 @@ const mocks = vi.hoisted(() => {
     setNotebookVisible: vi.fn(),
     setNotebookActiveTab: vi.fn(),
     setNotebookEditAnnotation: vi.fn(),
-    insertNotebook: vi.fn(() => ({ accepted: true })),
-    setSideBarVisible: vi.fn(),
     toast: vi.fn(),
     addAnnotation: vi.fn(),
     saveConfig: vi.fn(),
@@ -36,16 +34,6 @@ vi.mock('@/store/notebookStore', () => ({
     setNotebookActiveTab: mocks.setNotebookActiveTab,
     setNotebookEditAnnotation: mocks.setNotebookEditAnnotation,
   }),
-}));
-
-vi.mock('@/store/notebookDocumentStore', () => ({
-  useNotebookDocumentStore: Object.assign(vi.fn(), {
-    getState: () => ({ insert: mocks.insertNotebook }),
-  }),
-}));
-
-vi.mock('@/store/sidebarStore', () => ({
-  useSidebarStore: () => ({ setSideBarVisible: mocks.setSideBarVisible }),
 }));
 
 vi.mock('@/context/EnvContext', () => ({
@@ -107,7 +95,6 @@ const renderItem = (item: BookNote, inlineNoteEditing?: boolean) =>
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.insertNotebook.mockReturnValue({ accepted: true });
   mocks.state.booknotes = [];
 });
 
@@ -203,28 +190,5 @@ describe('BooknoteItem', () => {
     renderItem(makeItem());
     expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Add Note' })).toBeNull();
-  });
-
-  it('inserts linked source Markdown into the current book Notebook', () => {
-    renderItem(makeItem({ note: 'my thought' }), true);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Insert into Notebook' }));
-
-    expect(mocks.insertNotebook).toHaveBeenCalledWith(
-      'hash1',
-      expect.stringContaining('highlighted words'),
-    );
-    expect(mocks.setNotebookActiveTab).toHaveBeenCalledWith('notes');
-    expect(mocks.setNotebookVisible).toHaveBeenCalledWith(true);
-    expect(mocks.setSideBarVisible).not.toHaveBeenCalled();
-  });
-
-  it('keeps the Notebook closed when the insertion exceeds the size limit', () => {
-    mocks.insertNotebook.mockReturnValue({ accepted: false });
-    renderItem(makeItem(), true);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Insert into Notebook' }));
-
-    expect(mocks.setNotebookVisible).not.toHaveBeenCalled();
   });
 });

--- a/apps/readest-app/src/__tests__/app/reader/components/sidebar/BooknoteItem.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/sidebar/BooknoteItem.test.tsx
@@ -98,21 +98,10 @@ const makeItem = (overrides: Partial<BookNote> = {}): BookNote => ({
   ...overrides,
 });
 
-const renderItem = (
-  item: BookNote,
-  inlineNoteEditing?: boolean,
-  editTarget?: { placeholderIds: string[]; onFinish: () => void },
-) =>
+const renderItem = (item: BookNote, inlineNoteEditing?: boolean) =>
   render(
     <ul>
-      <BooknoteItem
-        bookKey='hash1-primary'
-        item={item}
-        inlineNoteEditing={inlineNoteEditing}
-        startEditing={!!editTarget}
-        placeholderIds={editTarget?.placeholderIds}
-        onFinishEditing={editTarget?.onFinish}
-      />
+      <BooknoteItem bookKey='hash1-primary' item={item} inlineNoteEditing={inlineNoteEditing} />
     </ul>,
   );
 
@@ -237,33 +226,5 @@ describe('BooknoteItem', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Insert into Notebook' }));
 
     expect(mocks.setNotebookVisible).not.toHaveBeenCalled();
-  });
-
-  it('opens a requested annotation editor and keeps a saved placeholder', () => {
-    const item = makeItem();
-    const onFinish = vi.fn();
-    mocks.state.booknotes = [item];
-    renderItem(item, true, { placeholderIds: [item.id], onFinish });
-
-    const editor = screen.getByRole('textbox');
-    fireEvent.change(editor, { target: { value: 'new thought' } });
-    fireEvent.click(screen.getByText('Save'));
-
-    expect((mocks.state.booknotes[0] as BookNote).note).toBe('new thought');
-    expect((mocks.state.booknotes[0] as BookNote).deletedAt).toBeUndefined();
-    expect(onFinish).toHaveBeenCalledTimes(1);
-  });
-
-  it('removes a new empty placeholder when requested editing is cancelled', () => {
-    const item = makeItem();
-    const onFinish = vi.fn();
-    mocks.state.booknotes = [item];
-    renderItem(item, true, { placeholderIds: [item.id], onFinish });
-
-    fireEvent.click(screen.getByText('Cancel'));
-
-    expect((mocks.state.booknotes[0] as BookNote).deletedAt).toBeTypeOf('number');
-    expect(mocks.saveConfig).toHaveBeenCalledTimes(1);
-    expect(onFinish).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-nativeHandles.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-nativeHandles.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, renderHook } from '@testing-library/react';
+
+// A lookup popup can never stack above the platform's selection grabbers: iOS
+// draws them as UIKit views over the whole web layer, outside the DOM. #5213
+// rules out deselecting (the selection has to survive the lookup so its dismiss
+// returns to the toolbar), so `suppressNativeSelectionHandles` takes the
+// grabbers away and leaves the selection: empty the selection for one painted
+// frame, then put the same range back programmatically. The engine only draws
+// grabbers for a user-initiated selection, so they do not come back, and
+// `handlesSuppressed` hands the job to the app's own handles.
+
+const h = vi.hoisted(() => ({
+  contents: [] as { doc: Document; index: number }[],
+  view: {
+    next: vi.fn(),
+    prev: vi.fn(),
+    deselect: vi.fn(),
+    getCFI: vi.fn((index: number) => `cfi-${index}`),
+    renderer: {
+      containerPosition: 0,
+      scrollLocked: false,
+      getContents: () => h.contents,
+    },
+  },
+  appService: { isAndroidApp: false, isMobile: true },
+  osPlatform: 'ios',
+  viewSettings: { scrolled: false },
+  isFixedLayout: false,
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: h.appService }),
+}));
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    getView: () => h.view,
+    getViewSettings: () => h.viewSettings,
+    getProgress: () => null,
+  }),
+}));
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({ getBookData: () => ({ isFixedLayout: h.isFixedLayout }) }),
+}));
+vi.mock('@/utils/event', () => ({
+  eventDispatcher: { onSync: vi.fn(), offSync: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+vi.mock('@/utils/bridge', () => ({
+  setSelectionSuppressed: vi.fn(async () => {}),
+}));
+vi.mock('@/app/reader/hooks/useInstantAnnotation', () => ({
+  useInstantAnnotation: () => ({
+    isInstantAnnotationEnabled: () => false,
+    handleInstantAnnotationPointerDown: vi.fn(),
+    handleInstantAnnotationPointerMove: vi.fn(),
+    handleInstantAnnotationPointerCancel: vi.fn(),
+    handleInstantAnnotationPointerUp: vi.fn(),
+    reapplyInstantAnnotation: vi.fn(),
+    cancelInstantAnnotation: vi.fn(),
+  }),
+}));
+vi.mock('@/utils/misc', async (importActual) => {
+  const actual = await importActual<typeof import('@/utils/misc')>();
+  return { ...actual, getOSPlatform: () => h.osPlatform };
+});
+
+import { useTextSelector } from '@/app/reader/hooks/useTextSelector';
+import type { TextSelection } from '@/utils/sel';
+
+const ZERO_INSETS = { top: 0, right: 0, bottom: 0, left: 0 };
+
+const setup = () => {
+  const setSelection = vi.fn();
+  const noop = vi.fn();
+  const hook = renderHook(() =>
+    useTextSelector(
+      'book-1',
+      ZERO_INSETS,
+      setSelection as never,
+      noop,
+      noop,
+      vi.fn(async (range: Range) => range.toString()),
+      noop,
+    ),
+  );
+  return { ...hook, setSelection };
+};
+
+/** A section iframe with `text` selected, as a touch long-press would leave it. */
+const makeSelectedPage = (text: string, index = 0) => {
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+  const doc = iframe.contentDocument!;
+  const win = iframe.contentWindow as Window & typeof globalThis;
+  win.requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(() => cb(0), 0) as never;
+  doc.body.innerHTML = `<p><span>${text}</span></p>`;
+  const span = doc.querySelector('span')!;
+  const range = doc.createRange();
+  range.selectNodeContents(span);
+  doc.getSelection()!.addRange(range);
+  return { doc, index, win };
+};
+
+const flush = () => new Promise((r) => setTimeout(r, 20));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = '';
+  h.appService = { isAndroidApp: false, isMobile: true };
+  h.osPlatform = 'ios';
+  h.viewSettings = { scrolled: false };
+  h.isFixedLayout = false;
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('suppressNativeSelectionHandles', () => {
+  test('puts the same selection back and hands the handles to the app', async () => {
+    const page = makeSelectedPage('a selected phrase');
+    h.contents = [page];
+    const { result, setSelection } = setup();
+
+    const done = result.current.suppressNativeSelectionHandles();
+    // The selection is emptied first — that is the frame that drops the
+    // platform's grabbers.
+    expect(page.doc.getSelection()!.rangeCount).toBe(0);
+
+    await done;
+    await flush();
+
+    // ...and the very same range is back, so the lookup still has its text and
+    // the toolbar has something to return to (#5213).
+    expect(page.doc.getSelection()!.toString()).toBe('a selected phrase');
+
+    const update = setSelection.mock.calls.at(-1)![0] as (
+      prev: TextSelection | null,
+    ) => TextSelection | null;
+    expect(update({ text: 'a selected phrase' } as TextSelection)).toMatchObject({
+      handlesSuppressed: true,
+    });
+  });
+
+  test('leaves a desktop selection alone — there are no grabbers to take away', async () => {
+    h.appService = { isAndroidApp: false, isMobile: false };
+    const page = makeSelectedPage('a selected phrase');
+    h.contents = [page];
+    const { result, setSelection } = setup();
+
+    await result.current.suppressNativeSelectionHandles();
+    await flush();
+
+    expect(page.doc.getSelection()!.toString()).toBe('a selected phrase');
+    expect(setSelection).not.toHaveBeenCalled();
+  });
+
+  test('backs off when another gesture re-selects while the frame is empty', async () => {
+    const page = makeSelectedPage('a selected phrase');
+    h.contents = [page];
+    const { result, setSelection } = setup();
+
+    const done = result.current.suppressNativeSelectionHandles();
+    // A competing gesture lands during the empty frame: the cloned range is no
+    // longer what is on screen, so it must not be forced back.
+    const other = page.doc.createRange();
+    other.selectNodeContents(page.doc.querySelector('p')!);
+    page.doc.getSelection()!.addRange(other);
+
+    await done;
+    await flush();
+
+    expect(setSelection).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when there is no live selection', async () => {
+    const page = makeSelectedPage('a selected phrase');
+    page.doc.getSelection()!.removeAllRanges();
+    h.contents = [page];
+    const { result, setSelection } = setup();
+
+    await result.current.suppressNativeSelectionHandles();
+    await flush();
+
+    expect(setSelection).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/components/BooknoteView.test.tsx
+++ b/apps/readest-app/src/__tests__/components/BooknoteView.test.tsx
@@ -41,8 +41,6 @@ vi.mock('@/store/sidebarStore', () => ({
     setBooknoteResults: vi.fn(),
     isSearchBarVisible: false,
     setSearchBarVisible: vi.fn(),
-    annotationEditTargets: {},
-    setAnnotationEditTarget: vi.fn(),
   }),
 }));
 

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotateNoteEditorFlow.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotateNoteEditorFlow.test.tsx
@@ -1,0 +1,374 @@
+/**
+ * #5987 / #5957 — "Annotate" used to highlight the selection and then hand the
+ * note off to the annotations sidebar, which lists notes in reading order and
+ * virtualizes them. The new note's editor mounted off screen, so the user got a
+ * higher annotation count and nothing else: no visible note, no caret.
+ *
+ * Annotate now opens the editor where the selection already is — inside the
+ * annotation toolbar popup on desktop, in a bottom sheet on phone-sized
+ * screens — and leaves the sidebar alone.
+ */
+
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { eventDispatcher } from '@/utils/event';
+import { BookNote } from '@/types/book';
+
+// Stand in for the two presentation surfaces so the test can assert *where*
+// the editor was handed to, and drive its save/cancel without laying a popup
+// or a sheet out in jsdom. Hoisted, because vi.mock factories run before any
+// top-level const in this file is initialised.
+const stub = vi.hoisted(() => {
+  const render = (
+    surface: string,
+    noteEditor?: { value: string; onSave: (note: string) => void; onCancel: () => void } | null,
+  ) => {
+    if (!noteEditor) return null;
+    return (
+      <div data-testid={`note-editor-${surface}`}>
+        <span data-testid={`note-editor-${surface}-value`}>{noteEditor.value}</span>
+        <button onClick={() => noteEditor.onSave('a thought worth keeping')}>stub-save</button>
+        <button onClick={() => noteEditor.onCancel()}>stub-cancel</button>
+      </div>
+    );
+  };
+  return { render };
+});
+
+type NoteEditorStub = {
+  value: string;
+  onSave: (note: string) => void;
+  onCancel: () => void;
+};
+
+const h = vi.hoisted(() => ({
+  actions: null as null | Record<string, () => boolean>,
+  config: { booknotes: [] as BookNote[], viewSettings: {} },
+  viewSettings: {
+    annotationToolbarItems: [] as string[],
+    noteExportConfig: {},
+    copyToNotebook: false,
+    rtl: false,
+    vertical: false,
+  },
+  saveConfig: vi.fn(),
+  updateBooknotes: vi.fn(),
+  setConfig: vi.fn(),
+  setSideBarVisible: vi.fn(),
+  setSearchBarVisible: vi.fn(),
+}));
+
+const settings = {
+  globalReadSettings: {
+    highlightStyle: 'highlight',
+    highlightStyles: { highlight: 'yellow', underline: 'green', squiggly: 'blue' },
+  },
+};
+
+vi.mock('@/hooks/useShortcuts', () => ({
+  default: (actions: Record<string, () => boolean>) => {
+    h.actions = actions;
+  },
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: {} }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (value: string) => value,
+}));
+
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (value: number) => value,
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: Object.assign(
+    () => ({
+      settings,
+      setSettingsDialogBookKey: vi.fn(),
+      setSettingsDialogOpen: vi.fn(),
+      setActiveSettingsItemId: vi.fn(),
+    }),
+    { getState: () => ({ settings }) },
+  ),
+}));
+
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({ isDarkMode: false }),
+}));
+
+vi.mock('@/store/bookDataStore', () => {
+  const state = {
+    getConfig: () => h.config,
+    setConfig: h.setConfig,
+    saveConfig: h.saveConfig,
+    getBookData: () => ({
+      book: { format: 'EPUB', primaryLanguage: 'en' },
+      bookDoc: { metadata: { language: 'en' } },
+      isFixedLayout: false,
+    }),
+    updateBooknotes: h.updateBooknotes,
+  };
+  // Annotator reads this store with selectors; useSaveBooknoteNoteText
+  // destructures it. Serve both call styles.
+  return {
+    useBookDataStore: (selector?: (value: typeof state) => unknown) =>
+      selector ? selector(state) : state,
+  };
+});
+
+vi.mock('@/store/readerStore', () => {
+  const state = {
+    getView: () => null,
+    getViewsById: () => [],
+    getViewSettings: () => h.viewSettings,
+  };
+  return {
+    useReaderStore: (selector?: (value: typeof state) => unknown) =>
+      selector ? selector(state) : state,
+  };
+});
+
+vi.mock('@/store/readerProgressStore', () => ({
+  getBookProgress: () => ({ page: 1 }),
+  useBookProgress: () => ({ page: 1, sectionHref: 'chapter.xhtml' }),
+}));
+
+vi.mock('@/store/notebookStore', () => ({
+  useNotebookStore: () => ({
+    setNotebookVisible: vi.fn(),
+    setNotebookActiveTab: vi.fn(),
+    setNotebookNewAnnotation: vi.fn(),
+    setNotebookNewHighlightIds: vi.fn(),
+  }),
+}));
+
+vi.mock('@/store/sidebarStore', () => ({
+  useSidebarStore: () => ({
+    clearBooknotesNav: vi.fn(),
+    isSideBarVisible: false,
+    setSideBarVisible: h.setSideBarVisible,
+    setSearchBarVisible: h.setSearchBarVisible,
+  }),
+}));
+
+vi.mock('@/store/customDictionaryStore', () => ({
+  useCustomDictionaryStore: () => ({
+    loadCustomDictionaries: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/store/deviceStore', () => ({
+  useDeviceControlStore: () => ({ listenToNativeTouchEvents: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useFileSelector', () => ({
+  useFileSelector: () => ({ selectFiles: vi.fn() }),
+}));
+
+vi.mock('@/app/reader/hooks/useNotesSync', () => ({ useNotesSync: () => {} }));
+vi.mock('@/app/reader/hooks/useBookOrbitNotesSync', () => ({ useBookOrbitNotesSync: () => {} }));
+vi.mock('@/app/reader/hooks/useReadwiseSync', () => ({ useReadwiseSync: () => {} }));
+vi.mock('@/app/reader/hooks/useHardcoverSync', () => ({ useHardcoverSync: () => {} }));
+vi.mock('@/app/reader/hooks/useNotionSync', () => ({ useNotionSync: () => {} }));
+vi.mock('@/app/reader/hooks/useFoliateEvents', () => ({ useFoliateEvents: () => {} }));
+vi.mock('@/app/reader/hooks/useRendererInputListeners', () => ({
+  useRendererInputListeners: () => {},
+}));
+
+vi.mock('@/app/reader/hooks/useTextSelector', () => ({
+  useTextSelector: () => ({
+    isTextSelected: { current: false },
+    isInstantAnnotating: { current: false },
+    handleScroll: vi.fn(),
+    handleTouchStart: vi.fn(),
+    handleTouchMove: vi.fn(),
+    handleTouchEnd: vi.fn(),
+    handleMouseDown: vi.fn(),
+    handlePointerDown: vi.fn(),
+    handlePointerMove: vi.fn(),
+    handleNativeTouchMove: vi.fn(),
+    handlePointerCancel: vi.fn(),
+    handlePointerUp: vi.fn(),
+    handleDoubleClick: vi.fn(),
+    handleSelectionchange: vi.fn(),
+    handleShowPopup: vi.fn(),
+    handleUpToPopup: vi.fn(),
+    handleContextmenu: vi.fn(),
+    dragSelectionTo: vi.fn(),
+    noteAutoTurnPoint: { current: null },
+    cancelAutoTurn: vi.fn(),
+    onAutoTurn: vi.fn(),
+  }),
+}));
+
+// jsdom lays nothing out, so the real popup positioning bails on a zero rect
+// and the toolbar popup never renders. Feed it fixed anchor points instead.
+vi.mock('@/utils/sel', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/sel')>();
+  return {
+    ...actual,
+    getPosition: () => ({ point: { x: 120, y: 200 }, dir: 'up' as const }),
+    getPopupPosition: () => ({ point: { x: 120, y: 140 }, dir: 'up' as const }),
+  };
+});
+
+vi.mock('@/services/transformService', () => ({
+  transformContent: ({ content }: { content: string }) => Promise.resolve(content),
+}));
+
+vi.mock('@/app/reader/components/annotator/AnnotationRangeEditor', () => ({ default: () => null }));
+vi.mock('@/app/reader/components/annotator/SelectionRangeEditor', () => ({ default: () => null }));
+vi.mock('@/app/reader/components/annotator/DictionaryPopup', () => ({ default: () => null }));
+vi.mock('@/app/reader/components/annotator/DictionarySheet', () => ({ default: () => null }));
+vi.mock('@/app/reader/components/annotator/TranslatorPopup', () => ({ default: () => null }));
+vi.mock('@/app/reader/components/annotator/ProofreadPopup', () => ({ default: () => null }));
+vi.mock('@/app/reader/components/annotator/ExportMarkdownDialog', () => ({ default: () => null }));
+vi.mock('@/app/reader/components/annotator/ImportAnnotationsDialog', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/reader/components/annotator/AnnotationPopup', () => ({
+  default: (props: { noteEditor?: NoteEditorStub | null }) =>
+    stub.render('popup', props.noteEditor),
+}));
+vi.mock('@/app/reader/components/annotator/NoteEditorSheet', () => ({
+  default: (props: NoteEditorStub) => stub.render('sheet', props),
+}));
+
+import Annotator from '@/app/reader/components/annotator/Annotator';
+
+const setViewport = (width: number, height: number) => {
+  Object.defineProperty(window, 'innerWidth', { value: width, writable: true, configurable: true });
+  Object.defineProperty(window, 'innerHeight', {
+    value: height,
+    writable: true,
+    configurable: true,
+  });
+};
+
+const selectText = async () => {
+  // repositionPopups needs the book's grid cell to measure against.
+  if (!document.querySelector('#gridcell-book-1')) {
+    const gridCell = document.createElement('div');
+    gridCell.id = 'gridcell-book-1';
+    document.body.append(gridCell);
+  }
+  const paragraph = document.createElement('p');
+  paragraph.textContent = 'selected text';
+  document.body.append(paragraph);
+  const range = document.createRange();
+  range.selectNodeContents(paragraph);
+  await act(async () => {
+    await eventDispatcher.dispatch('footnote-selection', {
+      key: 'book-1',
+      range,
+      index: 0,
+      cfi: 'epubcfi(/6/2!/4/2)',
+    });
+  });
+};
+
+const annotate = async () => {
+  render(<Annotator bookKey='book-1' contentInsets={{ top: 0, right: 0, bottom: 0, left: 0 }} />);
+  await selectText();
+  act(() => {
+    h.actions?.['onAnnotateSelection']?.();
+  });
+};
+
+const liveAnnotations = () => h.config.booknotes.filter((note) => !note.deletedAt);
+
+beforeEach(() => {
+  h.actions = null;
+  h.config.booknotes = [];
+  h.viewSettings.copyToNotebook = false;
+  // Mirror the real store: write back whatever array it is handed, since the
+  // note-text save builds a new array rather than mutating in place.
+  h.updateBooknotes.mockImplementation((_bookKey: string, booknotes: BookNote[]) => {
+    h.config.booknotes = booknotes;
+    return h.config;
+  });
+  setViewport(1280, 800);
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe('Annotate opens the note editor at the selection', () => {
+  test('hands the editor to the toolbar popup on a desktop-sized window', async () => {
+    await annotate();
+
+    expect(screen.getByTestId('note-editor-popup')).toBeTruthy();
+    expect(screen.queryByTestId('note-editor-sheet')).toBeNull();
+    expect(liveAnnotations()).toHaveLength(1);
+  });
+
+  test('hands the editor to the bottom sheet on a phone-sized window', async () => {
+    setViewport(390, 844);
+    await annotate();
+
+    expect(screen.getByTestId('note-editor-sheet')).toBeTruthy();
+    expect(screen.queryByTestId('note-editor-popup')).toBeNull();
+  });
+
+  test('leaves the sidebar alone', async () => {
+    await annotate();
+
+    expect(h.setSideBarVisible).not.toHaveBeenCalled();
+    expect(h.setSearchBarVisible).not.toHaveBeenCalled();
+    expect(h.setConfig).not.toHaveBeenCalledWith(
+      'book-1',
+      expect.objectContaining({
+        viewSettings: expect.objectContaining({ sideBarTab: 'annotations' }),
+      }),
+    );
+  });
+
+  test('saving writes the typed note onto the new annotation and closes the editor', async () => {
+    await annotate();
+
+    act(() => {
+      screen.getByText('stub-save').click();
+    });
+
+    expect(liveAnnotations()).toEqual([
+      expect.objectContaining({ note: 'a thought worth keeping', text: 'selected text' }),
+    ]);
+    expect(screen.queryByTestId('note-editor-popup')).toBeNull();
+  });
+
+  test('cancelling drops the placeholder highlight it just created (#4791)', async () => {
+    await annotate();
+    expect(liveAnnotations()).toHaveLength(1);
+
+    act(() => {
+      screen.getByText('stub-cancel').click();
+    });
+
+    expect(liveAnnotations()).toHaveLength(0);
+    expect(screen.queryByTestId('note-editor-popup')).toBeNull();
+  });
+
+  test('cancelling keeps a highlight that already existed before Annotate', async () => {
+    render(<Annotator bookKey='book-1' contentInsets={{ top: 0, right: 0, bottom: 0, left: 0 }} />);
+    await selectText();
+    // Highlight first, so Annotate attaches a note to an existing record
+    // instead of creating a placeholder of its own.
+    act(() => {
+      h.actions?.['onHighlightSelection']?.();
+    });
+    act(() => {
+      h.actions?.['onAnnotateSelection']?.();
+    });
+    expect(liveAnnotations()).toHaveLength(1);
+
+    act(() => {
+      screen.getByText('stub-cancel').click();
+    });
+
+    expect(liveAnnotations()).toHaveLength(1);
+  });
+});

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotateNoteEditorFlow.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotateNoteEditorFlow.test.tsx
@@ -66,6 +66,7 @@ const h = vi.hoisted(() => ({
   setSearchBarVisible: vi.fn(),
   deselect: vi.fn(),
   suppressNativeSelectionHandles: vi.fn(),
+  isSideBarVisible: false,
   isTextSelected: { current: true },
 }));
 
@@ -159,7 +160,9 @@ vi.mock('@/store/notebookStore', () => ({
 vi.mock('@/store/sidebarStore', () => ({
   useSidebarStore: () => ({
     clearBooknotesNav: vi.fn(),
-    isSideBarVisible: false,
+    get isSideBarVisible() {
+      return h.isSideBarVisible;
+    },
     setSideBarVisible: h.setSideBarVisible,
     setSearchBarVisible: h.setSearchBarVisible,
   }),
@@ -307,6 +310,7 @@ beforeEach(() => {
     return h.config;
   });
   setViewport(1280, 800);
+  h.isSideBarVisible = false;
   h.isTextSelected.current = true;
   vi.clearAllMocks();
 });
@@ -441,6 +445,31 @@ describe('Annotate opens the note editor at the selection', () => {
     expect(liveAnnotations()).toEqual([
       expect.objectContaining({ id: 'existing-note', note: 'an older thought' }),
     ]);
+  });
+
+  // #4791: the placeholder only lives as long as its editor is presented, and
+  // Cancel is not the only way it stops being presented. Opening the sidebar
+  // dismisses the popup from an effect, which used to clear the target and
+  // leave the empty highlight behind.
+  test('drops the placeholder when the editor is dismissed, not just cancelled', async () => {
+    const view = render(
+      <Annotator bookKey='book-1' contentInsets={{ top: 0, right: 0, bottom: 0, left: 0 }} />,
+    );
+    await selectText();
+    act(() => {
+      h.actions?.['onAnnotateSelection']?.();
+    });
+    expect(liveAnnotations()).toHaveLength(1);
+
+    h.isSideBarVisible = true;
+    act(() => {
+      view.rerender(
+        <Annotator bookKey='book-1' contentInsets={{ top: 0, right: 0, bottom: 0, left: 0 }} />,
+      );
+    });
+
+    expect(screen.queryByTestId('note-editor-popup')).toBeNull();
+    expect(liveAnnotations()).toHaveLength(0);
   });
 
   test('cancelling keeps a highlight that already existed before Annotate', async () => {

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotateNoteEditorFlow.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotateNoteEditorFlow.test.tsx
@@ -22,8 +22,14 @@ const stub = vi.hoisted(() => {
   const render = (
     surface: string,
     noteEditor?: { value: string; onSave: (note: string) => void; onCancel: () => void } | null,
+    onEditNote?: (note: { id: string }) => void,
   ) => {
-    if (!noteEditor) return null;
+    if (!noteEditor) {
+      // The bubble's pencil lives on the popup even with no editor open.
+      return onEditNote ? (
+        <button onClick={() => onEditNote({ id: 'existing-note' })}>stub-edit-note</button>
+      ) : null;
+    }
     return (
       <div data-testid={`note-editor-${surface}`}>
         <span data-testid={`note-editor-${surface}-value`}>{noteEditor.value}</span>
@@ -45,7 +51,9 @@ const h = vi.hoisted(() => ({
   actions: null as null | Record<string, () => boolean>,
   config: { booknotes: [] as BookNote[], viewSettings: {} },
   viewSettings: {
-    annotationToolbarItems: [] as string[],
+    // A non-empty toolbar so the popup actually renders (Annotator suppresses
+    // it entirely when there is nothing to show).
+    annotationToolbarItems: ['copy'] as string[],
     noteExportConfig: {},
     copyToNotebook: false,
     rtl: false,
@@ -56,6 +64,8 @@ const h = vi.hoisted(() => ({
   setConfig: vi.fn(),
   setSideBarVisible: vi.fn(),
   setSearchBarVisible: vi.fn(),
+  deselect: vi.fn(),
+  isTextSelected: { current: true },
 }));
 
 const settings = {
@@ -121,7 +131,7 @@ vi.mock('@/store/bookDataStore', () => {
 
 vi.mock('@/store/readerStore', () => {
   const state = {
-    getView: () => null,
+    getView: () => ({ deselect: h.deselect }),
     getViewsById: () => [],
     getViewSettings: () => h.viewSettings,
   };
@@ -155,9 +165,10 @@ vi.mock('@/store/sidebarStore', () => ({
 }));
 
 vi.mock('@/store/customDictionaryStore', () => ({
-  useCustomDictionaryStore: () => ({
-    loadCustomDictionaries: vi.fn().mockResolvedValue(undefined),
-  }),
+  useCustomDictionaryStore: Object.assign(
+    () => ({ loadCustomDictionaries: vi.fn().mockResolvedValue(undefined) }),
+    { getState: () => ({ settings: { providerEnabled: {} } }) },
+  ),
 }));
 
 vi.mock('@/store/deviceStore', () => ({
@@ -180,7 +191,7 @@ vi.mock('@/app/reader/hooks/useRendererInputListeners', () => ({
 
 vi.mock('@/app/reader/hooks/useTextSelector', () => ({
   useTextSelector: () => ({
-    isTextSelected: { current: false },
+    isTextSelected: h.isTextSelected,
     isInstantAnnotating: { current: false },
     handleScroll: vi.fn(),
     handleTouchStart: vi.fn(),
@@ -231,8 +242,10 @@ vi.mock('@/app/reader/components/annotator/ImportAnnotationsDialog', () => ({
 }));
 
 vi.mock('@/app/reader/components/annotator/AnnotationPopup', () => ({
-  default: (props: { noteEditor?: NoteEditorStub | null }) =>
-    stub.render('popup', props.noteEditor),
+  default: (props: {
+    noteEditor?: NoteEditorStub | null;
+    onEditNote?: (note: { id: string }) => void;
+  }) => stub.render('popup', props.noteEditor, props.onEditNote),
 }));
 vi.mock('@/app/reader/components/annotator/NoteEditorSheet', () => ({
   default: (props: NoteEditorStub) => stub.render('sheet', props),
@@ -292,6 +305,7 @@ beforeEach(() => {
     return h.config;
   });
   setViewport(1280, 800);
+  h.isTextSelected.current = true;
   vi.clearAllMocks();
 });
 
@@ -350,6 +364,74 @@ describe('Annotate opens the note editor at the selection', () => {
 
     expect(liveAnnotations()).toHaveLength(0);
     expect(screen.queryByTestId('note-editor-popup')).toBeNull();
+  });
+
+  const existingNote: BookNote = {
+    id: 'existing-note',
+    type: 'annotation',
+    cfi: 'epubcfi(/6/2!/4/2)',
+    text: 'selected text',
+    note: 'an older thought',
+    style: 'highlight',
+    color: 'yellow',
+    createdAt: 1,
+    updatedAt: 1,
+  };
+
+  const editExistingNote = async () => {
+    h.config.booknotes = [{ ...existingNote }];
+    render(<Annotator bookKey='book-1' contentInsets={{ top: 0, right: 0, bottom: 0, left: 0 }} />);
+    await selectText();
+    act(() => {
+      screen.getByText('stub-edit-note').click();
+    });
+  };
+
+  test('drops the selection so the range handles cannot cover the editor (#5815)', async () => {
+    await annotate();
+
+    expect(h.deselect).toHaveBeenCalled();
+    expect(h.isTextSelected.current).toBe(false);
+  });
+
+  test.each([
+    'onDictionarySelection',
+    'onTranslateSelection',
+    'onProofreadSelection',
+  ])('%s drops the selection too', async (action) => {
+    render(<Annotator bookKey='book-1' contentInsets={{ top: 0, right: 0, bottom: 0, left: 0 }} />);
+    await selectText();
+
+    act(() => {
+      h.actions?.[action]?.();
+    });
+
+    expect(h.deselect).toHaveBeenCalled();
+    expect(h.isTextSelected.current).toBe(false);
+  });
+
+  test('the note bubble pencil opens the same editor, seeded with the existing note', async () => {
+    await editExistingNote();
+    expect(screen.getByTestId('note-editor-popup-value').textContent).toBe('an older thought');
+
+    act(() => {
+      screen.getByText('stub-save').click();
+    });
+    expect(liveAnnotations()).toEqual([
+      expect.objectContaining({ id: 'existing-note', note: 'a thought worth keeping' }),
+    ]);
+  });
+
+  test('cancelling an existing note never deletes it', async () => {
+    await editExistingNote();
+
+    act(() => {
+      screen.getByText('stub-cancel').click();
+    });
+
+    expect(liveAnnotations()).toEqual([
+      expect.objectContaining({ id: 'existing-note', note: 'an older thought' }),
+    ]);
   });
 
   test('cancelling keeps a highlight that already existed before Annotate', async () => {

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotateNoteEditorFlow.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotateNoteEditorFlow.test.tsx
@@ -394,11 +394,15 @@ describe('Annotate opens the note editor at the selection', () => {
     expect(h.isTextSelected.current).toBe(false);
   });
 
+  // The other side of the boundary: a toolbar lookup keeps its selection so
+  // dismissing it lands back on the selection toolbar (#5213). Only the note
+  // editor consumes the selection; a lookup's handles are hidden for its
+  // duration by the same gate instead.
   test.each([
     'onDictionarySelection',
     'onTranslateSelection',
     'onProofreadSelection',
-  ])('%s drops the selection too', async (action) => {
+  ])('%s keeps the selection so its dismiss returns to the toolbar (#5213)', async (action) => {
     render(<Annotator bookKey='book-1' contentInsets={{ top: 0, right: 0, bottom: 0, left: 0 }} />);
     await selectText();
 
@@ -406,8 +410,8 @@ describe('Annotate opens the note editor at the selection', () => {
       h.actions?.[action]?.();
     });
 
-    expect(h.deselect).toHaveBeenCalled();
-    expect(h.isTextSelected.current).toBe(false);
+    expect(h.deselect).not.toHaveBeenCalled();
+    expect(h.isTextSelected.current).toBe(true);
   });
 
   test('the note bubble pencil opens the same editor, seeded with the existing note', async () => {

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotateNoteEditorFlow.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotateNoteEditorFlow.test.tsx
@@ -65,6 +65,7 @@ const h = vi.hoisted(() => ({
   setSideBarVisible: vi.fn(),
   setSearchBarVisible: vi.fn(),
   deselect: vi.fn(),
+  suppressNativeSelectionHandles: vi.fn(),
   isTextSelected: { current: true },
 }));
 
@@ -209,6 +210,7 @@ vi.mock('@/app/reader/hooks/useTextSelector', () => ({
     handleUpToPopup: vi.fn(),
     handleContextmenu: vi.fn(),
     dragSelectionTo: vi.fn(),
+    suppressNativeSelectionHandles: h.suppressNativeSelectionHandles,
     noteAutoTurnPoint: { current: null },
     cancelAutoTurn: vi.fn(),
     onAutoTurn: vi.fn(),
@@ -412,6 +414,9 @@ describe('Annotate opens the note editor at the selection', () => {
 
     expect(h.deselect).not.toHaveBeenCalled();
     expect(h.isTextSelected.current).toBe(true);
+    // ...but the platform's own grabbers go, since no z-index can get a popup
+    // above them on iOS.
+    expect(h.suppressNativeSelectionHandles).toHaveBeenCalled();
   });
 
   test('the note bubble pencil opens the same editor, seeded with the existing note', async () => {

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotationNoteEditor.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotationNoteEditor.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (value: string) => value,
+}));
+
+const { default: AnnotationNoteEditor } = await import(
+  '@/app/reader/components/annotator/AnnotationNoteEditor'
+);
+
+afterEach(cleanup);
+
+describe('AnnotationNoteEditor', () => {
+  it('opens focused and ready to type', () => {
+    render(<AnnotationNoteEditor value='' onSave={vi.fn()} onCancel={vi.fn()} />);
+
+    const editor = screen.getByRole('textbox');
+    expect(document.activeElement).toBe(editor);
+  });
+
+  it('seeds the draft with the existing note text', () => {
+    render(<AnnotationNoteEditor value='earlier thought' onSave={vi.fn()} onCancel={vi.fn()} />);
+
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('earlier thought');
+  });
+
+  it('saves what was typed', () => {
+    const onSave = vi.fn();
+    render(<AnnotationNoteEditor value='' onSave={onSave} onCancel={vi.fn()} />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'fresh thought' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    expect(onSave).toHaveBeenCalledWith('fresh thought');
+  });
+
+  it('cancels from the button and from Escape', () => {
+    const onCancel = vi.fn();
+    render(<AnnotationNoteEditor value='' onSave={vi.fn()} onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledTimes(2);
+  });
+
+  it('carries the shared note-editor test id so both surfaces are drivable', () => {
+    render(<AnnotationNoteEditor value='' onSave={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(screen.getByTestId('booknote-note-editor')).toBeTruthy();
+  });
+});

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotationNoteItem.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotationNoteItem.test.tsx
@@ -68,12 +68,15 @@ const makeBooknote = (overrides: Partial<BookNote> = {}): BookNote => ({
   ...overrides,
 });
 
+const onEdit = vi.fn();
+
 const renderItem = (note: BookNote = makeBooknote()) => {
   h.booknotes = [note];
   return render(
     <AnnotationNoteItem
       bookKey='test'
       note={note}
+      onEdit={onEdit}
       isVertical={false}
       popupHeight={120}
       onDismiss={() => {}}
@@ -106,36 +109,16 @@ describe('AnnotationNoteItem', () => {
     expect(h.setSideBarVisible).toHaveBeenCalledWith(true);
   });
 
-  it('clicking the edit icon enters edit mode without opening the sidebar', () => {
-    renderItem();
+  it('hands the note to the shared editor instead of editing in place', () => {
+    const note = makeBooknote();
+    renderItem(note);
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
 
-    const textbox = screen.getByRole('textbox') as HTMLTextAreaElement;
-    expect(textbox.value).toBe('Gryphon');
+    expect(onEdit).toHaveBeenCalledWith(note);
+    // The card stays as it is: the editor is the popup's job now, and the
+    // sidebar must not open underneath it.
+    expect(screen.queryByRole('textbox')).toBeNull();
     expect(h.setSideBarVisible).not.toHaveBeenCalled();
-  });
-
-  it('saving an edit persists the new note text', () => {
-    renderItem();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'updated note' } });
-    fireEvent.click(screen.getByText('Save'));
-
-    expect(h.updateBooknotes).toHaveBeenCalledTimes(1);
-    expect((h.booknotes[0] as BookNote).note).toBe('updated note');
-    expect(h.saveConfig).toHaveBeenCalledTimes(1);
-  });
-
-  it('cancelling an edit discards the draft without persisting', () => {
-    renderItem();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'discarded' } });
-    fireEvent.click(screen.getByText('Cancel'));
-
-    expect(h.updateBooknotes).not.toHaveBeenCalled();
-    screen.getByText('Gryphon');
   });
 });

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotationNotes.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotationNotes.test.tsx
@@ -62,6 +62,8 @@ const makeBooknote = (overrides: Partial<BookNote> = {}): BookNote => ({
   ...overrides,
 });
 
+const onEditNote = vi.fn();
+
 const renderNotes = (notes: BookNote[]) => {
   h.booknotes = notes;
   return render(
@@ -69,6 +71,7 @@ const renderNotes = (notes: BookNote[]) => {
       bookKey='test'
       isVertical={false}
       notes={notes}
+      onEditNote={onEditNote}
       toolsVisible={false}
       triangleDir='up'
       popupWidth={240}
@@ -100,7 +103,7 @@ describe('AnnotationNotes', () => {
     expect(cardTexts[1]).toContain('older note');
   });
 
-  it('entering edit mode on one note does not affect a sibling note in the same popup', () => {
+  it('routes each note pencil to the shared editor with that note', () => {
     const first = makeBooknote({ id: 'first', note: 'first note', updatedAt: 2000 });
     const second = makeBooknote({ id: 'second', note: 'second note', updatedAt: 1000 });
 
@@ -110,9 +113,10 @@ describe('AnnotationNotes', () => {
     expect(editButtons).toHaveLength(2);
     fireEvent.click(editButtons[0]!);
 
-    const textbox = screen.getByRole('textbox') as HTMLTextAreaElement;
-    expect(textbox.value).toBe('first note');
+    expect(onEditNote).toHaveBeenCalledWith(first);
+    // Both cards stay intact: nothing is edited in place any more.
+    screen.getByText('first note');
     screen.getByText('second note');
-    expect(screen.getAllByRole('button', { name: 'Edit' })).toHaveLength(1);
+    expect(screen.queryByRole('textbox')).toBeNull();
   });
 });

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotatorShortcuts.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotatorShortcuts.test.tsx
@@ -70,7 +70,12 @@ vi.mock('@/store/bookDataStore', () => {
     }),
     updateBooknotes: h.updateBooknotes,
   };
-  return { useBookDataStore: (selector: (value: typeof state) => unknown) => selector(state) };
+  // Annotator reads this store with selectors; useSaveBooknoteNoteText
+  // destructures it. Serve both call styles.
+  return {
+    useBookDataStore: (selector?: (value: typeof state) => unknown) =>
+      selector ? selector(state) : state,
+  };
 });
 
 vi.mock('@/store/readerStore', () => {
@@ -79,7 +84,10 @@ vi.mock('@/store/readerStore', () => {
     getViewsById: () => [],
     getViewSettings: () => h.viewSettings,
   };
-  return { useReaderStore: (selector: (value: typeof state) => unknown) => selector(state) };
+  return {
+    useReaderStore: (selector?: (value: typeof state) => unknown) =>
+      selector ? selector(state) : state,
+  };
 });
 
 vi.mock('@/store/readerProgressStore', () => ({

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotatorShortcuts.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotatorShortcuts.test.tsx
@@ -152,6 +152,7 @@ vi.mock('@/app/reader/hooks/useTextSelector', () => ({
     handleUpToPopup: vi.fn(),
     handleContextmenu: vi.fn(),
     dragSelectionTo: vi.fn(),
+    suppressNativeSelectionHandles: vi.fn(),
     noteAutoTurnPoint: { current: null },
     cancelAutoTurn: vi.fn(),
     onAutoTurn: vi.fn(),

--- a/apps/readest-app/src/__tests__/store/sidebar-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/sidebar-store.test.ts
@@ -11,7 +11,6 @@ beforeEach(() => {
     searchNavStates: {},
     booknotesNavStates: {},
     searchStatuses: {},
-    annotationEditTargets: {},
   });
 });
 
@@ -80,22 +79,6 @@ describe('sidebarStore', () => {
     test('sets the active book key', () => {
       useSidebarStore.getState().setSideBarBookKey('book-abc');
       expect(useSidebarStore.getState().sideBarBookKey).toBe('book-abc');
-    });
-  });
-
-  describe('annotation edit targets', () => {
-    test('tracks and clears a per-book inline editor target', () => {
-      useSidebarStore.getState().setAnnotationEditTarget('book1', {
-        annotationId: 'annotation-1',
-        placeholderIds: ['annotation-1'],
-      });
-      expect(useSidebarStore.getState().annotationEditTargets['book1']).toEqual({
-        annotationId: 'annotation-1',
-        placeholderIds: ['annotation-1'],
-      });
-
-      useSidebarStore.getState().setAnnotationEditTarget('book1', null);
-      expect(useSidebarStore.getState().annotationEditTargets['book1']).toBeUndefined();
     });
   });
 

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationNoteEditor.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationNoteEditor.tsx
@@ -35,7 +35,11 @@ const AnnotationNoteEditor: React.FC<AnnotationNoteEditorProps> = ({
   const save = () => onSave(draftText);
 
   return (
-    <div data-testid='booknote-note-editor' className={className} style={style}>
+    // `content` carries the responsive base font size (16 / 18.4 / 20px) that
+    // `font-size-sm` inside the editor is relative to. The sidebar's row has it
+    // from `li.content`; without it here the popup and sheet fell back to the
+    // root 16px and rendered a size smaller than the sidebar's editor.
+    <div data-testid='booknote-note-editor' className={clsx('content', className)} style={style}>
       {/* The host sizes this editor (a fixed popup card, or 60% of the screen
           in the sheet), so the text area takes the slack and the action row
           stays pinned to the bottom edge instead of floating under a

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationNoteEditor.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationNoteEditor.tsx
@@ -1,0 +1,67 @@
+import clsx from 'clsx';
+import React, { useState } from 'react';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import TextButton from '@/components/TextButton';
+import TextEditor from '@/components/TextEditor';
+
+interface AnnotationNoteEditorProps {
+  value: string;
+  isVertical?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+  onSave: (note: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * The note editor the "Annotate" action opens on the selection itself — hosted
+ * by the toolbar popup on desktop and by NoteEditorSheet on phone-sized
+ * screens. Shares `booknote-note-editor` with the sidebar's inline editor so
+ * both surfaces are drivable by the same tests; only one is ever presented at
+ * a time.
+ */
+const AnnotationNoteEditor: React.FC<AnnotationNoteEditorProps> = ({
+  value,
+  isVertical,
+  className,
+  style,
+  onSave,
+  onCancel,
+}) => {
+  const _ = useTranslation();
+  const [draftText, setDraftText] = useState(value);
+
+  const save = () => onSave(draftText);
+
+  return (
+    <div data-testid='booknote-note-editor' className={className} style={style}>
+      {/* The host sizes this editor (a fixed popup card, or 60% of the screen
+          in the sheet), so the text area takes the slack and the action row
+          stays pinned to the bottom edge instead of floating under a
+          content-sized textarea. */}
+      <div className={clsx('flex h-full min-h-0 gap-2 p-4', isVertical ? 'flex-row' : 'flex-col')}>
+        <TextEditor
+          value={draftText}
+          onChange={setDraftText}
+          onSave={save}
+          onEscape={onCancel}
+          className={clsx('min-h-0 flex-1 overflow-y-auto', isVertical && 'writing-vertical-rl')}
+          placeholder={_('Add Note')}
+          autoResize={false}
+          spellCheck={false}
+          autoFocus
+        />
+        <div
+          className={clsx('flex shrink-0 justify-end gap-3', isVertical && 'flex-col')}
+          dir='ltr'
+        >
+          <TextButton onClick={onCancel}>{_('Cancel')}</TextButton>
+          <TextButton onClick={save}>{_('Save')}</TextButton>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AnnotationNoteEditor;

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationNoteItem.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationNoteItem.tsx
@@ -9,15 +9,17 @@ import { useReaderStore } from '@/store/readerStore';
 import { useSidebarStore } from '@/store/sidebarStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
-import { useSaveBooknoteNoteText } from '../../hooks/useSaveBooknoteNoteText';
-import { useInlineTextEditor } from '../../hooks/useInlineTextEditor';
 import { parseNoteMarkdown } from '../../utils/noteMarkdown';
-import TextButton from '@/components/TextButton';
-import TextEditor from '@/components/TextEditor';
 
 interface AnnotationNoteItemProps {
   bookKey: string;
   note: BookNote;
+  /**
+   * Hands the note to the shared editor the Annotate action uses (a popup body
+   * on desktop, a bottom sheet on phones) instead of editing it in place, so a
+   * note is written the same way wherever the editor is opened from.
+   */
+  onEdit?: (note: BookNote) => void;
   isVertical: boolean;
   popupHeight: number;
   onDismiss: () => void;
@@ -31,6 +33,7 @@ const cardClassName = clsx(
 const AnnotationNoteItem: React.FC<AnnotationNoteItemProps> = ({
   bookKey,
   note,
+  onEdit,
   isVertical,
   popupHeight,
   onDismiss,
@@ -40,15 +43,11 @@ const AnnotationNoteItem: React.FC<AnnotationNoteItemProps> = ({
   const { getConfig, setConfig } = useBookDataStore();
   const { setHoveredBookKey } = useReaderStore();
   const { setSideBarVisible } = useSidebarStore();
-  const saveBooknoteNoteText = useSaveBooknoteNoteText(bookKey);
   const size16 = useResponsiveSize(16);
   // Same parser (and sanitizer) as the sidebar so a note previews identically
   // in both places (#5785); cached because the popup re-renders on every
   // reposition and parsing long notes is not free.
   const noteHtml = useMemo(() => (note.note ? parseNoteMarkdown(note.note) : ''), [note.note]);
-
-  const { editorRef, draftText, setDraftText, inlineEditMode, startEdit, cancelEdit, save } =
-    useInlineTextEditor((noteText) => saveBooknoteNoteText(note.id, noteText));
 
   const cardStyle = isVertical
     ? { minWidth: 'max-content', height: `${popupHeight}px`, maxHeight: `${popupHeight}px` }
@@ -75,30 +74,8 @@ const AnnotationNoteItem: React.FC<AnnotationNoteItemProps> = ({
     // Editing must not also trigger the card's own click handler
     // (handleShowAnnotation), which would open the sidebar underneath it.
     event.stopPropagation();
-    startEdit(note.note || '');
+    onEdit?.(note);
   };
-
-  if (inlineEditMode) {
-    return (
-      <div className={cardClassName} style={cardStyle}>
-        <div className='m-4 flex flex-col gap-2'>
-          <TextEditor
-            ref={editorRef}
-            value={draftText}
-            onChange={setDraftText}
-            onSave={save}
-            onEscape={cancelEdit}
-            spellCheck={false}
-            autoFocus
-          />
-          <div className='flex justify-end gap-3' dir='ltr'>
-            <TextButton onClick={cancelEdit}>{_('Cancel')}</TextButton>
-            <TextButton onClick={save}>{_('Save')}</TextButton>
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationNoteItem.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationNoteItem.tsx
@@ -108,7 +108,7 @@ const AnnotationNoteItem: React.FC<AnnotationNoteItemProps> = ({
                   devices, which have no hover state to reveal it. */}
               <button
                 onClick={handleEditClick}
-                className='btn btn-ghost btn-xs p-0 text-blue-500 hover:bg-transparent'
+                className='btn btn-ghost btn-xs p-0 text-blue-500 hover:border-transparent hover:bg-transparent'
                 aria-label={_('Edit')}
               >
                 <MdEdit size={size16} />

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationNotes.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationNotes.tsx
@@ -8,6 +8,7 @@ interface AnnotationNotesProps {
   bookKey: string;
   isVertical: boolean;
   notes: BookNote[];
+  onEditNote?: (note: BookNote) => void;
   toolsVisible: boolean;
   triangleDir: 'up' | 'down' | 'left' | 'right';
   popupWidth: number;
@@ -19,6 +20,7 @@ const AnnotationNotes: React.FC<AnnotationNotesProps> = ({
   bookKey,
   isVertical,
   notes,
+  onEditNote,
   toolsVisible,
   triangleDir,
   popupWidth,
@@ -73,6 +75,7 @@ const AnnotationNotes: React.FC<AnnotationNotesProps> = ({
             key={note.id || index}
             bookKey={bookKey}
             note={note}
+            onEdit={onEditNote}
             isVertical={isVertical}
             popupHeight={popupHeight}
             onDismiss={onDismiss}

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationPopup.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationPopup.tsx
@@ -33,6 +33,8 @@ interface AnnotationPopupProps {
    * user is typing is the only thing they care about (#5987).
    */
   noteEditor?: AnnotationNoteEditorTarget | null;
+  /** Opens `noteEditor` on an existing note (the bubble's pencil). */
+  onEditNote?: (note: BookNote) => void;
   position: Position;
   trianglePosition: Position;
   highlightOptionsVisible: boolean;
@@ -54,6 +56,7 @@ const AnnotationPopup: React.FC<AnnotationPopupProps> = ({
   buttons,
   notes,
   noteEditor,
+  onEditNote,
   position,
   trianglePosition,
   highlightOptionsVisible,
@@ -146,6 +149,7 @@ const AnnotationPopup: React.FC<AnnotationPopupProps> = ({
               bookKey={bookKey}
               isVertical={isVertical}
               notes={notes}
+              onEditNote={onEditNote}
               toolsVisible={false}
               triangleDir={trianglePosition.dir!}
               popupWidth={boxWidth}

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationPopup.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationPopup.tsx
@@ -1,11 +1,19 @@
 import clsx from 'clsx';
 import React from 'react';
 import { Position } from '@/utils/sel';
+import { useResponsiveSize } from '@/hooks/useResponsiveSize';
 import { BookNote, HighlightColor, HighlightStyle } from '@/types/book';
 import Popup from '@/components/Popup';
 import AnnotationToolButton from './AnnotationToolButton';
+import AnnotationNoteEditor from './AnnotationNoteEditor';
 import AnnotationNotes from './AnnotationNotes';
 import HighlightOptions from './HighlightOptions';
+
+export interface AnnotationNoteEditorTarget {
+  value: string;
+  onSave: (note: string) => void;
+  onCancel: () => void;
+}
 
 interface AnnotationPopupProps {
   bookKey: string;
@@ -19,6 +27,12 @@ interface AnnotationPopupProps {
     visible?: boolean;
   }>;
   notes: BookNote[];
+  /**
+   * Set while the Annotate action is collecting a note for the selection. It
+   * takes over the popup body: the toolbar's job is done, and the note the
+   * user is typing is the only thing they care about (#5987).
+   */
+  noteEditor?: AnnotationNoteEditorTarget | null;
   position: Position;
   trianglePosition: Position;
   highlightOptionsVisible: boolean;
@@ -39,6 +53,7 @@ const AnnotationPopup: React.FC<AnnotationPopupProps> = ({
   isVertical,
   buttons,
   notes,
+  noteEditor,
   position,
   trianglePosition,
   highlightOptionsVisible,
@@ -52,15 +67,22 @@ const AnnotationPopup: React.FC<AnnotationPopupProps> = ({
   onHighlight,
   onDismiss,
 }) => {
+  // Tall enough for a few lines plus the Cancel/Save row, so the editor opens
+  // at a usable size instead of the 44px toolbar height it replaces.
+  const noteEditorSize = useResponsiveSize(180);
+  // The popup's own box, with the vertical-writing swap already applied — the
+  // same values AnnotationNotes and HighlightOptions are handed.
+  const boxWidth = isVertical ? popupHeight : popupWidth;
+  const boxHeight = isVertical ? popupWidth : popupHeight;
   return (
     <div dir={dir}>
       <Popup
-        width={isVertical ? popupHeight : popupWidth}
-        height={isVertical ? popupWidth : popupHeight}
-        minHeight={isVertical ? popupWidth : popupHeight}
+        width={boxWidth}
+        height={boxHeight}
+        minHeight={boxHeight}
         position={position}
         trianglePosition={trianglePosition}
-        className={clsx('selection-popup', notes.length > 0 && 'bg-transparent')}
+        className={clsx('selection-popup', (notes.length > 0 || noteEditor) && 'bg-transparent')}
         onDismiss={onDismiss}
       >
         <div className={clsx('flex h-full gap-4', isVertical ? 'flex-row' : 'flex-col')}>
@@ -68,7 +90,7 @@ const AnnotationPopup: React.FC<AnnotationPopupProps> = ({
             className={clsx(
               'selection-buttons flex h-full w-full items-center justify-between p-2',
               isVertical ? 'flex-col overflow-y-auto' : 'flex-row overflow-x-auto',
-              notes.length > 0 && 'hidden',
+              (notes.length > 0 || noteEditor) && 'hidden',
             )}
             style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
           >
@@ -86,15 +108,48 @@ const AnnotationPopup: React.FC<AnnotationPopupProps> = ({
               );
             })}
           </div>
-          {notes.length > 0 ? (
+          {noteEditor ? (
+            <AnnotationNoteEditor
+              value={noteEditor.value}
+              isVertical={isVertical}
+              // Same chrome recipe as Popup's own container, so the editor
+              // reads as a panel over the page rather than a shadowless block
+              // in the page's own colour.
+              className={clsx(
+                'annotation-note-editor popup-container text-base-content absolute rounded-lg border',
+                'not-eink:border-base-content/20 not-eink:shadow-2xl',
+                'bg-base-300 theme-dark:bg-base-100',
+              )}
+              // Anchored to the popup's triangle edge and grown away from it,
+              // exactly like AnnotationNotes, so the editor covers the toolbar
+              // instead of drifting off the selection.
+              style={
+                isVertical
+                  ? {
+                      right: trianglePosition.dir === 'left' ? 0 : undefined,
+                      left: trianglePosition.dir === 'right' ? 0 : undefined,
+                      height: `${boxHeight}px`,
+                      width: `${noteEditorSize}px`,
+                    }
+                  : {
+                      top: trianglePosition.dir === 'down' ? 0 : undefined,
+                      bottom: trianglePosition.dir === 'up' ? 0 : undefined,
+                      width: `${boxWidth}px`,
+                      height: `${noteEditorSize}px`,
+                    }
+              }
+              onSave={noteEditor.onSave}
+              onCancel={noteEditor.onCancel}
+            />
+          ) : notes.length > 0 ? (
             <AnnotationNotes
               bookKey={bookKey}
               isVertical={isVertical}
               notes={notes}
               toolsVisible={false}
               triangleDir={trianglePosition.dir!}
-              popupWidth={isVertical ? popupHeight : popupWidth}
-              popupHeight={isVertical ? popupWidth : popupHeight}
+              popupWidth={boxWidth}
+              popupHeight={boxHeight}
               onDismiss={onDismiss}
             />
           ) : (
@@ -102,8 +157,8 @@ const AnnotationPopup: React.FC<AnnotationPopupProps> = ({
               <HighlightOptions
                 isVertical={isVertical}
                 triangleDir={trianglePosition.dir!}
-                popupWidth={isVertical ? popupHeight : popupWidth}
-                popupHeight={isVertical ? popupWidth : popupHeight}
+                popupWidth={boxWidth}
+                popupHeight={boxHeight}
                 selectedStyle={selectedStyle}
                 selectedColor={selectedColor}
                 globalToggleAvailable={globalToggleAvailable}

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationRangeEditor.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationRangeEditor.tsx
@@ -330,7 +330,14 @@ const AnnotationRangeEditor: React.FC<AnnotationRangeEditorProps> = ({
   const showLoupe = appService?.isMobile && !viewSettings?.isEink && !viewSettings?.vertical;
 
   return (
-    <div className='pointer-events-none fixed inset-0 z-50'>
+    // The handle layer sits BELOW the popup/sheet layer. Both used to be z-50
+    // in the same stacking context, so the tie broke on DOM order — and the
+    // range editors are rendered after the popups, which put their handles on
+    // top of the dictionary, the translator and the note editor sheet. z-[44]
+    // keeps them over the book and the paragraph/TTS chrome (z-40) while
+    // leaving the popups (z-50), dialogs (z-50) and the side panels' overlay
+    // (z-[45]) above them.
+    <div className='pointer-events-none fixed inset-0 z-[44]'>
       <Handle
         hidden={activeHandle === 'end' || loupeDragPoint !== null}
         position={currentStart}

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -359,6 +359,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     handleUpToPopup,
     handleContextmenu,
     dragSelectionTo,
+    suppressNativeSelectionHandles,
     noteAutoTurnPoint,
     cancelAutoTurn,
     onAutoTurn,
@@ -1479,8 +1480,10 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   //
   // The lookup popups are deliberately NOT here. A dictionary / translator /
   // proofread lookup leaves the selection alive so dismissing it lands back on
-  // the selection toolbar (#5213, e2e-covered); their handles are hidden for
-  // the duration by `overlaySurfaceOpen` instead.
+  // the selection toolbar (#5213, e2e-covered); they call
+  // `suppressNativeSelectionHandles` instead, which sheds the platform's
+  // grabbers without spending the selection, and `overlaySurfaceOpen` hides the
+  // app's own handles for the duration.
   const dropSelectionForOverlay = () => {
     isTextSelected.current = false;
     view?.deselect();
@@ -1596,12 +1599,14 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
       return;
     }
     setShowAnnotPopup(false);
+    void suppressNativeSelectionHandles();
     setShowDictionaryPopup(true);
   };
 
   const handleTranslation = () => {
     if (!selection || !selection.text) return;
     setShowAnnotPopup(false);
+    void suppressNativeSelectionHandles();
     setShowDeepLPopup(true);
   };
 
@@ -1636,6 +1641,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     // attribute footnotes) has nothing to attach to.
     if (selection.popup && !selection.cfi) return;
     setShowAnnotPopup(false);
+    void suppressNativeSelectionHandles();
     setShowProofreadPopup(true);
 
     if (getWordCount(selection.text) > 30) {

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -1494,10 +1494,19 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     // annotations sidebar instead used to strand it: that list is in reading
     // order and virtualized, so a note made further down the page mounted its
     // editor off screen (#5987, #5957).
+    dropSelectionForOverlay();
     setNoteEditorTarget({
       annotationId: target.id,
       placeholderIds: created.map((annotation) => annotation.id),
     });
+  };
+
+  // The pencil on a note bubble edits that note in the same editor the Annotate
+  // action opens, so a note reads and edits the same way wherever it is opened
+  // from. No placeholder to take back: the annotation already existed.
+  const handleEditNote = (note: BookNote) => {
+    dropSelectionForOverlay();
+    setNoteEditorTarget({ annotationId: note.id, placeholderIds: [] });
   };
 
   const handleSaveNote = (note: string) => {
@@ -1542,6 +1551,22 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     eventDispatcher.dispatch('search-term', { term, bookKey });
   };
 
+  // Every surface that opens over the page — a lookup popup, the note editor —
+  // is painted below both the app-drawn range handles and (on iOS) the native
+  // selection highlight, which sit above web content. Drop the selection as the
+  // surface opens so neither ends up covering it. The flag is cleared first:
+  // the selectionchange that deselect() fires would otherwise dismiss the very
+  // surface we are opening (#5585).
+  const dropSelectionForOverlay = () => {
+    isTextSelected.current = false;
+    view?.deselect();
+    // A popup-window selection lives in its own document (the footnote popup
+    // view's iframe or the host document), out of view.deselect()'s reach.
+    if (selection?.popup) {
+      selection.range.startContainer.ownerDocument?.getSelection()?.removeAllRanges();
+    }
+  };
+
   const handleDictionary = () => {
     if (!selection || !selection.text) return;
     // System-dictionary path: when the user has opted in via Settings →
@@ -1566,12 +1591,14 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
       return;
     }
     setShowAnnotPopup(false);
+    dropSelectionForOverlay();
     setShowDictionaryPopup(true);
   };
 
   const handleTranslation = () => {
     if (!selection || !selection.text) return;
     setShowAnnotPopup(false);
+    dropSelectionForOverlay();
     setShowDeepLPopup(true);
   };
 
@@ -1606,6 +1633,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     // attribute footnotes) has nothing to attach to.
     if (selection.popup && !selection.cfi) return;
     setShowAnnotPopup(false);
+    dropSelectionForOverlay();
     setShowProofreadPopup(true);
 
     if (getWordCount(selection.text) > 30) {
@@ -2160,11 +2188,13 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     }
   };
 
-  // The range editors are fixed full-screen overlays rendered after the lookup
-  // popups, so their handles would float on top of the dictionary sheet /
-  // popup (#5815). They belong to the toolbar: hide them while a lookup is
-  // open, and let them come back with the toolbar (or go with the dismiss).
-  const lookupPopupOpen = showDictionaryPopup || showDeepLPopup || showProofreadPopup;
+  // The range editors are fixed full-screen overlays rendered after the popups
+  // and sheets, so their handles would float on top of the dictionary, the
+  // translator, the proofreader or the note editor (#5815). They belong to the
+  // toolbar: hide them while any of those is open, and let them come back with
+  // the toolbar (or go with the dismiss).
+  const overlaySurfaceOpen =
+    showDictionaryPopup || showDeepLPopup || showProofreadPopup || !!noteEditorTarget;
 
   // Below `sm` (or short landscape) the note editor is a bottom sheet rather
   // than a popup pinned to the selection: an anchored editor would sit under
@@ -2252,6 +2282,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
             isVertical={viewSettings.vertical}
             buttons={toolButtons}
             notes={annotationNotes}
+            onEditNote={handleEditNote}
             noteEditor={
               noteEditorInPopup
                 ? { value: editedNoteText, onSave: handleSaveNote, onCancel: handleCancelNote }
@@ -2287,7 +2318,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
         />
       )}
       {!editingAnnotation &&
-        !lookupPopupOpen &&
+        !overlaySurfaceOpen &&
         selection?.handlesSuppressed &&
         selection.range && (
           <SelectionRangeEditor
@@ -2302,7 +2333,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
             onAutoTurn={onAutoTurn}
           />
         )}
-      {editingAnnotation && editingAnnotation.color && selection && !lookupPopupOpen && (
+      {editingAnnotation && editingAnnotation.color && selection && !overlaySurfaceOpen && (
         <AnnotationRangeEditor
           bookKey={bookKey}
           isVertical={viewSettings.vertical}

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -34,6 +34,7 @@ import { useReadwiseSync } from '../../hooks/useReadwiseSync';
 import { useHardcoverSync } from '../../hooks/useHardcoverSync';
 import { useNotionSync } from '../../hooks/useNotionSync';
 import { useTextSelector } from '../../hooks/useTextSelector';
+import { useSaveBooknoteNoteText } from '../../hooks/useSaveBooknoteNoteText';
 import { Point, Position, TextSelection } from '@/utils/sel';
 import {
   getPopupPosition,
@@ -69,6 +70,7 @@ import {
   drawAnnotationOverlay,
   mergeRestyledAnnotation,
   removeBookNoteOverlays,
+  removeEmptyAnnotationPlaceholder,
 } from '../../utils/annotatorUtil';
 import { buildAnnotationIndex, selectLocationAnnotations } from '../../utils/annotationIndex';
 import {
@@ -85,6 +87,7 @@ import SelectionRangeEditor from './SelectionRangeEditor';
 import AnnotationPopup from './AnnotationPopup';
 import DictionaryPopup from './DictionaryPopup';
 import DictionarySheet from './DictionarySheet';
+import NoteEditorSheet from './NoteEditorSheet';
 import TranslatorPopup from './TranslatorPopup';
 import useShortcuts from '@/hooks/useShortcuts';
 import ProofreadPopup from './ProofreadPopup';
@@ -124,16 +127,12 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   const getViewsById = useReaderStore((s) => s.getViewsById);
   const getViewSettings = useReaderStore((s) => s.getViewSettings);
   const { setNotebookVisible, setNotebookActiveTab } = useNotebookStore();
-  const {
-    clearBooknotesNav,
-    isSideBarVisible,
-    setAnnotationEditTarget,
-    setSearchBarVisible,
-    setSideBarVisible,
-  } = useSidebarStore();
+  const { clearBooknotesNav, isSideBarVisible } = useSidebarStore();
   const { listenToNativeTouchEvents } = useDeviceControlStore();
   const { loadCustomDictionaries } = useCustomDictionaryStore();
   const { selectFiles } = useFileSelector(appService, _);
+
+  const saveBooknoteNoteText = useSaveBooknoteNoteText(bookKey);
 
   useNotesSync(bookKey);
   useBookOrbitNotesSync(bookKey);
@@ -175,6 +174,12 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   const [proofreadPopupPosition, setProofreadPopupPosition] = useState<Position>();
   const [highlightOptionsVisible, setHighlightOptionsVisible] = useState(false);
   const [showAnnotationNotes, setShowAnnotationNotes] = useState(false);
+  // The note the Annotate action is currently collecting, plus the highlights
+  // it created on the way (#4791: those only live as long as this editor).
+  const [noteEditorTarget, setNoteEditorTarget] = useState<{
+    annotationId: string;
+    placeholderIds: string[];
+  } | null>(null);
   const [annotationNotes, setAnnotationNotes] = useState<BookNote[]>([]);
   const [editingAnnotation, setEditingAnnotation] = useState<BookNote | null>(null);
   const [externalDragPoint, setExternalDragPoint] = useState<Point | null>(null);
@@ -330,6 +335,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
       setShowDeepLPopup(false);
       setShowProofreadPopup(false);
       setEditingAnnotation(null);
+      setNoteEditorTarget(null);
     }, 500),
     [],
   );
@@ -1484,17 +1490,44 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
           annotation.type === 'annotation' && annotation.cfi === cfi && !annotation.deletedAt,
       );
     if (!target) return;
-    setAnnotationEditTarget(bookKey, {
+    // Open the editor on the selection itself. Routing the note through the
+    // annotations sidebar instead used to strand it: that list is in reading
+    // order and virtualized, so a note made further down the page mounted its
+    // editor off screen (#5987, #5957).
+    setNoteEditorTarget({
       annotationId: target.id,
       placeholderIds: created.map((annotation) => annotation.id),
     });
-    setSearchBarVisible(false);
-    clearBooknotesNav(bookKey);
-    setConfig(bookKey, {
-      viewSettings: { ...viewSettings, sideBarTab: 'annotations' },
-    });
-    setSideBarVisible(true);
-    handleDismissPopup();
+  };
+
+  const handleSaveNote = (note: string) => {
+    if (!noteEditorTarget) return;
+    saveBooknoteNoteText(noteEditorTarget.annotationId, note);
+    setNoteEditorTarget(null);
+    handleDismissPopupAndSelection();
+  };
+
+  // Cancelling takes back the highlight Annotate created for the note to hang
+  // on, but never one the user had already made themselves (#4791).
+  const handleCancelNote = () => {
+    if (!noteEditorTarget) return;
+    const { placeholderIds } = noteEditorTarget;
+    if (placeholderIds.length > 0) {
+      const { booknotes = [] } = getConfig(bookKey) ?? {};
+      const removed = placeholderIds
+        .map((id) => removeEmptyAnnotationPlaceholder(booknotes, id, Date.now()))
+        .filter((placeholder): placeholder is BookNote => placeholder !== null);
+      if (removed.length > 0) {
+        const views = getViewsById(bookKey.split('-')[0]!);
+        removed.forEach((placeholder) => {
+          views.forEach((view) => removeBookNoteOverlays(view, placeholder));
+        });
+        const updatedConfig = updateBooknotes(bookKey, booknotes);
+        if (updatedConfig) saveConfig(envConfig, bookKey, updatedConfig, settings);
+      }
+    }
+    setNoteEditorTarget(null);
+    handleDismissPopupAndSelection();
   };
 
   const handleSearch = () => {
@@ -2133,6 +2166,16 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   // open, and let them come back with the toolbar (or go with the dismiss).
   const lookupPopupOpen = showDictionaryPopup || showDeepLPopup || showProofreadPopup;
 
+  // Below `sm` (or short landscape) the note editor is a bottom sheet rather
+  // than a popup pinned to the selection: an anchored editor would sit under
+  // the on-screen keyboard. Same heuristic the dictionary uses.
+  const noteEditorInSheet =
+    !!noteEditorTarget && (window.innerWidth < 640 || window.innerHeight < 640);
+  const noteEditorInPopup = !!noteEditorTarget && !noteEditorInSheet;
+  const editedNoteText =
+    config.booknotes?.find((annotation) => annotation.id === noteEditorTarget?.annotationId)
+      ?.note || '';
+
   return (
     <div ref={containerRef} role='toolbar' tabIndex={-1}>
       <PageTurnHint bookKey={bookKey} contentInsets={contentInsets} hint={turnHint} />
@@ -2185,19 +2228,35 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
           onDismiss={handleDismissPopupShowToolbar}
         />
       )}
+      {noteEditorInSheet && (
+        <NoteEditorSheet
+          value={editedNoteText}
+          onSave={handleSaveNote}
+          onCancel={handleCancelNote}
+        />
+      )}
       {showAnnotPopup &&
+        !noteEditorInSheet &&
         trianglePosition &&
         annotPopupPosition &&
         // With an empty toolbar, suppress the popup on a plain selection rather
         // than showing an empty bar. Still allow it for editing an existing
-        // highlight (options) or viewing its notes.
-        (toolButtons.length > 0 || highlightOptionsVisible || annotationNotes.length > 0) && (
+        // highlight (options), viewing its notes, or writing a new one.
+        (toolButtons.length > 0 ||
+          highlightOptionsVisible ||
+          annotationNotes.length > 0 ||
+          noteEditorInPopup) && (
           <AnnotationPopup
             bookKey={bookKey}
             dir={viewSettings.rtl ? 'rtl' : 'ltr'}
             isVertical={viewSettings.vertical}
             buttons={toolButtons}
             notes={annotationNotes}
+            noteEditor={
+              noteEditorInPopup
+                ? { value: editedNoteText, onSave: handleSaveNote, onCancel: handleCancelNote }
+                : null
+            }
             position={annotPopupPosition}
             trianglePosition={trianglePosition}
             highlightOptionsVisible={highlightOptionsVisible}
@@ -2209,7 +2268,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
             globalToggleActive={globalToggleActive}
             onToggleGlobal={handleToggleGlobal}
             onHighlight={handleHighlight}
-            onDismiss={handleDismissPopupAndSelection}
+            onDismiss={noteEditorTarget ? handleCancelNote : handleDismissPopupAndSelection}
           />
         )}
       {showProofreadPopup && trianglePosition && proofreadPopupPosition && selection && (

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -1470,6 +1470,27 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     }
   };
 
+  // The note editor replaces the selection with the annotation it just created,
+  // so the selection has no job left — and both the app-drawn range handles and
+  // (on iOS) the native selection highlight paint above web content, which is
+  // how they ended up sitting on top of the editor sheet. Drop it. The flag is
+  // cleared first: the selectionchange that deselect() fires would otherwise
+  // dismiss the very surface we are opening (#5585).
+  //
+  // The lookup popups are deliberately NOT here. A dictionary / translator /
+  // proofread lookup leaves the selection alive so dismissing it lands back on
+  // the selection toolbar (#5213, e2e-covered); their handles are hidden for
+  // the duration by `overlaySurfaceOpen` instead.
+  const dropSelectionForOverlay = () => {
+    isTextSelected.current = false;
+    view?.deselect();
+    // A popup-window selection lives in its own document (the footnote popup
+    // view's iframe or the host document), out of view.deselect()'s reach.
+    if (selection?.popup) {
+      selection.range.startContainer.ownerDocument?.getSelection()?.removeAllRanges();
+    }
+  };
+
   const handleAnnotate = () => {
     if (!selection || !selection.text) return;
     // A popup selection without a CFI has nothing to anchor a note to (the
@@ -1551,22 +1572,6 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     eventDispatcher.dispatch('search-term', { term, bookKey });
   };
 
-  // Every surface that opens over the page — a lookup popup, the note editor —
-  // is painted below both the app-drawn range handles and (on iOS) the native
-  // selection highlight, which sit above web content. Drop the selection as the
-  // surface opens so neither ends up covering it. The flag is cleared first:
-  // the selectionchange that deselect() fires would otherwise dismiss the very
-  // surface we are opening (#5585).
-  const dropSelectionForOverlay = () => {
-    isTextSelected.current = false;
-    view?.deselect();
-    // A popup-window selection lives in its own document (the footnote popup
-    // view's iframe or the host document), out of view.deselect()'s reach.
-    if (selection?.popup) {
-      selection.range.startContainer.ownerDocument?.getSelection()?.removeAllRanges();
-    }
-  };
-
   const handleDictionary = () => {
     if (!selection || !selection.text) return;
     // System-dictionary path: when the user has opted in via Settings →
@@ -1591,14 +1596,12 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
       return;
     }
     setShowAnnotPopup(false);
-    dropSelectionForOverlay();
     setShowDictionaryPopup(true);
   };
 
   const handleTranslation = () => {
     if (!selection || !selection.text) return;
     setShowAnnotPopup(false);
-    dropSelectionForOverlay();
     setShowDeepLPopup(true);
   };
 
@@ -1633,7 +1636,6 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     // attribute footnotes) has nothing to attach to.
     if (selection.popup && !selection.cfi) return;
     setShowAnnotPopup(false);
-    dropSelectionForOverlay();
     setShowProofreadPopup(true);
 
     if (getWordCount(selection.text) > 30) {

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -1533,32 +1533,52 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     setNoteEditorTarget({ annotationId: note.id, placeholderIds: [] });
   };
 
+  // Takes back the highlight Annotate created for the note to hang on, but
+  // never one the user had already made themselves (#4791).
+  const removeNotePlaceholders = (placeholderIds: string[]) => {
+    if (placeholderIds.length === 0) return;
+    const { booknotes = [] } = getConfig(bookKey) ?? {};
+    const removed = placeholderIds
+      .map((id) => removeEmptyAnnotationPlaceholder(booknotes, id, Date.now()))
+      .filter((placeholder): placeholder is BookNote => placeholder !== null);
+    if (removed.length === 0) return;
+    const views = getViewsById(bookKey.split('-')[0]!);
+    removed.forEach((placeholder) => {
+      views.forEach((view) => removeBookNoteOverlays(view, placeholder));
+    });
+    const updatedConfig = updateBooknotes(bookKey, booknotes);
+    if (updatedConfig) saveConfig(envConfig, bookKey, updatedConfig, settings);
+  };
+
+  // That placeholder lives only as long as its editor is presented, and Cancel
+  // is not the only way it stops being presented: opening the sidebar and a
+  // page relocate both dismiss the popup from effects, and the relocate guard
+  // no longer holds now that opening the editor clears isTextSelected. So the
+  // cleanup hangs off the target going away rather than off any one dismiss
+  // path (the pre-#5928 Notebook did the same).
+  const pendingNotePlaceholdersRef = useRef<string[]>([]);
+  useEffect(() => {
+    if (noteEditorTarget) {
+      pendingNotePlaceholdersRef.current = noteEditorTarget.placeholderIds;
+      return;
+    }
+    const placeholderIds = pendingNotePlaceholdersRef.current;
+    pendingNotePlaceholdersRef.current = [];
+    removeNotePlaceholders(placeholderIds);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [noteEditorTarget]);
+
   const handleSaveNote = (note: string) => {
     if (!noteEditorTarget) return;
     saveBooknoteNoteText(noteEditorTarget.annotationId, note);
+    // The placeholder carries a note now — a real annotation, not a leftover.
+    pendingNotePlaceholdersRef.current = [];
     setNoteEditorTarget(null);
     handleDismissPopupAndSelection();
   };
 
-  // Cancelling takes back the highlight Annotate created for the note to hang
-  // on, but never one the user had already made themselves (#4791).
   const handleCancelNote = () => {
     if (!noteEditorTarget) return;
-    const { placeholderIds } = noteEditorTarget;
-    if (placeholderIds.length > 0) {
-      const { booknotes = [] } = getConfig(bookKey) ?? {};
-      const removed = placeholderIds
-        .map((id) => removeEmptyAnnotationPlaceholder(booknotes, id, Date.now()))
-        .filter((placeholder): placeholder is BookNote => placeholder !== null);
-      if (removed.length > 0) {
-        const views = getViewsById(bookKey.split('-')[0]!);
-        removed.forEach((placeholder) => {
-          views.forEach((view) => removeBookNoteOverlays(view, placeholder));
-        });
-        const updatedConfig = updateBooknotes(bookKey, booknotes);
-        if (updatedConfig) saveConfig(envConfig, bookKey, updatedConfig, settings);
-      }
-    }
     setNoteEditorTarget(null);
     handleDismissPopupAndSelection();
   };

--- a/apps/readest-app/src/app/reader/components/annotator/NoteEditorSheet.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/NoteEditorSheet.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import React from 'react';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import Dialog from '@/components/Dialog';
+import AnnotationNoteEditor from './AnnotationNoteEditor';
+
+interface NoteEditorSheetProps {
+  value: string;
+  onSave: (note: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Phone-sized presentation of the Annotate note editor: a bottom sheet, so the
+ * editor sits above the on-screen keyboard instead of being anchored to a
+ * selection the keyboard would cover. Mirrors DictionarySheet, which makes the
+ * same call for the same reason.
+ */
+const NoteEditorSheet: React.FC<NoteEditorSheetProps> = ({ value, onSave, onCancel }) => {
+  const _ = useTranslation();
+  return (
+    <Dialog
+      isOpen
+      title={_('Note')}
+      // Just over half the screen: enough room for a few lines above the
+      // keyboard, without burying the passage the note is about.
+      snapHeight={0.6}
+      dismissible
+      contentClassName='px-0! mt-0! flex-1 min-h-0'
+      onClose={onCancel}
+    >
+      <AnnotationNoteEditor className='h-full' value={value} onSave={onSave} onCancel={onCancel} />
+    </Dialog>
+  );
+};
+
+export default NoteEditorSheet;

--- a/apps/readest-app/src/app/reader/components/annotator/SelectionRangeEditor.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/SelectionRangeEditor.tsx
@@ -193,7 +193,14 @@ const SelectionRangeEditor: React.FC<SelectionRangeEditorProps> = ({
   const showLoupe = appService?.isMobile && !viewSettings?.isEink && !viewSettings?.vertical;
 
   return (
-    <div className='pointer-events-none fixed inset-0 z-50'>
+    // The handle layer sits BELOW the popup/sheet layer. Both used to be z-50
+    // in the same stacking context, so the tie broke on DOM order — and the
+    // range editors are rendered after the popups, which put their handles on
+    // top of the dictionary, the translator and the note editor sheet. z-[44]
+    // keeps them over the book and the paragraph/TTS chrome (z-40) while
+    // leaving the popups (z-50), dialogs (z-50) and the side panels' overlay
+    // (z-[45]) above them.
+    <div className='pointer-events-none fixed inset-0 z-[44]'>
       <Handle
         hidden={draggingHandle === 'end'}
         position={currentStart}

--- a/apps/readest-app/src/app/reader/components/sidebar/BooknoteItem.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/BooknoteItem.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import dayjs from 'dayjs';
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { MdEdit, MdDelete, MdContentCopy, MdPlaylistAdd } from 'react-icons/md';
 
 import { useEnv } from '@/context/EnvContext';
@@ -19,10 +19,7 @@ import { buildAnnotationUrl } from '@/utils/deeplink';
 import { buildAnnotationCopyMarkdown } from '@/utils/note';
 import { writeTextToClipboard } from '@/utils/clipboard';
 import { DEFAULT_NOTE_EXPORT_CONFIG } from '@/services/constants';
-import {
-  removeBookNoteOverlays,
-  removeEmptyAnnotationPlaceholder,
-} from '../../utils/annotatorUtil';
+import { removeBookNoteOverlays } from '../../utils/annotatorUtil';
 import { parseNoteMarkdown } from '../../utils/noteMarkdown';
 import { useSaveBooknoteNoteText } from '../../hooks/useSaveBooknoteNoteText';
 import { useInlineTextEditor } from '../../hooks/useInlineTextEditor';
@@ -35,9 +32,6 @@ interface BooknoteItemProps {
   isNearest?: boolean;
   onClick?: () => void;
   inlineNoteEditing?: boolean;
-  startEditing?: boolean;
-  placeholderIds?: string[];
-  onFinishEditing?: () => void;
 }
 
 const BooknoteItem: React.FC<BooknoteItemProps> = ({
@@ -46,9 +40,6 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
   isNearest,
   onClick,
   inlineNoteEditing,
-  startEditing,
-  placeholderIds = [],
-  onFinishEditing,
 }) => {
   const _ = useTranslation();
   const { envConfig, appService } = useEnv();
@@ -82,7 +73,6 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
     useInlineTextEditor((draftText) => {
       if (isBookmark) saveBookmarkText(draftText);
       else saveBooknoteNoteText(item.id, draftText);
-      onFinishEditing?.();
     });
   const separatorWidth = useResponsiveSize(3);
   const size18 = useResponsiveSize(18);
@@ -189,30 +179,6 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
 
   const editNoteInline = () => startEdit(item.note || '');
 
-  useEffect(() => {
-    if (startEditing) startEdit(item.note || '');
-  }, [item.note, startEdit, startEditing]);
-
-  const cancelRequestedEdit = () => {
-    if (placeholderIds.length > 0) {
-      const config = getConfig(bookKey);
-      const { booknotes = [] } = config ?? {};
-      const removed = placeholderIds
-        .map((id) => removeEmptyAnnotationPlaceholder(booknotes, id, Date.now()))
-        .filter((placeholder): placeholder is BookNote => placeholder !== null);
-      if (removed.length > 0) {
-        const views = getViewsById(bookKey.split('-')[0]!);
-        removed.forEach((placeholder) => {
-          views.forEach((view) => removeBookNoteOverlays(view, placeholder));
-        });
-        const updatedConfig = updateBooknotes(bookKey, booknotes);
-        if (updatedConfig) saveConfig(envConfig, bookKey, updatedConfig, settings);
-      }
-    }
-    cancelEdit();
-    onFinishEditing?.();
-  };
-
   if (inlineEditMode) {
     return (
       <div
@@ -230,15 +196,13 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
             value={draftText}
             onChange={setDraftText}
             onSave={save}
-            onEscape={startEditing ? cancelRequestedEdit : cancelEdit}
+            onEscape={cancelEdit}
             spellCheck={false}
             autoFocus
           />
         </div>
         <div className='flex justify-end space-x-3 p-2' dir='ltr'>
-          <TextButton onClick={startEditing ? cancelRequestedEdit : cancelEdit}>
-            {_('Cancel')}
-          </TextButton>
+          <TextButton onClick={cancelEdit}>{_('Cancel')}</TextButton>
           <TextButton onClick={save} disabled={isBookmark && !draftText}>
             {_('Save')}
           </TextButton>

--- a/apps/readest-app/src/app/reader/components/sidebar/BooknoteItem.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/BooknoteItem.tsx
@@ -1,15 +1,13 @@
 import clsx from 'clsx';
 import dayjs from 'dayjs';
 import React, { useMemo } from 'react';
-import { MdEdit, MdDelete, MdContentCopy, MdPlaylistAdd } from 'react-icons/md';
+import { MdEdit, MdDelete, MdContentCopy } from 'react-icons/md';
 
 import { useEnv } from '@/context/EnvContext';
 import { BookNote, HighlightColor } from '@/types/book';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useNotebookStore } from '@/store/notebookStore';
-import { useNotebookDocumentStore } from '@/store/notebookDocumentStore';
-import { useSidebarStore } from '@/store/sidebarStore';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
@@ -42,13 +40,11 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
   inlineNoteEditing,
 }) => {
   const _ = useTranslation();
-  const { envConfig, appService } = useEnv();
+  const { envConfig } = useEnv();
   const { settings } = useSettingsStore();
   const { getConfig, saveConfig, updateBooknotes } = useBookDataStore();
   const { getProgress, getView, getViewsById, getViewSettings } = useReaderStore();
-  const { setNotebookActiveTab, setNotebookEditAnnotation, setNotebookVisible } =
-    useNotebookStore();
-  const { setSideBarVisible } = useSidebarStore();
+  const { setNotebookEditAnnotation, setNotebookVisible } = useNotebookStore();
 
   const globalReadSettings = settings.globalReadSettings;
   const customColors = globalReadSettings.customHighlightColors;
@@ -157,24 +153,6 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
     });
   };
 
-  const handleInsertIntoNotebook = () => {
-    const { bookHash, markdown } = buildSourceMarkdown();
-    const result = useNotebookDocumentStore.getState().insert(bookHash, markdown);
-    if (!result.accepted) {
-      eventDispatcher.dispatch('toast', {
-        type: 'warning',
-        message: _('Notebook is too large to save. Copy or remove some text to continue.'),
-        timeout: 3000,
-      });
-      return;
-    }
-    setNotebookActiveTab('notes');
-    setNotebookVisible(true);
-    if (appService?.isMobile || window.innerWidth < 640 || window.innerHeight < 640) {
-      setSideBarVisible(false);
-    }
-  };
-
   const editBookmark = () => startEdit(text || '');
 
   const editNoteInline = () => startEdit(item.note || '');
@@ -189,7 +167,11 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
           'transition-all duration-300 ease-in-out',
         )}
       >
-        <div className='flex w-full'>
+        {/* Same anatomy as AnnotationNoteEditor — the field, then a
+            bottom-right Cancel/Save row — so a note reads the same whichever
+            editor opened it. This one keeps its content height: it sits in a
+            list row, not in a sized popup or sheet. */}
+        <div className='flex flex-col gap-2 p-2'>
           <TextEditor
             className='leading-normal!'
             ref={editorRef}
@@ -197,15 +179,16 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
             onChange={setDraftText}
             onSave={save}
             onEscape={cancelEdit}
+            placeholder={isBookmark ? undefined : _('Add Note')}
             spellCheck={false}
             autoFocus
           />
-        </div>
-        <div className='flex justify-end space-x-3 p-2' dir='ltr'>
-          <TextButton onClick={cancelEdit}>{_('Cancel')}</TextButton>
-          <TextButton onClick={save} disabled={isBookmark && !draftText}>
-            {_('Save')}
-          </TextButton>
+          <div className='flex shrink-0 justify-end gap-3' dir='ltr'>
+            <TextButton onClick={cancelEdit}>{_('Cancel')}</TextButton>
+            <TextButton onClick={save} disabled={isBookmark && !draftText}>
+              {_('Save')}
+            </TextButton>
+          </div>
         </div>
       </div>
     );
@@ -327,25 +310,15 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
           >
             <button
               onClick={handleCopyLink}
-              className='btn btn-ghost btn-xs text-base-content p-0 opacity-0 transition duration-300 ease-in-out hover:bg-transparent group-focus-within:opacity-100 group-hover:opacity-100'
+              className='btn btn-ghost btn-xs text-base-content p-0 opacity-0 transition duration-300 ease-in-out hover:border-transparent hover:bg-transparent group-focus-within:opacity-100 group-hover:opacity-100'
               aria-label={_('Copy')}
             >
               <MdContentCopy size={size18} />
             </button>
 
-            {(item.type === 'annotation' || item.type === 'excerpt') && (
-              <button
-                onClick={handleInsertIntoNotebook}
-                className='btn btn-ghost btn-xs text-base-content p-0 opacity-0 transition duration-300 ease-in-out hover:bg-transparent group-focus-within:opacity-100 group-hover:opacity-100'
-                aria-label={_('Insert into Notebook')}
-              >
-                <MdPlaylistAdd size={size18} />
-              </button>
-            )}
-
             <button
               onClick={deleteNote.bind(null, item)}
-              className='btn btn-ghost btn-xs p-0 text-red-500 opacity-0 transition duration-300 ease-in-out hover:bg-transparent group-focus-within:opacity-100 group-hover:opacity-100'
+              className='btn btn-ghost btn-xs p-0 text-red-500 opacity-0 transition duration-300 ease-in-out hover:border-transparent hover:bg-transparent group-focus-within:opacity-100 group-hover:opacity-100'
               aria-label={_('Delete')}
             >
               <MdDelete size={size18} />
@@ -360,7 +333,7 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
                       ? editNoteInline
                       : editNote.bind(null, item)
                 }
-                className='btn btn-ghost btn-xs p-0 text-blue-500 opacity-0 transition duration-300 ease-in-out hover:bg-transparent group-focus-within:opacity-100 group-hover:opacity-100'
+                className='btn btn-ghost btn-xs p-0 text-blue-500 opacity-0 transition duration-300 ease-in-out hover:border-transparent hover:bg-transparent group-focus-within:opacity-100 group-hover:opacity-100'
                 aria-label={item.note || item.type === 'bookmark' ? _('Edit') : _('Add Note')}
               >
                 <MdEdit size={size18} />

--- a/apps/readest-app/src/app/reader/components/sidebar/BooknoteView.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/BooknoteView.tsx
@@ -49,18 +49,11 @@ const BooknoteView: React.FC<{
   const _ = useTranslation();
   const { getConfig } = useBookDataStore();
   const { getProgress } = useReaderStore();
-  const {
-    setActiveBooknoteType,
-    setBooknoteResults,
-    isSearchBarVisible,
-    setSearchBarVisible,
-    annotationEditTargets,
-    setAnnotationEditTarget,
-  } = useSidebarStore();
+  const { setActiveBooknoteType, setBooknoteResults, isSearchBarVisible, setSearchBarVisible } =
+    useSidebarStore();
   const config = getConfig(bookKey)!;
   const progress = getProgress(bookKey);
   const allNotes = config.booknotes ?? [];
-  const editTarget = annotationEditTargets[bookKey];
 
   const [filterKind, setFilterKind] = useState<AnnotationFilterKind>('all');
   const [searchInput, setSearchInput] = useState('');
@@ -361,22 +354,11 @@ const BooknoteView: React.FC<{
             isNearest={row.item.cfi === nearestCfi}
             onClick={handleBrowseBookNotes}
             inlineNoteEditing={type === 'annotation'}
-            startEditing={type === 'annotation' && editTarget?.annotationId === row.item.id}
-            placeholderIds={editTarget?.placeholderIds}
-            onFinishEditing={() => setAnnotationEditTarget(bookKey, null)}
           />
         </ul>
       );
     },
-    [
-      flatItems,
-      bookKey,
-      nearestCfi,
-      handleBrowseBookNotes,
-      type,
-      editTarget,
-      setAnnotationEditTarget,
-    ],
+    [flatItems, bookKey, nearestCfi, handleBrowseBookNotes, type],
   );
 
   // Always mount the listHostRef host so the height-measurement effect (and

--- a/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
@@ -369,6 +369,47 @@ export const useTextSelector = (
     await makeSelection(sel, index, false, true);
   };
 
+  // A lookup popup opening over a live selection can never stack above the
+  // platform's own selection grabbers: iOS draws them (and the callout bar) as
+  // UIKit views over the whole web layer, so they are outside the DOM and no
+  // z-index reaches them. #5213 rules out just deselecting — the selection has
+  // to survive the lookup so its dismiss lands back on the toolbar — so take
+  // the grabbers away instead and leave the selection.
+  //
+  // Same trick as suppressNativeHandlesForPages: a selection that goes empty
+  // for one painted frame drops its native handles, and re-adding the range
+  // programmatically doesn't bring them back (the engine only draws them for a
+  // user-initiated selection). `handlesSuppressed` then hands the job to the
+  // app's own handles, which do stack below the popup.
+  const suppressNativeSelectionHandles = async () => {
+    // Desktop has no grabbers to take away, and the dance would only churn the
+    // selection the popup is anchored to.
+    if (!appService?.isMobile) return;
+    const content = getContents().find(
+      (c) => c.doc && c.index != null && isValidSelection(c.doc.getSelection()!),
+    );
+    if (!content) return;
+    const doc = content.doc;
+    const win = doc.defaultView;
+    const sel = doc.getSelection();
+    if (!win || !sel) return;
+    const range = sel.getRangeAt(0).cloneRange();
+    guardProgrammaticSelection();
+    sel.removeAllRanges();
+    await new Promise<void>((resolve) =>
+      win.requestAnimationFrame(() => win.requestAnimationFrame(() => resolve())),
+    );
+    // Bail if a competing gesture touched the selection while we waited: the
+    // range we cloned is no longer the one on screen.
+    if (sel.rangeCount > 0 || range.collapsed) {
+      releaseProgrammaticSelection();
+      return;
+    }
+    sel.addRange(range);
+    releaseProgrammaticSelection();
+    setSelection((prev) => (prev ? { ...prev, handlesSuppressed: true } : prev));
+  };
+
   const {
     isInstantAnnotationEnabled,
     handleInstantAnnotationPointerDown,
@@ -1148,6 +1189,7 @@ export const useTextSelector = (
     handleUpToPopup,
     handleContextmenu,
     dragSelectionTo,
+    suppressNativeSelectionHandles,
     // The shared corner auto-turn feed/cancel/subscribe, re-exposed so the range
     // editors can drive the same machine from their overlay handle drags.
     noteAutoTurnPoint,

--- a/apps/readest-app/src/components/TextButton.tsx
+++ b/apps/readest-app/src/components/TextButton.tsx
@@ -37,7 +37,11 @@ const TextButton: React.FC<TextButtonProps> = ({
     <button
       type={type}
       className={clsx(
-        'content settings-content btn btn-ghost hover:bg-transparent',
+        // daisyUI's btn carries a 1px border that btn-ghost only colours in on
+        // hover, which `hover:bg-transparent` doesn't touch — it read as a box
+        // appearing around Cancel/Save. Keep the border for geometry, keep it
+        // invisible.
+        'content settings-content btn btn-ghost hover:border-transparent hover:bg-transparent',
         'flex items-end p-0',
         sizeClasses[size],
         disabled ? 'btn-disabled bg-transparent!' : '',

--- a/apps/readest-app/src/store/sidebarStore.ts
+++ b/apps/readest-app/src/store/sidebarStore.ts
@@ -19,11 +19,6 @@ interface BooknotesNavState {
   booknoteIndex: number;
 }
 
-export interface AnnotationEditTarget {
-  annotationId: string;
-  placeholderIds: string[];
-}
-
 interface SidebarState {
   sideBarBookKey: string | null;
   sideBarWidth: string;
@@ -34,7 +29,6 @@ interface SidebarState {
   searchNavStates: Record<string, SearchNavState>;
   booknotesNavStates: Record<string, BooknotesNavState>;
   searchStatuses: Record<string, SearchStatus>;
-  annotationEditTargets: Record<string, AnnotationEditTarget>;
   getIsSideBarVisible: () => boolean;
   getSideBarWidth: () => string;
   setSideBarBookKey: (key: string) => void;
@@ -63,7 +57,6 @@ interface SidebarState {
   setBooknoteResults: (bookKey: string, results: BookNote[] | null) => void;
   setBooknoteIndex: (bookKey: string, index: number) => void;
   clearBooknotesNav: (bookKey: string) => void;
-  setAnnotationEditTarget: (bookKey: string, target: AnnotationEditTarget | null) => void;
 }
 
 const defaultSearchNavState: SearchNavState = {
@@ -90,7 +83,6 @@ export const useSidebarStore = create<SidebarState>((set, get) => ({
   searchNavStates: {},
   booknotesNavStates: {},
   searchStatuses: {},
-  annotationEditTargets: {},
   getIsSideBarVisible: () => get().isSideBarVisible,
   getSideBarWidth: () => get().sideBarWidth,
   setSideBarBookKey: (key: string) => set({ sideBarBookKey: key }),
@@ -216,11 +208,4 @@ export const useSidebarStore = create<SidebarState>((set, get) => ({
         [bookKey]: { ...defaultBooknotesNavState },
       },
     })),
-  setAnnotationEditTarget: (bookKey: string, target: AnnotationEditTarget | null) =>
-    set((state) => {
-      const annotationEditTargets = { ...state.annotationEditTargets };
-      if (target) annotationEditTargets[bookKey] = target;
-      else delete annotationEditTargets[bookKey];
-      return { annotationEditTargets };
-    }),
 }));


### PR DESCRIPTION
Closes #5987. Closes #5957.

0.12.6 moved the Annotate action out of the Notebook: it highlighted the selection, opened the annotations sidebar, and asked the matching row to start editing. That hub lists notes in reading order and virtualizes them, so a note made further down the current page kept its row outside the mounted window and its editor never rendered. The user got an annotation count that went up and nothing else — no note to see, no caret to type into — then found the note "at the bottom" later (#5987), or in an order that looked arbitrary from one note to the next (#5957). `findNearestCfi` collapses the reading position to the *page start*, so a note made lower on the same page is never the "nearest" one the panel scrolls to.

## The note editor moves to the selection

On desktop it takes over the annotation toolbar popup, the same surface that already hosts an existing note's editor. Below `sm` (or in short landscape) it opens as a bottom sheet snapped to 60% of the screen, so the field clears the on-screen keyboard — the call `DictionarySheet` already makes for the same reason. Both surfaces render one `AnnotationNoteEditor`: text area on top, Cancel/Save pinned bottom-right, autofocused. The pencil on a note bubble opens that same editor, so a note is written the same way wherever it starts from.

Reading order stays the hub's sort. The sidebar is left alone: `annotationEditTargets` and `BooknoteItem`'s `startEditing` / `placeholderIds` / `onFinishEditing` plumbing are gone.

**#4791 placeholder cleanup now hangs off the editor closing, not off Cancel.** Annotate creates an empty highlight for the note to hang on, and Cancel is not the only way the editor stops being presented — opening the sidebar and a page relocate both dismiss the popup from effects. Either one used to leave a highlight the user never asked for. (Caught by CodeRabbit; the relocate path had also just gone from unreachable to live, see below.)

## The overlay stacking bug underneath it

The range-handle layer and the popup layer were both `z-50` in one stacking context, so the tie broke on DOM order — and the range editors render after the popups. That is why #5815 had to *unmount* them for the lookup popups, and why the note editor, a fourth surface that never joined that gate, got handles drawn over its sheet.

Handles now sit at `z-[44]`: above the book and the paragraph / TTS chrome (`z-40`), below the side panels (`z-[45]`) and the popups and dialogs (`z-50`). The #5815 gate stays as the product behaviour it is, but a surface that forgets to join it is no longer covered. The new e2e reads both layers' computed z-index off the live DOM rather than mirroring class names.

## iOS: the platform's own grabbers

z-order can't reach those — WebKit composites the selection grabbers and the callout bar as UIKit views above the whole web layer. Deselecting is off the table for a lookup, since #5213 wants the selection alive so the dismiss returns to the toolbar. So `suppressNativeSelectionHandles()` takes the grabbers away and leaves the selection: empty the selection for one painted frame, then re-add the same range programmatically. The engine only draws grabbers for a user-initiated selection, so they stay gone, and `handlesSuppressed` hands over to the app's handles. It generalises the trick `suppressNativeHandlesForPages` already uses for Android cross-page drags (#5809).

## Polish

- **Insert into Notebook is removed** from the annotation row — a third destination for a note that nobody reaches for. Its string is pruned from all 34 locales by the extractor.
- **The hover border is gone.** daisyUI's `btn` carries a 1px border that `btn-ghost` only colours in on hover, which `hover:bg-transparent` never touched, so a box appeared around every icon button and around Cancel/Save. Fixed on the row's icons, the bubble's pencil, and `TextButton` — which covers Cancel/Save everywhere.
- **The two note editors match.** The sidebar's inline editor gets the same anatomy and placeholder, and the same size: `.content.font-size-sm` is 0.875*em*, so it depends on the ancestor carrying `.content`'s responsive base; the popup and sheet lacked it and rendered a size smaller. Measured 14px text and 14px buttons in both, side by side.

## Verification

Chrome, against a 70-annotation book: annotating the last line of a page used to leave the panel parked at the top with **no editor in the DOM at all**. Now the editor opens on the selection, saves the typed note, and Cancel drops the placeholder (77 → 76 live annotations). Checked on the desktop popup at 1511×812 and the sheet at 430×932 and 500×632, plus the bubble pencil, the removed action, the hover borders and the font sizes.

Tests: `AnnotationNoteEditor.test.tsx`, `AnnotateNoteEditorFlow.test.tsx` (popup vs sheet routing, sidebar untouched, save, cancel-drops-placeholder, dismiss-drops-placeholder, cancel-keeps-pre-existing-highlight, #5213 selection kept for the lookups, bubble-edit seeding/saving/cancel) and `useTextSelector-nativeHandles.test.ts` (mutation-checked). `AnnotationNoteItem` / `AnnotationNotes` / `BooknoteItem` tests rewritten to the new contracts. Full suite 10655 passed, browser 420, all 24 e2e specs, lint and format clean.

## Not verified

The iOS grabber suppression has no device run — the mechanism is the one already shipping for Android cross-page, but the WebKit behaviour it leans on deserves a check on hardware. The `z-[44]` move also reorders every reader overlay, not just the note editor, so handles now paint under the annotation toolbar where they overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)