### PR TITLE
fix(dict): play MDD audio, jump to POS sections, zoom entry images

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/annotator/DictionarySheet.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/annotator/DictionarySheet.test.tsx
@@ -92,6 +92,27 @@ vi.mock('@tauri-apps/plugin-opener', () => ({
   openUrl: (...args: unknown[]) => mockOpenUrl(...args),
 }));
 
+// Blob -> data URL conversion needs a real `fetch` for `blob:` URLs, which
+// jsdom doesn't provide; the viewer only cares that it receives a data URL.
+const mockConvertBlobUrlToDataUrl = vi.fn(async (src: string) => `data:image/png;base64,${src}`);
+vi.mock('@/libs/document', async () => {
+  const actual = await vi.importActual<typeof import('@/libs/document')>('@/libs/document');
+  return {
+    ...actual,
+    convertBlobUrlToDataUrl: (src: string) => mockConvertBlobUrlToDataUrl(src),
+  };
+});
+
+// Thin stand-in for the reader's full-screen image viewer.
+vi.mock('@/app/reader/components/ImageViewer', () => ({
+  default: ({ src, onClose }: { src: string | null; onClose: () => void }) =>
+    src ? (
+      <div data-testid='dict-image-viewer' data-src={src}>
+        <button type='button' aria-label='Close image viewer' onClick={onClose} />
+      </div>
+    ) : null,
+}));
+
 vi.mock('@/services/environment', async () => {
   const actual =
     await vi.importActual<typeof import('@/services/environment')>('@/services/environment');
@@ -204,6 +225,53 @@ const buildSlowProvider = (abortObserver: { aborted: boolean }): DictionaryProvi
   },
 });
 
