### PR TITLE
feat(settings): add a Gamepad Support toggle

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2538,5 +2538,7 @@
   "As {{alias}}": "باسم {{alias}}",
   "Keep this screen on so nearby devices can find you.": "أبقِ هذه الشاشة قيد التشغيل حتى تتمكّن الأجهزة القريبة من العثور عليك.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "تختفي الأجهزة من القائمة عند إيقاف تشغيل شاشتها؛ أبقِ الشاشة قيد التشغيل لتبقى مرئيًا.",
-  "{{name}}'s Readest": "Readest الخاص بـ {{name}}"
+  "{{name}}'s Readest": "Readest الخاص بـ {{name}}",
+  "Gamepad Support": "دعم ذراع الألعاب",
+  "Navigate with a connected controller": "التنقل باستخدام ذراع ألعاب متصل"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "{{alias}} হিসেবে",
   "Keep this screen on so nearby devices can find you.": "কাছাকাছি ডিভাইসগুলি যাতে আপনাকে খুঁজে পায় সেজন্য এই স্ক্রিনটি চালু রাখুন।",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "স্ক্রিন বন্ধ হলে ডিভাইসগুলি তালিকা থেকে অদৃশ্য হয়ে যায়; দৃশ্যমান থাকতে স্ক্রিন চালু রাখুন।",
-  "{{name}}'s Readest": "{{name}}-এর Readest"
+  "{{name}}'s Readest": "{{name}}-এর Readest",
+  "Gamepad Support": "গেমপ্যাড সমর্থন",
+  "Navigate with a connected controller": "সংযুক্ত কন্ট্রোলার দিয়ে নেভিগেট করুন"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2238,5 +2238,7 @@
   "As {{alias}}": "{{alias}} ཞེས་སུ།",
   "Keep this screen on so nearby devices can find you.": "ཉེ་འགྲམ་གྱི་སྒྲིག་ཆས་ཀྱིས་ཁྱེད་རང་རྙེད་ཐུབ་པའི་ཆེད་དུ་བརྙན་ཡོལ་འདི་གསལ་བར་བཞག",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "སྒྲིག་ཆས་ཀྱི་བརྙན་ཡོལ་ཁ་བརྒྱབ་སྐབས་རེའུ་མིག་ནས་མི་སྣང་བར་འགྱུར། མཐོང་རྒྱུ་ཡོད་པར་གནས་ཆེད་བརྙན་ཡོལ་གསལ་བར་བཞག",
-  "{{name}}'s Readest": "{{name}}ཡི་ Readest"
+  "{{name}}'s Readest": "{{name}}ཡི་ Readest",
+  "Gamepad Support": "རྩེད་མོའི་ཚོད་འཛིན་ཆས་རྒྱབ་སྐྱོར།",
+  "Navigate with a connected controller": "སྦྲེལ་ཟིན་པའི་ཚོད་འཛིན་ཆས་ཐོག་ནས་གནས་སྤོ་བྱེད་པ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "Als {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Lassen Sie diesen Bildschirm eingeschaltet, damit Geräte in der Nähe Sie finden können.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Geräte verschwinden aus der Liste, wenn ihr Bildschirm ausgeschaltet wird; lassen Sie den Bildschirm eingeschaltet, um sichtbar zu bleiben.",
-  "{{name}}'s Readest": "Readest von {{name}}"
+  "{{name}}'s Readest": "Readest von {{name}}",
+  "Gamepad Support": "Gamepad-Unterstützung",
+  "Navigate with a connected controller": "Mit einem verbundenen Controller navigieren"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "Ως {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Διατηρήστε αυτήν την οθόνη ανοιχτή ώστε οι κοντινές συσκευές να μπορούν να σας βρουν.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Οι συσκευές εξαφανίζονται από τη λίστα όταν σβήσει η οθόνη τους· κρατήστε την οθόνη ανοιχτή για να παραμένετε ορατοί.",
-  "{{name}}'s Readest": "Το Readest του {{name}}"
+  "{{name}}'s Readest": "Το Readest του {{name}}",
+  "Gamepad Support": "Υποστήριξη χειριστηρίου",
+  "Navigate with a connected controller": "Πλοήγηση με συνδεδεμένο χειριστήριο"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2358,5 +2358,7 @@
   "As {{alias}}": "Como {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Mantén esta pantalla encendida para que los dispositivos cercanos puedan encontrarte.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Los dispositivos desaparecen de la lista cuando se apaga su pantalla; mantén la pantalla encendida para seguir visible.",
-  "{{name}}'s Readest": "Readest de {{name}}"
+  "{{name}}'s Readest": "Readest de {{name}}",
+  "Gamepad Support": "Compatibilidad con mando",
+  "Navigate with a connected controller": "Navegar con un mando conectado"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "به‌عنوان {{alias}}",
   "Keep this screen on so nearby devices can find you.": "این صفحه را روشن نگه دارید تا دستگاه‌های نزدیک بتوانند شما را پیدا کنند.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "وقتی صفحهٔ دستگاه‌ها خاموش می‌شود، از فهرست ناپدید می‌شوند؛ برای دیده‌شدن، صفحه را روشن نگه دارید.",
-  "{{name}}'s Readest": "Readestِ {{name}}"
+  "{{name}}'s Readest": "Readestِ {{name}}",
+  "Gamepad Support": "پشتیبانی از دسته بازی",
+  "Navigate with a connected controller": "پیمایش با دسته بازی متصل"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2358,5 +2358,7 @@
   "As {{alias}}": "En tant que {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Gardez cet écran allumé pour que les appareils à proximité puissent vous trouver.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Les appareils disparaissent de la liste lorsque leur écran s'éteint ; gardez l'écran allumé pour rester visible.",
-  "{{name}}'s Readest": "Readest de {{name}}"
+  "{{name}}'s Readest": "Readest de {{name}}",
+  "Gamepad Support": "Prise en charge des manettes",
+  "Navigate with a connected controller": "Naviguer avec une manette connectée"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2358,5 +2358,7 @@
   "As {{alias}}": "בתור {{alias}}",
   "Keep this screen on so nearby devices can find you.": "השאירו מסך זה דולק כדי שמכשירים בקרבת מקום יוכלו למצוא אתכם.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "מכשירים נעלמים מהרשימה כשהמסך שלהם כבה; השאירו את המסך דולק כדי להישאר גלויים.",
-  "{{name}}'s Readest": "Readest של {{name}}"
+  "{{name}}'s Readest": "Readest של {{name}}",
+  "Gamepad Support": "תמיכה בבקר משחק",
+  "Navigate with a connected controller": "ניווט באמצעות בקר מחובר"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "{{alias}} के रूप में",
   "Keep this screen on so nearby devices can find you.": "आस-पास के डिवाइस आपको ढूंढ सकें, इसके लिए इस स्क्रीन को चालू रखें।",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "जब किसी डिवाइस की स्क्रीन बंद हो जाती है तो वह सूची से गायब हो जाता है; दृश्यमान बने रहने के लिए स्क्रीन चालू रखें।",
-  "{{name}}'s Readest": "{{name}} का Readest"
+  "{{name}}'s Readest": "{{name}} का Readest",
+  "Gamepad Support": "गेमपैड समर्थन",
+  "Navigate with a connected controller": "कनेक्टेड कंट्रोलर से नेविगेट करें"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "Mint {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Tartsa bekapcsolva ezt a képernyőt, hogy a közeli eszközök megtalálhassák Önt.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Az eszközök eltűnnek a listáról, amikor a képernyőjük kikapcsol; tartsa bekapcsolva a képernyőt, hogy látható maradjon.",
-  "{{name}}'s Readest": "{{name}} Readestje"
+  "{{name}}'s Readest": "{{name}} Readestje",
+  "Gamepad Support": "Kontroller támogatása",
+  "Navigate with a connected controller": "Navigálás csatlakoztatott kontrollerrel"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2238,5 +2238,7 @@
   "As {{alias}}": "Sebagai {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Biarkan layar ini tetap menyala agar perangkat di sekitar dapat menemukan Anda.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Perangkat menghilang dari daftar saat layarnya mati; biarkan layar menyala agar tetap terlihat.",
-  "{{name}}'s Readest": "Readest {{name}}"
+  "{{name}}'s Readest": "Readest {{name}}",
+  "Gamepad Support": "Dukungan Gamepad",
+  "Navigate with a connected controller": "Navigasi dengan pengontrol yang terhubung"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2358,5 +2358,7 @@
   "As {{alias}}": "Come {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Tieni acceso questo schermo affinché i dispositivi nelle vicinanze possano trovarti.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "I dispositivi scompaiono dall'elenco quando il loro schermo si spegne; tieni acceso lo schermo per restare visibile.",
-  "{{name}}'s Readest": "Readest di {{name}}"
+  "{{name}}'s Readest": "Readest di {{name}}",
+  "Gamepad Support": "Supporto gamepad",
+  "Navigate with a connected controller": "Naviga con un controller collegato"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2238,5 +2238,7 @@
   "As {{alias}}": "{{alias}} として",
   "Keep this screen on so nearby devices can find you.": "近くのデバイスから見つけてもらえるよう、この画面をオンのままにしてください。",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "デバイスは画面がオフになるとリストから消えます。表示され続けるには画面をオンのままにしてください。",
-  "{{name}}'s Readest": "{{name}}のReadest"
+  "{{name}}'s Readest": "{{name}}のReadest",
+  "Gamepad Support": "ゲームパッド対応",
+  "Navigate with a connected controller": "接続したコントローラーで操作する"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "როგორც {{alias}}",
   "Keep this screen on so nearby devices can find you.": "დატოვეთ ეს ეკრანი ჩართული, რომ ახლომდებარე მოწყობილობებმა შეძლონ თქვენი პოვნა.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "მოწყობილობები ქრება სიიდან, როცა მათი ეკრანი გამოირთვება; დატოვეთ ეკრანი ჩართული, რომ ხილვადი დარჩეთ.",
-  "{{name}}'s Readest": "{{name}}-ის Readest"
+  "{{name}}'s Readest": "{{name}}-ის Readest",
+  "Gamepad Support": "გეიმპედის მხარდაჭერა",
+  "Navigate with a connected controller": "ნავიგაცია მიერთებული კონტროლერით"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2238,5 +2238,7 @@
   "As {{alias}}": "{{alias}}(으)로 표시",
   "Keep this screen on so nearby devices can find you.": "근처 기기가 나를 찾을 수 있도록 이 화면을 켜 두세요.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "화면이 꺼지면 기기가 목록에서 사라집니다. 계속 표시되려면 화면을 켜 두세요.",
-  "{{name}}'s Readest": "{{name}}의 Readest"
+  "{{name}}'s Readest": "{{name}}의 Readest",
+  "Gamepad Support": "게임패드 지원",
+  "Navigate with a connected controller": "연결된 컨트롤러로 탐색"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2238,5 +2238,7 @@
   "As {{alias}}": "Sebagai {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Biarkan skrin ini menyala supaya peranti berdekatan dapat menemui anda.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Peranti hilang daripada senarai apabila skrinnya dimatikan; biarkan skrin menyala supaya kekal kelihatan.",
-  "{{name}}'s Readest": "Readest {{name}}"
+  "{{name}}'s Readest": "Readest {{name}}",
+  "Gamepad Support": "Sokongan Gamepad",
+  "Navigate with a connected controller": "Navigasi dengan pengawal yang disambungkan"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "Als {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Houd dit scherm aan zodat apparaten in de buurt je kunnen vinden.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Apparaten verdwijnen uit de lijst wanneer hun scherm uitgaat; houd het scherm aan om zichtbaar te blijven.",
-  "{{name}}'s Readest": "Readest van {{name}}"
+  "{{name}}'s Readest": "Readest van {{name}}",
+  "Gamepad Support": "Gamepad-ondersteuning",
+  "Navigate with a connected controller": "Navigeren met een aangesloten controller"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2418,5 +2418,7 @@
   "As {{alias}}": "Jako {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Pozostaw ten ekran włączony, aby pobliskie urządzenia mogły Cię znaleźć.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Urządzenia znikają z listy, gdy ich ekran się wyłącza; pozostaw ekran włączony, aby pozostać widocznym.",
-  "{{name}}'s Readest": "Readest użytkownika {{name}}"
+  "{{name}}'s Readest": "Readest użytkownika {{name}}",
+  "Gamepad Support": "Obsługa gamepada",
+  "Navigate with a connected controller": "Nawigacja podłączonym kontrolerem"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2358,5 +2358,7 @@
   "As {{alias}}": "Como {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Mantenha esta tela ligada para que dispositivos próximos possam encontrar você.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Os dispositivos desaparecem da lista quando a tela é desligada; mantenha a tela ligada para continuar visível.",
-  "{{name}}'s Readest": "Readest de {{name}}"
+  "{{name}}'s Readest": "Readest de {{name}}",
+  "Gamepad Support": "Suporte a gamepad",
+  "Navigate with a connected controller": "Navegar com um controle conectado"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2358,5 +2358,7 @@
   "As {{alias}}": "Como {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Mantenha este ecrã ligado para que os dispositivos próximos o possam encontrar.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Os dispositivos desaparecem da lista quando o ecrã se desliga; mantenha o ecrã ligado para continuar visível.",
-  "{{name}}'s Readest": "Readest de {{name}}"
+  "{{name}}'s Readest": "Readest de {{name}}",
+  "Gamepad Support": "Suporte a gamepad",
+  "Navigate with a connected controller": "Navegar com um controle conectado"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2358,5 +2358,7 @@
   "As {{alias}}": "Ca {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Păstrează acest ecran pornit pentru ca dispozitivele din apropiere să te poată găsi.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Dispozitivele dispar din listă când ecranul lor se stinge; păstrează ecranul pornit ca să rămâi vizibil.",
-  "{{name}}'s Readest": "Readest al lui {{name}}"
+  "{{name}}'s Readest": "Readest al lui {{name}}",
+  "Gamepad Support": "Suport pentru gamepad",
+  "Navigate with a connected controller": "Navigare cu un controler conectat"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2418,5 +2418,7 @@
   "As {{alias}}": "Как {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Оставьте этот экран включённым, чтобы устройства поблизости могли вас найти.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Устройства исчезают из списка, когда их экран выключается; оставьте экран включённым, чтобы оставаться видимым.",
-  "{{name}}'s Readest": "Readest пользователя {{name}}"
+  "{{name}}'s Readest": "Readest пользователя {{name}}",
+  "Gamepad Support": "Поддержка геймпада",
+  "Navigate with a connected controller": "Навигация с помощью подключённого геймпада"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "{{alias}} ලෙස",
   "Keep this screen on so nearby devices can find you.": "අවට උපාංගවලට ඔබව සොයාගත හැකි වන පරිදි මෙම තිරය සක්‍රීයව තබා ගන්න.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "තිරය ක්‍රියාවිරහිත වූ විට උපාංග ලැයිස්තුවෙන් අතුරුදහන් වේ; දෘශ්‍යමානව සිටීමට තිරය සක්‍රීයව තබා ගන්න.",
-  "{{name}}'s Readest": "{{name}} ගේ Readest"
+  "{{name}}'s Readest": "{{name}} ගේ Readest",
+  "Gamepad Support": "ගේම්පෑඩ් සහාය",
+  "Navigate with a connected controller": "සම්බන්ධිත පාලකයක් සමඟ සංචලනය කරන්න"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2418,5 +2418,7 @@
   "As {{alias}}": "Kot {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Naj ta zaslon ostane vklopljen, da vas naprave v bližini lahko najdejo.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Naprave izginejo s seznama, ko se njihov zaslon izklopi; naj bo zaslon vklopljen, da ostanete vidni.",
-  "{{name}}'s Readest": "Readest uporabnika {{name}}"
+  "{{name}}'s Readest": "Readest uporabnika {{name}}",
+  "Gamepad Support": "Podpora za igralni plošček",
+  "Navigate with a connected controller": "Krmarjenje s priključenim krmilnikom"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "Som {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Håll den här skärmen på så att enheter i närheten kan hitta dig.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Enheter försvinner från listan när skärmen stängs av; håll skärmen på för att fortsätta synas.",
-  "{{name}}'s Readest": "{{name}}s Readest"
+  "{{name}}'s Readest": "{{name}}s Readest",
+  "Gamepad Support": "Stöd för handkontroll",
+  "Navigate with a connected controller": "Navigera med en ansluten handkontroll"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "{{alias}} ஆக",
   "Keep this screen on so nearby devices can find you.": "அருகிலுள்ள சாதனங்கள் உங்களைக் கண்டறிய இந்தத் திரையை இயக்கத்தில் வைக்கவும்.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "திரை அணைந்தால் சாதனங்கள் பட்டியலிலிருந்து மறைந்துவிடும்; தெரியும் நிலையில் இருக்க திரையை இயக்கத்தில் வைக்கவும்.",
-  "{{name}}'s Readest": "{{name}} இன் Readest"
+  "{{name}}'s Readest": "{{name}} இன் Readest",
+  "Gamepad Support": "கேம்பேட் ஆதரவு",
+  "Navigate with a connected controller": "இணைக்கப்பட்ட கன்ட்ரோலரைக் கொண்டு வழிசெலுத்தவும்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2238,5 +2238,7 @@
   "As {{alias}}": "ในชื่อ {{alias}}",
   "Keep this screen on so nearby devices can find you.": "เปิดหน้าจอนี้ไว้เพื่อให้อุปกรณ์ใกล้เคียงค้นหาคุณเจอ",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "อุปกรณ์จะหายไปจากรายการเมื่อหน้าจอปิด เปิดหน้าจอไว้เพื่อให้ยังคงมองเห็นได้",
-  "{{name}}'s Readest": "Readest ของ {{name}}"
+  "{{name}}'s Readest": "Readest ของ {{name}}",
+  "Gamepad Support": "รองรับเกมแพด",
+  "Navigate with a connected controller": "นำทางด้วยคอนโทรลเลอร์ที่เชื่อมต่อ"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "{{alias}} olarak",
   "Keep this screen on so nearby devices can find you.": "Yakındaki cihazların sizi bulabilmesi için bu ekranı açık tutun.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Ekranı kapandığında cihazlar listeden kaybolur; görünür kalmak için ekranı açık tutun.",
-  "{{name}}'s Readest": "{{name}} Readest'i"
+  "{{name}}'s Readest": "{{name}} Readest'i",
+  "Gamepad Support": "Oyun Kumandası Desteği",
+  "Navigate with a connected controller": "Bağlı bir kumandayla gezinin"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2418,5 +2418,7 @@
   "As {{alias}}": "Як {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Залиште цей екран увімкненим, щоб пристрої поблизу могли вас знайти.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Пристрої зникають зі списку, коли їхній екран вимикається; залиште екран увімкненим, щоб залишатися видимим.",
-  "{{name}}'s Readest": "Readest користувача {{name}}"
+  "{{name}}'s Readest": "Readest користувача {{name}}",
+  "Gamepad Support": "Підтримка геймпада",
+  "Navigate with a connected controller": "Навігація за допомогою підключеного геймпада"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2298,5 +2298,7 @@
   "As {{alias}}": "{{alias}} sifatida",
   "Keep this screen on so nearby devices can find you.": "Yaqin atrofdagi qurilmalar sizni topa olishi uchun bu ekranni yoniq qoldiring.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Qurilmalar ekrani o'chganda ro'yxatdan yo'qoladi; ko'rinib turish uchun ekranni yoniq qoldiring.",
-  "{{name}}'s Readest": "{{name}}ning Readest'i"
+  "{{name}}'s Readest": "{{name}}ning Readest'i",
+  "Gamepad Support": "Geympad qoʻllab-quvvatlashi",
+  "Navigate with a connected controller": "Ulangan boshqaruv pulti bilan harakatlanish"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2238,5 +2238,7 @@
   "As {{alias}}": "Với tên {{alias}}",
   "Keep this screen on so nearby devices can find you.": "Giữ màn hình này bật để các thiết bị ở gần có thể tìm thấy bạn.",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Thiết bị sẽ biến mất khỏi danh sách khi màn hình tắt; hãy bật màn hình để luôn hiển thị.",
-  "{{name}}'s Readest": "Readest của {{name}}"
+  "{{name}}'s Readest": "Readest của {{name}}",
+  "Gamepad Support": "Hỗ trợ tay cầm chơi game",
+  "Navigate with a connected controller": "Điều hướng bằng tay cầm đã kết nối"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2238,5 +2238,7 @@
   "As {{alias}}": "以 {{alias}} 的身份",
   "Keep this screen on so nearby devices can find you.": "保持此屏幕点亮，附近设备才能找到你。",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "设备屏幕关闭后会从列表中消失；保持屏幕点亮以持续可见。",
-  "{{name}}'s Readest": "{{name}} 的 Readest"
+  "{{name}}'s Readest": "{{name}} 的 Readest",
+  "Gamepad Support": "手柄支持",
+  "Navigate with a connected controller": "使用已连接的手柄进行导航"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2238,5 +2238,7 @@
   "As {{alias}}": "以 {{alias}} 的身分",
   "Keep this screen on so nearby devices can find you.": "讓此螢幕保持開啟，附近裝置才能找到你。",
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "裝置螢幕關閉後會從清單中消失；讓螢幕保持開啟以持續顯示。",
-  "{{name}}'s Readest": "{{name}} 的 Readest"
+  "{{name}}'s Readest": "{{name}} 的 Readest",
+  "Gamepad Support": "手把支援",
+  "Navigate with a connected controller": "使用已連接的手把進行導覽"
 }