+// Mimics the MDict provider's rendering: the entry body lives in a shadow
+// root, so a click's `target` is retargeted to the host and only the composed
+// path names the image that was actually tapped.
+const buildShadowImageProvider = (): DictionaryProvider => ({
+  id: 'shadow-img',
+  kind: 'mdict',
+  label: 'Shadow Image Dict',
+  async lookup(word, ctx) {
+    const host = document.createElement('div');
+    host.setAttribute('data-testid', 'img-shadow-host');
+    ctx.container.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const img = document.createElement('img');
+    img.setAttribute('src', 'blob:test/pic-1');
+    shadow.appendChild(img);
+    const linked = document.createElement('a');
+    linked.setAttribute('href', 'https://example.com/more');
+    const linkedImg = document.createElement('img');
+    linkedImg.setAttribute('src', 'blob:test/pic-2');
+    linked.appendChild(linkedImg);
+    shadow.appendChild(linked);
+    // OALD9 wraps its illustrations in a hrefless `<a class="topic no-href">`,
+    // so the wrapper is markup, not a link, and must not swallow the tap.
+    const hrefless = document.createElement('a');
+    hrefless.className = 'topic no-href';
+    const heldImg = document.createElement('img');
+    heldImg.setAttribute('src', 'blob:test/pic-3');
+    hrefless.appendChild(heldImg);
+    shadow.appendChild(hrefless);
+    // OALD9 ships each illustration twice inside `<div class="ox-enlarge">`: a
+    // hidden full-resolution copy followed by the `thumb` that is laid out.
+    const pair = document.createElement('a');
+    pair.className = 'topic no-href';
+    const fullsize = document.createElement('img');
+    fullsize.setAttribute('src', 'blob:test/pic-fullsize');
+    fullsize.style.display = 'none';
+    Object.defineProperty(fullsize, 'naturalWidth', { value: 720 });
+    const thumb = document.createElement('img');
+    thumb.className = 'thumb';
+    thumb.setAttribute('src', 'blob:test/pic-thumb');
+    Object.defineProperty(thumb, 'naturalWidth', { value: 100 });
+    pair.append(fullsize, thumb);
+    shadow.appendChild(pair);
+    return { ok: true, headword: word, sourceLabel: 'Shadow Image Dict' };
+  },
+});
+
 const buildEmptyProvider = (id: string, label: string): DictionaryProvider => ({
   id,
   kind: 'stardict',
@@ -268,6 +336,7 @@ const resetStoreToEmpty = () => {
 beforeEach(() => {
   providersForNextRender.length = 0;
   mockOpenUrl.mockClear();
+  mockConvertBlobUrlToDataUrl.mockClear();
   resetStoreToEmpty();
 });
 
@@ -586,5 +655,83 @@ describe('DictionarySheet — abort on unmount', () => {
     await waitFor(() => {
       expect(observer.aborted).toBe(true);
     });
+  });
+});
+
+describe('DictionarySheet - image zoom', () => {
+  it('opens the full-screen viewer when an image in a shadow-rendered entry is tapped (#6018)', async () => {
+    providersForNextRender.push(buildShadowImageProvider());
+    renderSheet({ word: 'hello' });
+
+    const host = await waitFor(() => {
+      const el = screen.getByTestId('img-shadow-host');
+      if (!el.shadowRoot) throw new Error('shadow root not attached');
+      return el;
+    });
+    const img = host.shadowRoot!.querySelector('img[src="blob:test/pic-1"]') as HTMLImageElement;
+
+    fireEvent.click(img);
+
+    const viewer = await waitFor(() => screen.getByTestId('dict-image-viewer'));
+    expect(viewer.getAttribute('data-src')).toBe('data:image/png;base64,blob:test/pic-1');
+
+    fireEvent.click(screen.getByLabelText('Close image viewer'));
+    await waitFor(() => expect(screen.queryByTestId('dict-image-viewer')).toBeNull());
+  });
+
+  it('leaves an image wrapped in a link to the link handler', async () => {
+    providersForNextRender.push(buildShadowImageProvider());
+    renderSheet({ word: 'hello' });
+
+    const host = await waitFor(() => {
+      const el = screen.getByTestId('img-shadow-host');
+      if (!el.shadowRoot) throw new Error('shadow root not attached');
+      return el;
+    });
+    const linkedImg = host.shadowRoot!.querySelector(
+      'img[src="blob:test/pic-2"]',
+    ) as HTMLImageElement;
+
+    fireEvent.click(linkedImg);
+
+    await act(async () => {});
+    expect(screen.queryByTestId('dict-image-viewer')).toBeNull();
+    expect(mockConvertBlobUrlToDataUrl).not.toHaveBeenCalled();
+  });
+
+  it('zooms an image wrapped in an anchor that has no href (#6018)', async () => {
+    providersForNextRender.push(buildShadowImageProvider());
+    renderSheet({ word: 'hello' });
+
+    const host = await waitFor(() => {
+      const el = screen.getByTestId('img-shadow-host');
+      if (!el.shadowRoot) throw new Error('shadow root not attached');
+      return el;
+    });
+    const heldImg = host.shadowRoot!.querySelector(
+      'img[src="blob:test/pic-3"]',
+    ) as HTMLImageElement;
+
+    fireEvent.click(heldImg);
+
+    const viewer = await waitFor(() => screen.getByTestId('dict-image-viewer'));
+    expect(viewer.getAttribute('data-src')).toBe('data:image/png;base64,blob:test/pic-3');
+  });
+
+  it('zooms the hidden full-resolution twin, not the thumbnail (#6018)', async () => {
+    providersForNextRender.push(buildShadowImageProvider());
+    renderSheet({ word: 'hello' });
+
+    const host = await waitFor(() => {
+      const el = screen.getByTestId('img-shadow-host');
+      if (!el.shadowRoot) throw new Error('shadow root not attached');
+      return el;
+    });
+    const thumb = host.shadowRoot!.querySelector('img.thumb') as HTMLImageElement;
+
+    fireEvent.click(thumb);
+
+    const viewer = await waitFor(() => screen.getByTestId('dict-image-viewer'));
+    expect(viewer.getAttribute('data-src')).toBe('data:image/png;base64,blob:test/pic-fullsize');
   });
 });

--- a/apps/readest-app/src/__tests__/services/dictionaries/importMdxHeaderTitle.test.ts
+++ b/apps/readest-app/src/__tests__/services/dictionaries/importMdxHeaderTitle.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The MDX header is XML, so its attribute values arrive escaped: OALD9 ships
+ * `Title="Oxford Advanced Learner&apos;s Dictionary 9th edition"`. Lifting the
+ * raw attribute text into the dictionary name printed the entity verbatim in
+ * the lookup sheet's source label (#6018).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { importDictionaries } from '@/services/dictionaries/dictionaryService';
+import type { FileSystem } from '@/types/system';
+
+function createMockFs(): FileSystem {
+  return {
+    resolvePath: vi
+      .fn()
+      .mockReturnValue({ baseDir: 0, basePrefix: async () => '', fp: 'x', base: 'Dictionaries' }),
+    getURL: vi.fn().mockReturnValue('url'),
+    getBlobURL: vi.fn().mockResolvedValue('blob:url'),
+    getImageURL: vi.fn().mockResolvedValue('image:url'),
+    openFile: vi.fn().mockResolvedValue(new File([], 'unused')),
+    copyFile: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockResolvedValue(''),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    removeFile: vi.fn().mockResolvedValue(undefined),
+    readDir: vi.fn().mockResolvedValue([]),
+    createDir: vi.fn().mockResolvedValue(undefined),
+    removeDir: vi.fn().mockResolvedValue(undefined),
+    exists: vi.fn().mockResolvedValue(false),
+    stats: vi.fn().mockResolvedValue({
+      isFile: true,
+      isDirectory: false,
+      size: 0,
+      mtime: null,
+      atime: null,
+      birthtime: null,
+    }),
+    getPrefix: vi.fn().mockResolvedValue('Readest/Dictionaries'),
+  };
+}
+
+/** An MDX file that carries nothing but the header the importer reads. */
+function createMdxFile(xml: string, name = 'oald9.mdx'): File {
+  const utf16 = new Uint8Array(xml.length * 2);
+  const view = new DataView(utf16.buffer);
+  for (let i = 0; i < xml.length; i++) {
+    view.setUint16(i * 2, xml.charCodeAt(i), true);
+  }
+  const size = new Uint8Array(4);
+  new DataView(size.buffer).setUint32(0, utf16.byteLength, false);
+  return new File([size, utf16, new Uint8Array(4)], name);
+}
+
+describe('importDictionaries — MDX header title', () => {
+  it('decodes XML entities in the title (#6018)', async () => {
+    const fs = createMockFs();
+    const mdx = createMdxFile(
+      '<Dictionary GeneratedByEngineVersion="2.0" Encrypted="2" ' +
+        'Title="Oxford Advanced Learner&apos;s Dictionary &amp; Thesaurus &#169; 2016" ' +
+        'Encoding="UTF-8"/>',
+    );
+
+    const result = await importDictionaries(fs, [{ file: mdx }]);
+
+    expect(result.imported).toHaveLength(1);
+    const entry = result.imported[0]!;
+    expect(entry.kind).toBe('mdict');
+    expect(entry.name).toBe("Oxford Advanced Learner's Dictionary & Thesaurus © 2016");
+    expect(entry.unsupported).toBeUndefined();
+  });
+});

--- a/apps/readest-app/src/__tests__/services/dictionaries/mdictProvider.test.ts
+++ b/apps/readest-app/src/__tests__/services/dictionaries/mdictProvider.test.ts
@@ -454,6 +454,196 @@ describe('mdictProvider', () => {
     }
   });
 