--- a/apps/readest-app/src/__tests__/components/settings/ControlPanelGamepad.test.tsx
+++ b/apps/readest-app/src/__tests__/components/settings/ControlPanelGamepad.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Settings > Behavior > Device > Gamepad Support (issue #5979).
+ *
+ * The reader polls the Web Gamepad API and replays every button as a
+ * synthetic key event. On a Steam Deck that fights Steam Input, which is
+ * already mapping the same physical buttons to keys, so every press lands
+ * twice. There was no way to turn the built-in support off.
+ */
+
+const sysSettings: Record<string, unknown> = { gamepadEnabled: true };
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: { isMobileApp: false } }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    getView: () => null,
+    getViews: () => [],
+    getViewSettings: () => ({ scrolled: false, noContinuousScroll: false }),
+    recreateViewer: vi.fn(),
+  }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({
+    getBookData: () => ({ isFixedLayout: false, book: { format: 'EPUB' } }),
+  }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: { globalViewSettings: {}, ...sysSettings } }),
+}));
+
+vi.mock('@/hooks/useResetSettings', () => ({
+  useResetViewSettings: () => vi.fn(),
+}));
+
+vi.mock('@/hooks/useEinkMode', () => ({
+  useEinkMode: () => ({ applyEinkMode: vi.fn() }),
+}));
+
+const saveSysSettings = vi.fn();
+vi.mock('@/helpers/settings', () => ({
+  saveViewSettings: vi.fn(),
+  saveSysSettings: (...args: unknown[]) => saveSysSettings(...args),
+}));
+
+vi.mock('@/services/environment', () => ({
+  isTauriAppPlatform: () => false,
+}));
+
+vi.mock('@/utils/share', () => ({
+  canShareText: () => true,
+}));
+
+vi.mock('@/utils/telemetry', () => ({
+  optInTelemetry: vi.fn(),
+  optOutTelemetry: vi.fn(),
+}));
+
+// Unrelated to the Device section and pulls in the device-control store.
+vi.mock('@/components/settings/PageTurnerSettings', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/utils/style', () => ({ getStyles: () => '' }));
+vi.mock('@/utils/config', () => ({ getMaxInlineSize: () => 720 }));
+vi.mock('@/app/reader/hooks/useCapturedTurn', () => ({
+  applyPageTurnAttributes: vi.fn(),
+}));
+
+import ControlPanel from '@/components/settings/ControlPanel';
+
+const gamepadSwitch = () =>
+  screen
+    .getByText('Gamepad Support')
+    .closest('[data-setting-id="settings.control.gamepadEnabled"]')
+    ?.querySelector('input') as HTMLInputElement | null;
+
+afterEach(() => {
+  cleanup();
+  saveSysSettings.mockClear();
+  sysSettings['gamepadEnabled'] = true;
+});
+
+describe('Settings > Behavior > Device > Gamepad Support', () => {
+  it('reflects the saved gamepad preference', () => {
+    sysSettings['gamepadEnabled'] = false;
+    render(<ControlPanel bookKey='test' onRegisterReset={() => {}} />);
+
+    expect(gamepadSwitch()?.checked).toBe(false);
+  });
+
+  it('persists the gamepad preference when toggled off', () => {
+    render(<ControlPanel bookKey='test' onRegisterReset={() => {}} />);
+    expect(gamepadSwitch()?.checked).toBe(true);
+
+    fireEvent.click(gamepadSwitch()!);
+
+    expect(saveSysSettings).toHaveBeenCalledWith({}, 'gamepadEnabled', false);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/ReaderContent.tsx
+++ b/apps/readest-app/src/app/reader/components/ReaderContent.tsx
@@ -89,11 +89,14 @@ const ReaderContent: React.FC<{ ids?: string; settings: SystemSettings }> = ({ i
 
   useBookShortcuts({ sideBarBookKey, bookKeys });
   const isAndroidApp = appService?.isAndroidApp === true;
-  const androidGamepadConnected = useAndroidGamepadConnection(isAndroidApp);
+  // Settings > Behavior > Device > Gamepad Support. Off when the device's own
+  // remapper already binds the controller to keys (issue #5979).
+  const gamepadEnabled = useSettingsStore((state) => state.settings.gamepadEnabled) !== false;
+  const androidGamepadConnected = useAndroidGamepadConnection(isAndroidApp && gamepadEnabled);
   // Android's native bridge gates the Web Gamepad API so Chromium polls only
   // while a controller exists. Other platforms retain the existing behavior.
   useGamepad({
-    enabled: appService !== null && (!isAndroidApp || androidGamepadConnected),
+    enabled: appService !== null && gamepadEnabled && (!isAndroidApp || androidGamepadConnected),
   });
 
   useEffect(() => {

--- a/apps/readest-app/src/components/settings/ControlPanel.tsx
+++ b/apps/readest-app/src/components/settings/ControlPanel.tsx
@@ -70,6 +70,7 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
   );
   const [screenWakeLock, setScreenWakeLock] = useState(settings.screenWakeLock);
   const [autohideCursor, setAutohideCursor] = useState(settings.autohideCursor);
+  const [gamepadEnabled, setGamepadEnabled] = useState(settings.gamepadEnabled);
   const [allowScript, setAllowScript] = useState(viewSettings.allowScript);
   const [isAutoCheckUpdates, setIsAutoCheckUpdates] = useState(settings.autoCheckUpdates);
   const [isNightlyChannel, setIsNightlyChannel] = useState(settings.updateChannel === 'nightly');
@@ -275,6 +276,12 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
     getViews().forEach((view) => view?.toggleAttribute('autohide-cursor', autohideCursor));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autohideCursor]);
+
+  useEffect(() => {
+    if (gamepadEnabled === settings.gamepadEnabled) return;
+    saveSysSettings(envConfig, 'gamepadEnabled', gamepadEnabled);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gamepadEnabled]);
 
   useEffect(() => {
     if (viewSettings.allowScript === allowScript) return;
@@ -549,6 +556,13 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
             data-setting-id='settings.control.autohideCursor'
           />
         )}
+        <SettingsSwitchRow
+          label={_('Gamepad Support')}
+          description={_('Navigate with a connected controller')}
+          checked={gamepadEnabled}
+          onChange={() => setGamepadEnabled(!gamepadEnabled)}
+          data-setting-id='settings.control.gamepadEnabled'
+        />
       </BoxedList>
 
       {appService?.hasUpdater && (

--- a/apps/readest-app/src/services/commandRegistry.ts
+++ b/apps/readest-app/src/services/commandRegistry.ts
@@ -525,6 +525,12 @@ const controlPanelItems = [
     section: 'Device',
   },
   {
+    id: 'settings.control.gamepadEnabled',
+    labelKey: _('Gamepad Support'),
+    keywords: ['gamepad', 'controller', 'joystick', 'steam', 'deck', 'joypad'],
+    section: 'Device',
+  },
+  {
     id: 'settings.control.allowJavascript',
     labelKey: _('Allow JavaScript'),
     keywords: ['javascript', 'js', 'script', 'security', 'allow'],

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -204,6 +204,7 @@ export const DEFAULT_SYSTEM_SETTINGS: Partial<SystemSettings> = {
       refresh: null,
     },
   },
+  gamepadEnabled: true,
   openLastBooks: false,
   lastOpenBooks: [],
   autoImportBooksOnOpen: false,

--- a/apps/readest-app/src/types/settings.ts
+++ b/apps/readest-app/src/types/settings.ts
@@ -431,6 +431,13 @@ export interface SystemSettings {
   autoScreenBrightness: boolean;
   swipeBrightnessGesture: boolean;
   hardwarePageTurner: HardwarePageTurnerSettings;
+  /**
+   * Replay a connected controller's buttons and sticks as key events in the
+   * reader. Off is a real need on handhelds whose own remapper (Steam Input on
+   * the Steam Deck) already binds those buttons to keys, so every press would
+   * otherwise land twice (issue #5979).
+   */
+  gamepadEnabled: boolean;
   alwaysShowStatusBar: boolean;
   openLastBooks: boolean;
   lastOpenBooks: string[];


### PR DESCRIPTION
Closes #5979.

## The problem

Readest replays a connected controller's buttons and sticks as key events in the reader, and there was no way to turn that off. On a handheld whose own remapper already binds the same buttons to keys, every press lands twice: the remapper's key plus Readest's own.

The reporter hit this with the Flatpak on a Steam Deck, where Steam Input is already mapping the D-pad and sticks, so one button press turns two pages. They also noticed the SteamOS overlay picking up double inputs while Readest is open.

## The change

Settings > Behavior > Device > **Gamepad Support**, on by default so nothing changes for anyone who is not affected.

| | |
|---|---|
| `types/settings.ts` | new `gamepadEnabled: boolean` on `SystemSettings` |
| `services/constants.ts` | `gamepadEnabled: true` in `DEFAULT_SYSTEM_SETTINGS` |
| `settings/ControlPanel.tsx` | the switch row, last item of the Device list |
| `services/commandRegistry.ts` | registry entry so settings search finds it |
| `reader/components/ReaderContent.tsx` | gates `useGamepad` and `useAndroidGamepadConnection` |

No migration is needed: `loadSettings` spreads `DEFAULT_SYSTEM_SETTINGS` under the saved settings, so existing profiles read `true`.

Turning it off takes effect immediately. `saveSysSettings` writes through the store, the primitive selector in `ReaderContent` re-evaluates, and `useGamepad`'s cleanup cancels the animation frame loop and removes the `gamepadconnected` / `gamepaddisconnected` listeners. Nothing has to be reloaded.

## Scope

Only the toggle, which is what the issue said would cover most cases. Remapping is left out: once Readest stops competing for those buttons, Steam Input and the desktop remappers already own that job.

## Verification

- New unit test `ControlPanelGamepad.test.tsx` (written first, confirmed failing): the row reflects the saved preference, and toggling it persists `gamepadEnabled`. `useGamepad`'s existing test already covers listeners and polling being torn down when `enabled` flips false.
- `pnpm test` 888 files / 10679 tests passed, 16 skipped.
- `pnpm lint` (tsc + biome) and `pnpm format:check` clean.
- In the browser, with a synthetic `gamepadconnected` event against a spy: setting off, no handler runs; toggled on from the reader's own settings dialog with no reload, the handler runs; toggled off again, silent. The off state survives a page reload, and searching settings for "gamepad" returns the row.
- All 34 locales translated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Gamepad Support setting under Settings > Behavior > Device.
  * Gamepad support is enabled by default and can be turned off to prevent duplicate inputs.
  * Added search support for the setting using gamepad, controller, joystick, and related terms.
  * Added localized labels and guidance across supported languages.

* **Tests**
  * Added coverage verifying the setting reflects saved preferences and persists changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->