+  it('jumps within the entry for entry://#anchor instead of looking it up as a headword', async () => {
+    const jsmdict = await import('js-mdict');
+    const origMDXCreate = jsmdict.MDX.create.bind(jsmdict.MDX);
+    type FakeMDX = ReturnType<typeof origMDXCreate> extends Promise<infer T> ? T : never;
+    jsmdict.MDX.create = async () =>
+      ({
+        meta: { encrypt: 0 },
+        header: {},
+        lookup: async (word: string) => ({
+          keyText: word,
+          definition:
+            `<a href="entry://#pos-noun">noun</a>` +
+            `<a href="entry://#pos-verb">verb</a>` +
+            `<div id="pos-noun">noun senses</div>` +
+            `<a name="pos-verb"></a><div>verb senses</div>`,
+        }),
+      }) as unknown as FakeMDX;
+    const scrollSpy = vi.fn();
+    (Element.prototype as unknown as { scrollIntoView: unknown }).scrollIntoView = scrollSpy;
+
+    try {
+      const provider = createMdictProvider({ dict: buildDict(false), fs: makeFs() });
+      const container = document.createElement('div');
+      const onNavigate = vi.fn();
+      await provider.lookup('bank', {
+        signal: new AbortController().signal,
+        container,
+        onNavigate,
+      });
+
+      const shadow = getMdictShadow(container);
+      const nounLink = shadow.querySelector('a[href="entry://#pos-noun"]') as HTMLAnchorElement;
+      const verbLink = shadow.querySelector('a[href="entry://#pos-verb"]') as HTMLAnchorElement;
+      expect(nounLink).not.toBeNull();
+
+      // `#anchor` is a section of the entry that is already rendered, not a
+      // headword — forwarding it to onNavigate looks up the literal string and
+      // leaves an empty card titled `#pos-noun` (#6018).
+      nounLink.click();
+      expect(onNavigate).not.toHaveBeenCalled();
+      expect(scrollSpy.mock.instances[0]).toBe(shadow.querySelector('#pos-noun'));
+
+      // Legacy `<a name="...">` targets resolve too — MDX bodies predate `id`.
+      verbLink.click();
+      expect(onNavigate).not.toHaveBeenCalled();
+      expect(scrollSpy.mock.instances[1]).toBe(shadow.querySelector('a[name="pos-verb"]'));
+    } finally {
+      jsmdict.MDX.create = origMDXCreate;
+      delete (Element.prototype as unknown as { scrollIntoView?: unknown }).scrollIntoView;
+    }
+  });
+
+  it('jumps within the entry for a bare #anchor href', async () => {
+    const jsmdict = await import('js-mdict');
+    const origMDXCreate = jsmdict.MDX.create.bind(jsmdict.MDX);
+    type FakeMDX = ReturnType<typeof origMDXCreate> extends Promise<infer T> ? T : never;
+    jsmdict.MDX.create = async () =>
+      ({
+        meta: { encrypt: 0 },
+        header: {},
+        lookup: async (word: string) => ({
+          keyText: word,
+          definition: `<a href="#idm140">adjective</a><div id="idm140">adjective senses</div>`,
+        }),
+      }) as unknown as FakeMDX;
+    const scrollSpy = vi.fn();
+    (Element.prototype as unknown as { scrollIntoView: unknown }).scrollIntoView = scrollSpy;
+
+    try {
+      const provider = createMdictProvider({ dict: buildDict(false), fs: makeFs() });
+      const container = document.createElement('div');
+      const onNavigate = vi.fn();
+      await provider.lookup('fine', {
+        signal: new AbortController().signal,
+        container,
+        onNavigate,
+      });
+
+      const shadow = getMdictShadow(container);
+      const link = shadow.querySelector('a[href="#idm140"]') as HTMLAnchorElement;
+      expect(link).not.toBeNull();
+
+      // Default fragment navigation can't reach a target inside the card's
+      // shadow root, so the jump has to be performed explicitly.
+      const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+      link.dispatchEvent(clickEvent);
+      expect(clickEvent.defaultPrevented).toBe(true);
+      expect(onNavigate).not.toHaveBeenCalled();
+      expect(scrollSpy.mock.instances[0]).toBe(shadow.querySelector('#idm140'));
+    } finally {
+      jsmdict.MDX.create = origMDXCreate;
+      delete (Element.prototype as unknown as { scrollIntoView?: unknown }).scrollIntoView;
+    }
+  });
+
+  it('still navigates for entry://word#anchor, which names another headword', async () => {
+    const jsmdict = await import('js-mdict');
+    const origMDXCreate = jsmdict.MDX.create.bind(jsmdict.MDX);
+    type FakeMDX = ReturnType<typeof origMDXCreate> extends Promise<infer T> ? T : never;
+    jsmdict.MDX.create = async () =>
+      ({
+        meta: { encrypt: 0 },
+        header: {},
+        lookup: async (word: string) => ({
+          keyText: word,
+          definition: `<a href="entry://timid#pos-adj">timid</a>`,
+        }),
+      }) as unknown as FakeMDX;
+
+    try {
+      const provider = createMdictProvider({ dict: buildDict(false), fs: makeFs() });
+      const container = document.createElement('div');
+      const onNavigate = vi.fn();
+      await provider.lookup('shy', {
+        signal: new AbortController().signal,
+        container,
+        onNavigate,
+      });
+
+      const link = getMdictShadow(container).querySelector(
+        'a[href^="entry://timid"]',
+      ) as HTMLAnchorElement;
+      link.click();
+      expect(onNavigate).toHaveBeenCalledWith('timid');
+    } finally {
+      jsmdict.MDX.create = origMDXCreate;
+    }
+  });
+
+  it('types sound:// audio blobs and starts the element inside the click gesture', async () => {
+    const jsmdict = await import('js-mdict');
+    const origMDXCreate = jsmdict.MDX.create.bind(jsmdict.MDX);
+    const origMDDCreate = jsmdict.MDD.create.bind(jsmdict.MDD);
+    const locateMock = vi.fn(async (key: string) => ({
+      keyText: key,
+      data: new Uint8Array([0xff, 0xfb, 0x90, 0x00]),
+    }));
+    const playSpy = vi
+      .spyOn(window.HTMLMediaElement.prototype, 'play')
+      .mockResolvedValue(undefined);
+    const blobs: Blob[] = [];
+    const outerCreateObjectURL = globalThis.URL.createObjectURL;
+    globalThis.URL.createObjectURL = (blob: Blob) => {
+      blobs.push(blob);
+      return outerCreateObjectURL(blob);
+    };
+    type FakeMDX = ReturnType<typeof origMDXCreate> extends Promise<infer T> ? T : never;
+    type FakeMDD = ReturnType<typeof origMDDCreate> extends Promise<infer T> ? T : never;
+    jsmdict.MDX.create = async () =>
+      ({
+        meta: { encrypt: 0 },
+        header: {},
+        lookup: async (word: string) => ({
+          keyText: word,
+          definition: `<a href="sound://us/hello.wav">play</a>`,
+        }),
+      }) as unknown as FakeMDX;
+    jsmdict.MDD.create = async () => ({ locateBytes: locateMock }) as unknown as FakeMDD;
+
+    try {
+      const provider = createMdictProvider({ dict: buildDict(true), fs: makeFs() });
+      const container = document.createElement('div');
+      await provider.lookup('hello', {
+        signal: new AbortController().signal,
+        container,
+      });
+
+      const anchor = getMdictShadow(container).querySelector(
+        'a[href^="sound://"]',
+      ) as HTMLAnchorElement;
+      anchor.click();
+      // WebKit only lets a media element start from inside the user gesture,
+      // and the MDD read below is async — so playback must be started (on a
+      // reused element) synchronously, before the first await (#6018).
+      expect(playSpy).toHaveBeenCalled();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // A media element refuses to decode a typeless blob URL on WebKit, so
+      // the MIME type has to come from the resource path.
+      const audioBlob = blobs.find((b) => b.type.startsWith('audio/'));
+      expect(audioBlob?.type).toBe('audio/wav');
+    } finally {
+      globalThis.URL.createObjectURL = outerCreateObjectURL;
+      jsmdict.MDX.create = origMDXCreate;
+      jsmdict.MDD.create = origMDDCreate;
+      playSpy.mockRestore();
+    }
+  });
+
   it('inlines a stylesheet referenced via <link rel=stylesheet> by reading bytes from MDD', async () => {
     const jsmdict = await import('js-mdict');
     const origMDXCreate = jsmdict.MDX.create.bind(jsmdict.MDX);

--- a/apps/readest-app/src/__tests__/services/dictionaries/mdictProvider.test.ts
+++ b/apps/readest-app/src/__tests__/services/dictionaries/mdictProvider.test.ts
@@ -338,7 +338,9 @@ describe('mdictProvider', () => {
 
       expect(locateMock).toHaveBeenCalledWith('test01.mp3');
       expect(playSpy).toHaveBeenCalled();
-      expect(anchor!.getAttribute('data-mdd-resolved')).toMatch(/^blob:/);
+      // The resolved URL is cached off the DOM, so assert on what played.
+      const played = playSpy.mock.instances.at(-1) as HTMLMediaElement;
+      expect(played.src).toMatch(/^blob:/);
 
       // Second click reuses the cached blob URL — no extra MDD read.
       locateMock.mockClear();

--- a/apps/readest-app/src/app/reader/components/annotator/DictionaryResultsView.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/DictionaryResultsView.tsx
@@ -8,6 +8,9 @@ import { openUrl } from '@tauri-apps/plugin-opener';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useEnv } from '@/context/EnvContext';
 import { useThemeStore } from '@/store/themeStore';
+import { convertBlobUrlToDataUrl } from '@/libs/document';
+import ModalPortal from '@/components/ModalPortal';
+import ImageViewer from '@/app/reader/components/ImageViewer';
 import { useCustomDictionaryStore } from '@/store/customDictionaryStore';
 import { getEnabledProviders } from '@/services/dictionaries/registry';
 import { buildLookupCandidates } from '@/services/dictionaries/lookupCandidates';
@@ -22,8 +25,24 @@ import type {
   DictionaryProvider,
   WebSearchEntry,
 } from '@/services/dictionaries/types';
+import type { Insets } from '@/types/misc';
 
 const isTauri = isTauriAppPlatform();
+const ZERO_INSETS: Insets = { top: 0, right: 0, bottom: 0, left: 0 };
+
+/**
+ * The `src` worth blowing up for a tapped entry image. MDX bodies ship an
+ * illustration twice — a hidden full-resolution copy beside the `thumb` that is
+ * actually laid out (OALD9's `<div class="ox-enlarge">`) — and zooming the
+ * 100px thumb is no enlargement at all. Take the largest decoded twin.
+ */
+const fullResolutionSrc = (image: HTMLImageElement | null) => {
+  if (!image) return null;
+  const wrapper = image.closest('a') ?? image.parentElement;
+  const twins = wrapper ? [...wrapper.querySelectorAll('img')] : [];
+  const largest = twins.reduce((a, b) => (b.naturalWidth > a.naturalWidth ? b : a), image);
+  return largest.getAttribute('src');
+};
 
 interface CardState {
   state: 'loading' | 'loaded' | 'empty' | 'unsupported' | 'error';
@@ -54,6 +73,9 @@ export interface DictionaryResultsState {
   noProvidersAtAll: boolean;
   /** Dictionary popup font-size multiplier (#4443); `1` = default sizes. */
   fontScale: number;
+  /** Data URL of the entry image being shown full screen, or `null` (#6018). */
+  zoomedImageSrc: string | null;
+  closeZoomedImage: () => void;
   /** Whether the current word is being fetched/spoken by the TTS engine (#4876). */
   isSpeaking: boolean;
   /** Pronounce the current word via Edge TTS (falling back to platform speech). */
@@ -201,14 +223,44 @@ export function useDictionaryResults({
     });
   }, [cards, manuallyToggled]);
 
-  // External-link delegation inside provider-rendered DOM: on Tauri we
-  // route http(s) anchors through `openUrl` because target="_blank" doesn't
-  // work; on web we let the anchor handle it natively.
+  const [zoomedImageSrc, setZoomedImageSrc] = useState<string | null>(null);
+  const closeZoomedImage = useCallback(() => setZoomedImageSrc(null), []);
+
+  // Click delegation inside provider-rendered DOM. MDict entries render in a
+  // shadow root, where `e.target` is retargeted to the host — only the composed
+  // path names the element that was actually clicked.
   const handleContainerClick = useCallback((e: React.MouseEvent) => {
-    if (!isTauri) return;
     if (e.defaultPrevented) return;
-    const anchor = (e.target as Element | null)?.closest?.('a');
-    if (!anchor) return;
+    let image: HTMLImageElement | null = null;
+    let anchor: HTMLAnchorElement | null = null;
+    for (const node of e.nativeEvent.composedPath()) {
+      if (node === e.currentTarget) break;
+      if (!(node instanceof Element)) continue;
+      if (!image && node.tagName === 'IMG') image = node as HTMLImageElement;
+      // Only a real link claims the tap: MDX bodies wrap illustrations in
+      // hrefless anchors (OALD9 uses `<a class="topic no-href">`), which are
+      // markup, not navigation.
+      if (!anchor && node.tagName === 'A' && node.hasAttribute('href')) {
+        anchor = node as HTMLAnchorElement;
+      }
+    }
+
+    // Tap an illustration to blow it up, as in the book itself (#6018). An
+    // image wrapped in a link belongs to the link.
+    const imageSrc = anchor ? null : fullResolutionSrc(image);
+    if (imageSrc) {
+      e.preventDefault();
+      void convertBlobUrlToDataUrl(imageSrc)
+        .then(setZoomedImageSrc)
+        .catch((err) => {
+          console.warn('Failed to load dictionary image', imageSrc, err);
+        });
+      return;
+    }
+
+    // External links: on Tauri we route http(s) anchors through `openUrl`
+    // because target="_blank" doesn't work; on web the anchor handles it.
+    if (!isTauri || !anchor) return;
     const rawHref = anchor.getAttribute('href');
     if (!rawHref || !/^https?:\/\//i.test(rawHref)) return;
     e.preventDefault();
@@ -361,6 +413,8 @@ export function useDictionaryResults({
     onWebSearchClickTauri,
     noProvidersAtAll,
     fontScale: settings.fontScale ?? 1,
+    zoomedImageSrc,
+    closeZoomedImage,
     isSpeaking,
     speakWord,
   };
@@ -455,8 +509,11 @@ export const DictionaryResultsBody: React.FC<DictionaryResultsBodyProps> = ({
   onWebSearchClickTauri,
   noProvidersAtAll,
   fontScale,
+  zoomedImageSrc,
+  closeZoomedImage,
 }) => {
   const _ = useTranslation();
+  const safeAreaInsets = useThemeStore((s) => s.safeAreaInsets);
 
   // `first:pt-2` keeps the leading section's tighter top padding whichever of
   // the two comes first.
@@ -585,6 +642,15 @@ export const DictionaryResultsBody: React.FC<DictionaryResultsBodyProps> = ({
           </>
         )}
       </div>
+      {zoomedImageSrc && (
+        <ModalPortal showOverlay={false}>
+          <ImageViewer
+            gridInsets={safeAreaInsets ?? ZERO_INSETS}
+            src={zoomedImageSrc}
+            onClose={closeZoomedImage}
+          />
+        </ModalPortal>
+      )}
     </div>
   );
 };

--- a/apps/readest-app/src/app/reader/components/annotator/DictionaryResultsView.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/DictionaryResultsView.tsx
@@ -224,7 +224,13 @@ export function useDictionaryResults({
   }, [cards, manuallyToggled]);
 
   const [zoomedImageSrc, setZoomedImageSrc] = useState<string | null>(null);
-  const closeZoomedImage = useCallback(() => setZoomedImageSrc(null), []);
+  // Reading the image out of the entry is async, so a second tap (or a close)
+  // while the first is still decoding must win. Only the newest request paints.
+  const zoomRequestRef = useRef(0);
+  const closeZoomedImage = useCallback(() => {
+    zoomRequestRef.current += 1;
+    setZoomedImageSrc(null);
+  }, []);
 
   // Click delegation inside provider-rendered DOM. MDict entries render in a
   // shadow root, where `e.target` is retargeted to the host — only the composed
@@ -250,8 +256,11 @@ export function useDictionaryResults({
     const imageSrc = anchor ? null : fullResolutionSrc(image);
     if (imageSrc) {
       e.preventDefault();
+      const request = ++zoomRequestRef.current;
       void convertBlobUrlToDataUrl(imageSrc)
-        .then(setZoomedImageSrc)
+        .then((src) => {
+          if (zoomRequestRef.current === request) setZoomedImageSrc(src);
+        })
         .catch((err) => {
           console.warn('Failed to load dictionary image', imageSrc, err);
         });

--- a/apps/readest-app/src/services/dictionaries/dictionaryService.ts
+++ b/apps/readest-app/src/services/dictionaries/dictionaryService.ts
@@ -352,6 +352,30 @@ async function importStarDictBundle(
   };
 }
 
+const XML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  apos: "'",
+  gt: '>',
+  lt: '<',
+  quot: '"',
+};
+
+/**
+ * Unescape an MDX header attribute value. The header is XML, so a dictionary
+ * whose title contains an apostrophe ships it as
+ * `Title="Oxford Advanced Learner&apos;s Dictionary 9th edition"`, and the raw
+ * attribute text would be shown verbatim as the dictionary's name (#6018).
+ */
+const decodeXmlEntities = (value: string) =>
+  value.replace(
+    /&(?:#([0-9]+)|#[xX]([0-9a-fA-F]+)|([a-z]+));/g,
+    (entity: string, dec?: string, hex?: string, named?: string) => {
+      if (named) return XML_ENTITIES[named] ?? entity;
+      const code = dec ? Number(dec) : parseInt(hex!, 16);
+      return code <= 0x10ffff ? String.fromCodePoint(code) : entity;
+    },
+  );
+
 /**
  * Read just the XML header from an MDX/MDD file and pull out the fields we
  * need at import time (Title, Encoding, Encrypted bitmap). Avoids triggering
@@ -383,7 +407,7 @@ async function readMdxHeader(file: File): Promise<{
   const xml = new TextDecoder('utf-16le').decode(xmlBuf).replace(/ +$/, '');
   const attrs: Record<string, string> = {};
   for (const m of xml.matchAll(/(\w+)="((?:.|\r|\n)*?)"/g)) {
-    attrs[m[1]!] = m[2]!;
+    attrs[m[1]!] = decodeXmlEntities(m[2]!);
   }
   let encrypt = 0;
   const encVal = attrs['Encrypted'];

--- a/apps/readest-app/src/services/dictionaries/providers/mdictProvider.ts
+++ b/apps/readest-app/src/services/dictionaries/providers/mdictProvider.ts
@@ -17,6 +17,7 @@
  * `meta.encrypt`) and surfaces as `unsupported`.
  */
 import { eventDispatcher } from '@/utils/event';
+import { SILENCE_DATA } from '@/services/tts/TTSData';
 import { stubTranslation as _ } from '@/utils/misc';
 import { getDictStyles } from '@/utils/style';
 import type { DictionaryProvider, ImportedDictionary } from '../types';
@@ -126,6 +127,10 @@ async function resolveImageResources(
  *   the same dictionary. Click forwards to `ctx.onNavigate(word)`, which the
  *   shell turns into a re-lookup. URL-encoded targets (e.g. `entry://word%20here`)
  *   are decoded before forwarding.
+ * - `entry://#anchor` (and a bare `#anchor`)  — jump to a section of the entry
+ *   that is already rendered, which is how the part-of-speech switcher of
+ *   Oxford-style dictionaries is built. Click scrolls to the target inside the
+ *   card's shadow root; see {@link scrollToEntryFragment}.
  *
  * Other schemes (`http(s)://`, `file://`, etc.) bubble up and are handled by
  * the surrounding shell's container click delegation.
@@ -234,6 +239,57 @@ async function resolveCssUrls(
 const V0R_PLAY_RX = /v0r\.v\s*\(\s*this\s*,\s*['"]([^'"]+)['"]\s*\)/i;
 const AUDIO_EXTS = ['.mp3', '.m4a', '.aac', '.ogg', '.opus', '.wav'] as const;
 
+// Audio bytes come out of the MDD with no MIME type, and a media element given
+// a typeless blob URL refuses to decode it ("Format error") on WebKit, so the
+// type has to be recovered from the resource path — the same constraint EPUB
+// Media Overlays audio hits (see MediaOverlayClient).
+const AUDIO_MIME_TYPES: Record<string, string> = {
+  mp3: 'audio/mpeg',
+  mp4: 'audio/mp4',
+  m4a: 'audio/mp4',
+  aac: 'audio/aac',
+  ogg: 'audio/ogg',
+  oga: 'audio/ogg',
+  opus: 'audio/ogg',
+  wav: 'audio/wav',
+  flac: 'audio/flac',
+  webm: 'audio/webm',
+};
+
+const audioBlobFor = (path: string, data: Uint8Array<ArrayBuffer>): Blob =>
+  new Blob([data], {
+    type: AUDIO_MIME_TYPES[path.split('.').pop()?.toLowerCase() ?? ''] ?? 'audio/mpeg',
+  });
+
+// One element for every dictionary pronunciation, module-scoped so the unlock
+// outlives the card that triggered it. WebKit only lets a media element start
+// from inside a user gesture, and reading the bytes out of the MDD is async: by
+// the time they arrive the gesture window has closed and a freshly constructed
+// `Audio` is rejected by the autoplay policy (#6018). Starting this element on
+// a silent source *synchronously* in the click handler unlocks it; swapping
+// `src` afterwards keeps playing on the already-unlocked element.
+let dictAudio: HTMLAudioElement | null = null;
+
+const primeDictAudio = (): HTMLAudioElement => {
+  if (!dictAudio) {
+    dictAudio = document.createElement('audio');
+    dictAudio.preload = 'auto';
+  }
+  dictAudio.src = SILENCE_DATA;
+  // jsdom's play() returns undefined; in browsers the promise rejects when the
+  // src swap below aborts this load, which must not surface as an unhandled
+  // rejection.
+  (dictAudio.play() as Promise<void> | undefined)?.catch(() => {});
+  return dictAudio;
+};
+
+const playDictAudio = (audio: HTMLAudioElement, url: string, label: string): void => {
+  audio.src = url;
+  (audio.play() as Promise<void> | undefined)?.catch((err) => {
+    console.warn('Dictionary audio playback failed', label, err);
+  });
+};
+
 async function wireMdictAudioOnclick(
   container: HTMLElement,
   mdds: MDDInstance[],
@@ -265,6 +321,7 @@ async function wireMdictAudioOnclick(
     el.addEventListener('click', async (e) => {
       e.preventDefault();
       e.stopPropagation();
+      const audio = primeDictAudio();
 
       let url = el.getAttribute('data-mdd-audio');
       if (!url) {
@@ -288,8 +345,7 @@ async function wireMdictAudioOnclick(
                 console.log(
                   `[MDD-AUDIO] HIT path="${path}" mdd[${i}] ${dt}ms bytes=${located.data.byteLength}`,
                 );
-                const blob = new Blob([new Uint8Array(located.data)]);
-                url = URL.createObjectURL(blob);
+                url = URL.createObjectURL(audioBlobFor(path, new Uint8Array(located.data)));
                 trackedUrls.push(url);
                 el.setAttribute('data-mdd-audio', url);
                 break outer;
@@ -311,13 +367,39 @@ async function wireMdictAudioOnclick(
         console.log(`[MDD-AUDIO] cache hit key=${key}`);
       }
       if (!url) return;
-      const audio = new Audio(url);
-      audio.play().catch((err) => {
-        console.warn('[MDD-AUDIO] playback failed for key', key, err);
-      });
+      playDictAudio(audio, url, key);
     });
   }
 }
+
+const safeDecode = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+/**
+ * Jump to a fragment target inside the entry that is already rendered. MDict
+ * writes in-entry links as `entry://#anchor` (or a bare `#anchor`), which the
+ * part-of-speech switcher of Oxford-style dictionaries uses (#6018). The browser
+ * can't perform this jump itself: the body lives in a shadow root, which
+ * document fragment navigation never enters.
+ */
+const scrollToEntryFragment = (root: ParentNode, frag: string): void => {
+  let target: Element | null = null;
+  try {
+    target = root.querySelector(`#${CSS.escape(frag)}`);
+  } catch {
+    target = null;
+  }
+  // MDX bodies predate `id` and commonly mark sections with `<a name="...">`.
+  target ??=
+    Array.from(root.querySelectorAll('a[name]')).find((a) => a.getAttribute('name') === frag) ??
+    null;
+  target?.scrollIntoView({ block: 'start' });
+};
 
 function wireMdxAnchors(
   container: HTMLElement,
@@ -353,14 +435,14 @@ function wireMdxAnchors(
           return;
         }
 
+        const audio = primeDictAudio();
         let url = anchor.getAttribute('data-mdd-resolved');
         if (!url) {
           for (const mdd of mdds) {
             try {
               const located = await mdd.locateBytes(path);
               if (located.data) {
-                const blob = new Blob([new Uint8Array(located.data)]);
-                url = URL.createObjectURL(blob);
+                url = URL.createObjectURL(audioBlobFor(path, new Uint8Array(located.data)));
                 trackedUrls.push(url);
                 anchor.setAttribute('data-mdd-resolved', url);
                 break;
@@ -371,24 +453,33 @@ function wireMdxAnchors(
           }
         }
         if (!url) return;
-        const audio = new Audio(url);
-        audio.play().catch((err) => {
-          console.warn('Sound playback failed', path, err);
-        });
+        playDictAudio(audio, url, path);
       });
       continue;
     }
 
-    if (ENTRY_HREF_RX.test(raw)) {
-      if (!onNavigate) continue;
-      const rawTarget = raw.replace(ENTRY_HREF_RX, '');
-      let target: string;
-      try {
-        target = decodeURIComponent(rawTarget).trim();
-      } catch {
-        target = rawTarget.trim();
+    if (ENTRY_HREF_RX.test(raw) || raw.startsWith('#')) {
+      const rest = raw.startsWith('#') ? raw : raw.replace(ENTRY_HREF_RX, '');
+      const hashAt = rest.indexOf('#');
+      const target = safeDecode(hashAt < 0 ? rest : rest.slice(0, hashAt)).trim();
+      const frag = hashAt < 0 ? '' : safeDecode(rest.slice(hashAt + 1)).trim();
+
+      // No headword before the `#`: the target is a section of the entry that
+      // is already rendered, so jump to it instead of looking the fragment up
+      // as a headword.
+      if (!target) {
+        if (!frag) continue;
+        anchor.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          // Wiring runs before the body is moved into the card's shadow root,
+          // so resolve the search root from the anchor at click time.
+          scrollToEntryFragment((anchor.getRootNode() as ParentNode) ?? container, frag);
+        });
+        continue;
       }
-      if (!target) continue;
+
+      if (!onNavigate) continue;
       anchor.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/apps/readest-app/src/services/dictionaries/providers/mdictProvider.ts
+++ b/apps/readest-app/src/services/dictionaries/providers/mdictProvider.ts
@@ -270,6 +270,12 @@ const audioBlobFor = (path: string, data: Uint8Array<ArrayBuffer>): Blob =>
 // `src` afterwards keeps playing on the already-unlocked element.
 let dictAudio: HTMLAudioElement | null = null;
 
+// Resolved audio blob URLs, keyed by the element that plays them. The MDX body
+// is untrusted markup, so a URL parked in one of its attributes and read back
+// out is attacker-supplied text by the time it reaches a media element; keeping
+// the cache off the DOM keeps the value ours.
+const resolvedAudioUrls = new WeakMap<Element, string>();
+
 const primeDictAudio = (): HTMLAudioElement => {
   if (!dictAudio) {
     dictAudio = document.createElement('audio');
@@ -323,7 +329,7 @@ async function wireMdictAudioOnclick(
       e.stopPropagation();
       const audio = primeDictAudio();
 
-      let url = el.getAttribute('data-mdd-audio');
+      let url = resolvedAudioUrls.get(el);
       if (!url) {
         // Candidate paths: vocabulary.com's MDD stores audio as
         // `<KEY>.mp3` (with `/` -> `\` normalisation handled inside
@@ -347,7 +353,7 @@ async function wireMdictAudioOnclick(
                 );
                 url = URL.createObjectURL(audioBlobFor(path, new Uint8Array(located.data)));
                 trackedUrls.push(url);
-                el.setAttribute('data-mdd-audio', url);
+                resolvedAudioUrls.set(el, url);
                 break outer;
               } else {
                 console.log(`[MDD-AUDIO] miss path="${path}" mdd[${i}] ${dt}ms`);
@@ -436,7 +442,7 @@ function wireMdxAnchors(
         }
 
         const audio = primeDictAudio();
-        let url = anchor.getAttribute('data-mdd-resolved');
+        let url = resolvedAudioUrls.get(anchor);
         if (!url) {
           for (const mdd of mdds) {
             try {
@@ -444,7 +450,7 @@ function wireMdxAnchors(
               if (located.data) {
                 url = URL.createObjectURL(audioBlobFor(path, new Uint8Array(located.data)));
                 trackedUrls.push(url);
-                anchor.setAttribute('data-mdd-resolved', url);
+                resolvedAudioUrls.set(anchor, url);
                 break;
               }
             } catch (err) {


### PR DESCRIPTION
Fixes #6018.

Three defects reported against MDD dictionaries, all reproduced and fixed with the reporter's Oxford Advanced Learner's Dictionary 9th edition.

### Pronunciation never played

Audio pulled out of an MDD is raw bytes, and the blob URL was built with no MIME type, which WebKit refuses to decode. Reading those bytes is also async, so by the time playback started the user gesture window had closed and the autoplay policy rejected the freshly constructed `Audio` element. Both rules are WebKit-only, which is why this reproduced on the reporter's iOS build.

A module-scoped element is now primed on a silent source synchronously inside the click handler and has its `src` swapped once the bytes arrive, and the blob carries the type recovered from the resource path. This is the same pattern EPUB Media Overlays audio already uses.

### Tapping a part-of-speech label did nothing

Oxford-style entries link their own sections as `entry://#<anchor>`. That was forwarded as a headword lookup, so tapping `verb` searched for the 32-hex anchor id. A fragment with no headword before the `#` now scrolls to the target inside the card's shadow root, which document fragment navigation never enters. `<a name="...">` targets are matched too, since MDX bodies predate `id`.

### Entry images could not be enlarged

Tapping an illustration now opens the existing `ImageViewer`. Two details: the delegation walks `composedPath()` because a shadow root retargets `e.target` to the host, and it picks the hidden full-resolution twin that MDX bodies ship beside the laid-out thumbnail (OALD9's `<div class="ox-enlarge">` holds a 720x540 copy next to a 100px `thumb`). Hrefless anchors such as `<a class="topic no-href">` are markup, not navigation, so they no longer swallow the tap.

### Dictionary name showed an HTML entity

The source label read `Oxford Advanced Learner&apos;s Dictionary 9th edition`. The MDX header is XML, and `readMdxHeader` lifted attribute values straight out of a regex with no entity decoding, so the escaped apostrophe was stored as the dictionary's name at import time. Already-imported dictionaries keep the stored name until re-imported; Settings has a rename.

## Verification

`pnpm test`, `pnpm lint`, `pnpm format:check` all pass. New unit tests cover the typed audio blob, the fragment jump, the full-resolution twin, and the header decoding.

Verified on a physical Android device with the reporter's dictionary (word `house`):

- audio: blob `type: "audio/mpeg"`, `canplay` to `playing` to `ended`, 1.26 s
- POS: tapping `verb` moved the card `scrollTop` 0 to 3405 of 4145 and left the sheet header on `house`
- image: the zoomed `<img>` reports `naturalWidth 720`, laid out 393x295

The audio fix targets two WebKit-only rules, so Android proves the mechanism but not the reporter's exact iOS failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added full-screen viewing for images in dictionary entries, including higher-resolution versions when available.
  - Improved navigation for links to sections within the current dictionary entry.
  - Enhanced dictionary audio playback with broader format support and improved browser compatibility.

- **Bug Fixes**
  - Dictionary titles now correctly display decoded special characters from MDX files.
  - Improved handling of encoded dictionary links and image links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->