### PR TITLE
feat(pdf): add a Lock Horizontal Panning toggle for zoomed pages

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2540,5 +2540,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "تختفي الأجهزة من القائمة عند إيقاف تشغيل شاشتها؛ أبقِ الشاشة قيد التشغيل لتبقى مرئيًا.",
   "{{name}}'s Readest": "Readest الخاص بـ {{name}}",
   "Gamepad Support": "دعم ذراع الألعاب",
-  "Navigate with a connected controller": "التنقل باستخدام ذراع ألعاب متصل"
+  "Navigate with a connected controller": "التنقل باستخدام ذراع ألعاب متصل",
+  "Lock Horizontal Panning": "قفل التحريك الأفقي"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "স্ক্রিন বন্ধ হলে ডিভাইসগুলি তালিকা থেকে অদৃশ্য হয়ে যায়; দৃশ্যমান থাকতে স্ক্রিন চালু রাখুন।",
   "{{name}}'s Readest": "{{name}}-এর Readest",
   "Gamepad Support": "গেমপ্যাড সমর্থন",
-  "Navigate with a connected controller": "সংযুক্ত কন্ট্রোলার দিয়ে নেভিগেট করুন"
+  "Navigate with a connected controller": "সংযুক্ত কন্ট্রোলার দিয়ে নেভিগেট করুন",
+  "Lock Horizontal Panning": "অনুভূমিক প্যানিং লক করুন"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2240,5 +2240,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "སྒྲིག་ཆས་ཀྱི་བརྙན་ཡོལ་ཁ་བརྒྱབ་སྐབས་རེའུ་མིག་ནས་མི་སྣང་བར་འགྱུར། མཐོང་རྒྱུ་ཡོད་པར་གནས་ཆེད་བརྙན་ཡོལ་གསལ་བར་བཞག",
   "{{name}}'s Readest": "{{name}}ཡི་ Readest",
   "Gamepad Support": "རྩེད་མོའི་ཚོད་འཛིན་ཆས་རྒྱབ་སྐྱོར།",
-  "Navigate with a connected controller": "སྦྲེལ་ཟིན་པའི་ཚོད་འཛིན་ཆས་ཐོག་ནས་གནས་སྤོ་བྱེད་པ།"
+  "Navigate with a connected controller": "སྦྲེལ་ཟིན་པའི་ཚོད་འཛིན་ཆས་ཐོག་ནས་གནས་སྤོ་བྱེད་པ།",
+  "Lock Horizontal Panning": "ཐད་ཐིག་སྤོ་འགུལ་བཀག་པ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Geräte verschwinden aus der Liste, wenn ihr Bildschirm ausgeschaltet wird; lassen Sie den Bildschirm eingeschaltet, um sichtbar zu bleiben.",
   "{{name}}'s Readest": "Readest von {{name}}",
   "Gamepad Support": "Gamepad-Unterstützung",
-  "Navigate with a connected controller": "Mit einem verbundenen Controller navigieren"
+  "Navigate with a connected controller": "Mit einem verbundenen Controller navigieren",
+  "Lock Horizontal Panning": "Horizontales Schwenken sperren"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Οι συσκευές εξαφανίζονται από τη λίστα όταν σβήσει η οθόνη τους· κρατήστε την οθόνη ανοιχτή για να παραμένετε ορατοί.",
   "{{name}}'s Readest": "Το Readest του {{name}}",
   "Gamepad Support": "Υποστήριξη χειριστηρίου",
-  "Navigate with a connected controller": "Πλοήγηση με συνδεδεμένο χειριστήριο"
+  "Navigate with a connected controller": "Πλοήγηση με συνδεδεμένο χειριστήριο",
+  "Lock Horizontal Panning": "Κλείδωμα οριζόντιας μετακίνησης"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2360,5 +2360,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Los dispositivos desaparecen de la lista cuando se apaga su pantalla; mantén la pantalla encendida para seguir visible.",
   "{{name}}'s Readest": "Readest de {{name}}",
   "Gamepad Support": "Compatibilidad con mando",
-  "Navigate with a connected controller": "Navegar con un mando conectado"
+  "Navigate with a connected controller": "Navegar con un mando conectado",
+  "Lock Horizontal Panning": "Bloquear el movimiento horizontal"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "وقتی صفحهٔ دستگاه‌ها خاموش می‌شود، از فهرست ناپدید می‌شوند؛ برای دیده‌شدن، صفحه را روشن نگه دارید.",
   "{{name}}'s Readest": "Readestِ {{name}}",
   "Gamepad Support": "پشتیبانی از دسته بازی",
-  "Navigate with a connected controller": "پیمایش با دسته بازی متصل"
+  "Navigate with a connected controller": "پیمایش با دسته بازی متصل",
+  "Lock Horizontal Panning": "قفل کردن جابه‌جایی افقی"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2360,5 +2360,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Les appareils disparaissent de la liste lorsque leur écran s'éteint ; gardez l'écran allumé pour rester visible.",
   "{{name}}'s Readest": "Readest de {{name}}",
   "Gamepad Support": "Prise en charge des manettes",
-  "Navigate with a connected controller": "Naviguer avec une manette connectée"
+  "Navigate with a connected controller": "Naviguer avec une manette connectée",
+  "Lock Horizontal Panning": "Verrouiller le panoramique horizontal"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2360,5 +2360,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "מכשירים נעלמים מהרשימה כשהמסך שלהם כבה; השאירו את המסך דולק כדי להישאר גלויים.",
   "{{name}}'s Readest": "Readest של {{name}}",
   "Gamepad Support": "תמיכה בבקר משחק",
-  "Navigate with a connected controller": "ניווט באמצעות בקר מחובר"
+  "Navigate with a connected controller": "ניווט באמצעות בקר מחובר",
+  "Lock Horizontal Panning": "נעל הזזה אופקית"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "जब किसी डिवाइस की स्क्रीन बंद हो जाती है तो वह सूची से गायब हो जाता है; दृश्यमान बने रहने के लिए स्क्रीन चालू रखें।",
   "{{name}}'s Readest": "{{name}} का Readest",
   "Gamepad Support": "गेमपैड समर्थन",
-  "Navigate with a connected controller": "कनेक्टेड कंट्रोलर से नेविगेट करें"
+  "Navigate with a connected controller": "कनेक्टेड कंट्रोलर से नेविगेट करें",
+  "Lock Horizontal Panning": "क्षैतिज पैनिंग लॉक करें"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Az eszközök eltűnnek a listáról, amikor a képernyőjük kikapcsol; tartsa bekapcsolva a képernyőt, hogy látható maradjon.",
   "{{name}}'s Readest": "{{name}} Readestje",
   "Gamepad Support": "Kontroller támogatása",
-  "Navigate with a connected controller": "Navigálás csatlakoztatott kontrollerrel"
+  "Navigate with a connected controller": "Navigálás csatlakoztatott kontrollerrel",
+  "Lock Horizontal Panning": "Vízszintes mozgatás zárolása"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2240,5 +2240,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Perangkat menghilang dari daftar saat layarnya mati; biarkan layar menyala agar tetap terlihat.",
   "{{name}}'s Readest": "Readest {{name}}",
   "Gamepad Support": "Dukungan Gamepad",
-  "Navigate with a connected controller": "Navigasi dengan pengontrol yang terhubung"
+  "Navigate with a connected controller": "Navigasi dengan pengontrol yang terhubung",
+  "Lock Horizontal Panning": "Kunci geser horizontal"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2360,5 +2360,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "I dispositivi scompaiono dall'elenco quando il loro schermo si spegne; tieni acceso lo schermo per restare visibile.",
   "{{name}}'s Readest": "Readest di {{name}}",
   "Gamepad Support": "Supporto gamepad",
-  "Navigate with a connected controller": "Naviga con un controller collegato"
+  "Navigate with a connected controller": "Naviga con un controller collegato",
+  "Lock Horizontal Panning": "Blocca il movimento orizzontale"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2240,5 +2240,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "デバイスは画面がオフになるとリストから消えます。表示され続けるには画面をオンのままにしてください。",
   "{{name}}'s Readest": "{{name}}のReadest",
   "Gamepad Support": "ゲームパッド対応",
-  "Navigate with a connected controller": "接続したコントローラーで操作する"
+  "Navigate with a connected controller": "接続したコントローラーで操作する",
+  "Lock Horizontal Panning": "横方向の移動をロック"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "მოწყობილობები ქრება სიიდან, როცა მათი ეკრანი გამოირთვება; დატოვეთ ეკრანი ჩართული, რომ ხილვადი დარჩეთ.",
   "{{name}}'s Readest": "{{name}}-ის Readest",
   "Gamepad Support": "გეიმპედის მხარდაჭერა",
-  "Navigate with a connected controller": "ნავიგაცია მიერთებული კონტროლერით"
+  "Navigate with a connected controller": "ნავიგაცია მიერთებული კონტროლერით",
+  "Lock Horizontal Panning": "ჰორიზონტალური გადაადგილების დაბლოკვა"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2240,5 +2240,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "화면이 꺼지면 기기가 목록에서 사라집니다. 계속 표시되려면 화면을 켜 두세요.",
   "{{name}}'s Readest": "{{name}}의 Readest",
   "Gamepad Support": "게임패드 지원",
-  "Navigate with a connected controller": "연결된 컨트롤러로 탐색"
+  "Navigate with a connected controller": "연결된 컨트롤러로 탐색",
+  "Lock Horizontal Panning": "가로 이동 잠금"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2240,5 +2240,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Peranti hilang daripada senarai apabila skrinnya dimatikan; biarkan skrin menyala supaya kekal kelihatan.",
   "{{name}}'s Readest": "Readest {{name}}",
   "Gamepad Support": "Sokongan Gamepad",
-  "Navigate with a connected controller": "Navigasi dengan pengawal yang disambungkan"
+  "Navigate with a connected controller": "Navigasi dengan pengawal yang disambungkan",
+  "Lock Horizontal Panning": "Kunci gerakan mengufuk"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Apparaten verdwijnen uit de lijst wanneer hun scherm uitgaat; houd het scherm aan om zichtbaar te blijven.",
   "{{name}}'s Readest": "Readest van {{name}}",
   "Gamepad Support": "Gamepad-ondersteuning",
-  "Navigate with a connected controller": "Navigeren met een aangesloten controller"
+  "Navigate with a connected controller": "Navigeren met een aangesloten controller",
+  "Lock Horizontal Panning": "Horizontaal verschuiven vergrendelen"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2420,5 +2420,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Urządzenia znikają z listy, gdy ich ekran się wyłącza; pozostaw ekran włączony, aby pozostać widocznym.",
   "{{name}}'s Readest": "Readest użytkownika {{name}}",
   "Gamepad Support": "Obsługa gamepada",
-  "Navigate with a connected controller": "Nawigacja podłączonym kontrolerem"
+  "Navigate with a connected controller": "Nawigacja podłączonym kontrolerem",
+  "Lock Horizontal Panning": "Zablokuj przesuwanie poziome"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2360,5 +2360,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Os dispositivos desaparecem da lista quando a tela é desligada; mantenha a tela ligada para continuar visível.",
   "{{name}}'s Readest": "Readest de {{name}}",
   "Gamepad Support": "Suporte a gamepad",
-  "Navigate with a connected controller": "Navegar com um controle conectado"
+  "Navigate with a connected controller": "Navegar com um controle conectado",
+  "Lock Horizontal Panning": "Bloquear deslocamento horizontal"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2360,5 +2360,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Os dispositivos desaparecem da lista quando o ecrã se desliga; mantenha o ecrã ligado para continuar visível.",
   "{{name}}'s Readest": "Readest de {{name}}",
   "Gamepad Support": "Suporte a gamepad",
-  "Navigate with a connected controller": "Navegar com um controle conectado"
+  "Navigate with a connected controller": "Navegar com um controle conectado",
+  "Lock Horizontal Panning": "Bloquear deslocamento horizontal"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2360,5 +2360,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Dispozitivele dispar din listă când ecranul lor se stinge; păstrează ecranul pornit ca să rămâi vizibil.",
   "{{name}}'s Readest": "Readest al lui {{name}}",
   "Gamepad Support": "Suport pentru gamepad",
-  "Navigate with a connected controller": "Navigare cu un controler conectat"
+  "Navigate with a connected controller": "Navigare cu un controler conectat",
+  "Lock Horizontal Panning": "Blochează deplasarea orizontală"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2420,5 +2420,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Устройства исчезают из списка, когда их экран выключается; оставьте экран включённым, чтобы оставаться видимым.",
   "{{name}}'s Readest": "Readest пользователя {{name}}",
   "Gamepad Support": "Поддержка геймпада",
-  "Navigate with a connected controller": "Навигация с помощью подключённого геймпада"
+  "Navigate with a connected controller": "Навигация с помощью подключённого геймпада",
+  "Lock Horizontal Panning": "Заблокировать горизонтальное перемещение"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "තිරය ක්‍රියාවිරහිත වූ විට උපාංග ලැයිස්තුවෙන් අතුරුදහන් වේ; දෘශ්‍යමානව සිටීමට තිරය සක්‍රීයව තබා ගන්න.",
   "{{name}}'s Readest": "{{name}} ගේ Readest",
   "Gamepad Support": "ගේම්පෑඩ් සහාය",
-  "Navigate with a connected controller": "සම්බන්ධිත පාලකයක් සමඟ සංචලනය කරන්න"
+  "Navigate with a connected controller": "සම්බන්ධිත පාලකයක් සමඟ සංචලනය කරන්න",
+  "Lock Horizontal Panning": "තිරස් චලනය අගුළු දමන්න"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2420,5 +2420,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Naprave izginejo s seznama, ko se njihov zaslon izklopi; naj bo zaslon vklopljen, da ostanete vidni.",
   "{{name}}'s Readest": "Readest uporabnika {{name}}",
   "Gamepad Support": "Podpora za igralni plošček",
-  "Navigate with a connected controller": "Krmarjenje s priključenim krmilnikom"
+  "Navigate with a connected controller": "Krmarjenje s priključenim krmilnikom",
+  "Lock Horizontal Panning": "Zakleni vodoravno premikanje"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Enheter försvinner från listan när skärmen stängs av; håll skärmen på för att fortsätta synas.",
   "{{name}}'s Readest": "{{name}}s Readest",
   "Gamepad Support": "Stöd för handkontroll",
-  "Navigate with a connected controller": "Navigera med en ansluten handkontroll"
+  "Navigate with a connected controller": "Navigera med en ansluten handkontroll",
+  "Lock Horizontal Panning": "Lås horisontell panorering"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "திரை அணைந்தால் சாதனங்கள் பட்டியலிலிருந்து மறைந்துவிடும்; தெரியும் நிலையில் இருக்க திரையை இயக்கத்தில் வைக்கவும்.",
   "{{name}}'s Readest": "{{name}} இன் Readest",
   "Gamepad Support": "கேம்பேட் ஆதரவு",
-  "Navigate with a connected controller": "இணைக்கப்பட்ட கன்ட்ரோலரைக் கொண்டு வழிசெலுத்தவும்"
+  "Navigate with a connected controller": "இணைக்கப்பட்ட கன்ட்ரோலரைக் கொண்டு வழிசெலுத்தவும்",
+  "Lock Horizontal Panning": "கிடைமட்ட நகர்வைப் பூட்டவும்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2240,5 +2240,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "อุปกรณ์จะหายไปจากรายการเมื่อหน้าจอปิด เปิดหน้าจอไว้เพื่อให้ยังคงมองเห็นได้",
   "{{name}}'s Readest": "Readest ของ {{name}}",
   "Gamepad Support": "รองรับเกมแพด",
-  "Navigate with a connected controller": "นำทางด้วยคอนโทรลเลอร์ที่เชื่อมต่อ"
+  "Navigate with a connected controller": "นำทางด้วยคอนโทรลเลอร์ที่เชื่อมต่อ",
+  "Lock Horizontal Panning": "ล็อคการเลื่อนแนวนอน"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Ekranı kapandığında cihazlar listeden kaybolur; görünür kalmak için ekranı açık tutun.",
   "{{name}}'s Readest": "{{name}} Readest'i",
   "Gamepad Support": "Oyun Kumandası Desteği",
-  "Navigate with a connected controller": "Bağlı bir kumandayla gezinin"
+  "Navigate with a connected controller": "Bağlı bir kumandayla gezinin",
+  "Lock Horizontal Panning": "Yatay hareketi kilitle"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2420,5 +2420,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Пристрої зникають зі списку, коли їхній екран вимикається; залиште екран увімкненим, щоб залишатися видимим.",
   "{{name}}'s Readest": "Readest користувача {{name}}",
   "Gamepad Support": "Підтримка геймпада",
-  "Navigate with a connected controller": "Навігація за допомогою підключеного геймпада"
+  "Navigate with a connected controller": "Навігація за допомогою підключеного геймпада",
+  "Lock Horizontal Panning": "Заблокувати горизонтальне переміщення"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2300,5 +2300,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Qurilmalar ekrani o'chganda ro'yxatdan yo'qoladi; ko'rinib turish uchun ekranni yoniq qoldiring.",
   "{{name}}'s Readest": "{{name}}ning Readest'i",
   "Gamepad Support": "Geympad qoʻllab-quvvatlashi",
-  "Navigate with a connected controller": "Ulangan boshqaruv pulti bilan harakatlanish"
+  "Navigate with a connected controller": "Ulangan boshqaruv pulti bilan harakatlanish",
+  "Lock Horizontal Panning": "Gorizontal siljitishni quflash"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2240,5 +2240,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "Thiết bị sẽ biến mất khỏi danh sách khi màn hình tắt; hãy bật màn hình để luôn hiển thị.",
   "{{name}}'s Readest": "Readest của {{name}}",
   "Gamepad Support": "Hỗ trợ tay cầm chơi game",
-  "Navigate with a connected controller": "Điều hướng bằng tay cầm đã kết nối"
+  "Navigate with a connected controller": "Điều hướng bằng tay cầm đã kết nối",
+  "Lock Horizontal Panning": "Khóa di chuyển ngang"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2240,5 +2240,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "设备屏幕关闭后会从列表中消失；保持屏幕点亮以持续可见。",
   "{{name}}'s Readest": "{{name}} 的 Readest",
   "Gamepad Support": "手柄支持",
-  "Navigate with a connected controller": "使用已连接的手柄进行导航"
+  "Navigate with a connected controller": "使用已连接的手柄进行导航",
+  "Lock Horizontal Panning": "锁定水平平移"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2240,5 +2240,6 @@
   "Devices disappear from the list when their screen turns off; keep the screen on to stay visible.": "裝置螢幕關閉後會從清單中消失；讓螢幕保持開啟以持續顯示。",
   "{{name}}'s Readest": "{{name}} 的 Readest",
   "Gamepad Support": "手把支援",
-  "Navigate with a connected controller": "使用已連接的手把進行導覽"
+  "Navigate with a connected controller": "使用已連接的手把進行導覽",
+  "Lock Horizontal Panning": "鎖定水平平移"
 }

--- a/apps/readest-app/src/__tests__/document/fixed-layout-paginated-scroll.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-paginated-scroll.test.ts
@@ -11,7 +11,9 @@ describe('fixed-layout paginated page-turn scroll reset', () => {
         elementWidth: 800,
         containerWidth: 800,
         scrollTop: 1200,
+        scrollLeft: 0,
         pageTurn: true,
+        lockPanX: false,
       }),
     ).toEqual({ scrollLeft: 0, scrollTop: 0 });
   });
@@ -22,7 +24,9 @@ describe('fixed-layout paginated page-turn scroll reset', () => {
         elementWidth: 800,
         containerWidth: 800,
         scrollTop: 1200,
+        scrollLeft: 0,
         pageTurn: false,
+        lockPanX: false,
       }),
     ).toEqual({ scrollLeft: 0, scrollTop: 1200 });
   });
@@ -33,7 +37,53 @@ describe('fixed-layout paginated page-turn scroll reset', () => {
         elementWidth: 1200,
         containerWidth: 800,
         scrollTop: 0,
+        scrollLeft: 0,
         pageTurn: true,
+        lockPanX: false,
+      }),
+    ).toEqual({ scrollLeft: 200, scrollTop: 0 });
+  });
+});
+
+describe('fixed-layout horizontal pan lock (#5976)', () => {
+  it('keeps the current horizontal offset on a page turn when locked', () => {
+    // The reader panned a zoomed page so its wide side margins fall outside the
+    // viewport. Turning the page must land on the same column of the new page
+    // instead of snapping back to the centre.
+    expect(
+      computePaginatedScroll({
+        elementWidth: 1200,
+        containerWidth: 800,
+        scrollTop: 900,
+        scrollLeft: 340,
+        pageTurn: true,
+        lockPanX: true,
+      }),
+    ).toEqual({ scrollLeft: 340, scrollTop: 0 });
+  });
+
+  it('keeps the current horizontal offset on a re-render when locked', () => {
+    expect(
+      computePaginatedScroll({
+        elementWidth: 1200,
+        containerWidth: 800,
+        scrollTop: 900,
+        scrollLeft: 340,
+        pageTurn: false,
+        lockPanX: true,
+      }),
+    ).toEqual({ scrollLeft: 340, scrollTop: 900 });
+  });
+
+  it('still re-centers when the lock is off', () => {
+    expect(
+      computePaginatedScroll({
+        elementWidth: 1200,
+        containerWidth: 800,
+        scrollTop: 0,
+        scrollLeft: 340,
+        pageTurn: true,
+        lockPanX: false,
       }),
     ).toEqual({ scrollLeft: 200, scrollTop: 0 });
   });

--- a/apps/readest-app/src/__tests__/document/fixed-layout-pan-lock.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-pan-lock.browser.test.ts
@@ -1,0 +1,101 @@
+/**
+ * "Lock Horizontal Panning" (issue #5976). A zoomed PDF page is panned with
+ * native touch scrolling, so a swipe that is only slightly diagonal drifts the
+ * page sideways and the reader has to keep re-cropping the wide side margins.
+ * The lock is a `touch-action` narrowing on the renderer host, which only a
+ * real engine resolves — the selector carries an exemption for horizontal
+ * scroll flow and has to out-specify the base rule to take effect at all.
+ */
+
+import { describe, it, expect, afterEach, beforeAll } from 'vitest';
+
+beforeAll(async () => {
+  await import('foliate-js/fixed-layout.js');
+});
+
+let host: HTMLElement | null = null;
+
+const mount = (attrs: Record<string, string>) => {
+  host = document.createElement('foliate-fxl');
+  for (const [name, value] of Object.entries(attrs)) host.setAttribute(name, value);
+  document.body.append(host);
+  const page = document.createElement('div');
+  page.className = 'scroll-page';
+  host.shadowRoot!.append(page);
+  return {
+    host: getComputedStyle(host).touchAction,
+    page: getComputedStyle(page).touchAction,
+  };
+};
+
+afterEach(() => {
+  host?.remove();
+  host = null;
+});
+
+describe('fixed-layout horizontal pan lock', () => {
+  it('leaves both axes pannable when the lock is off', () => {
+    expect(mount({ flow: 'scrolled', 'scroll-direction': 'vertical' })).toEqual({
+      host: 'pan-x pan-y',
+      page: 'pan-x pan-y',
+    });
+  });
+
+  it('drops the horizontal axis in vertical scroll flow when locked', () => {
+    expect(mount({ flow: 'scrolled', 'scroll-direction': 'vertical', 'lock-pan-x': '' })).toEqual({
+      host: 'pan-y',
+      page: 'pan-y',
+    });
+  });
+
+  it('drops the horizontal axis in paginated flow when locked', () => {
+    expect(mount({ flow: 'paginated', 'lock-pan-x': '' }).host).toBe('pan-y');
+  });
+
+  // A stale lock must not survive a switch to horizontal scrolling, where the
+  // locked axis is the reading axis and the reader would be stranded.
+  it('keeps both axes in horizontal scroll flow even when locked', () => {
+    expect(mount({ flow: 'scrolled', 'scroll-direction': 'horizontal', 'lock-pan-x': '' })).toEqual(
+      { host: 'pan-x pan-y', page: 'pan-x pan-y' },
+    );
+  });
+});
+
+/**
+ * `touch-action` does not cross an iframe boundary: a touch that lands on page
+ * content is governed by that document's own value, so narrowing it on the host
+ * alone leaves a zoomed page pannable sideways on a real device (#5976). The
+ * renderer has to mirror the lock inside every page frame.
+ */
+describe('fixed-layout horizontal pan lock inside page frames', () => {
+  const mountFrame = async (attrs: Record<string, string>) => {
+    host = document.createElement('foliate-fxl');
+    for (const [name, value] of Object.entries(attrs)) host.setAttribute(name, value);
+    document.body.append(host);
+    const iframe = document.createElement('iframe');
+    const loaded = new Promise((resolve) =>
+      iframe.addEventListener('load', resolve, { once: true }),
+    );
+    iframe.srcdoc = '<!doctype html><html><body>page</body></html>';
+    host.shadowRoot!.append(iframe);
+    await loaded;
+    return iframe;
+  };
+
+  it('locks the frame document when the attribute is set', async () => {
+    const iframe = await mountFrame({ flow: 'scrolled', 'scroll-direction': 'vertical' });
+    expect(iframe.contentDocument!.documentElement.style.touchAction).toBe('');
+
+    host!.toggleAttribute('lock-pan-x', true);
+    expect(iframe.contentDocument!.documentElement.style.touchAction).toBe('pan-y');
+
+    host!.toggleAttribute('lock-pan-x', false);
+    expect(iframe.contentDocument!.documentElement.style.touchAction).toBe('');
+  });
+
+  it('leaves the frame document alone in horizontal scroll flow', async () => {
+    const iframe = await mountFrame({ flow: 'scrolled', 'scroll-direction': 'horizontal' });
+    host!.toggleAttribute('lock-pan-x', true);
+    expect(iframe.contentDocument!.documentElement.style.touchAction).toBe('');
+  });
+});

--- a/apps/readest-app/src/__tests__/document/pdf-pan-lock.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/pdf-pan-lock.browser.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Panning a zoomed PDF page is a script write, not native scrolling: the text
+ * layer's own pointer handler moves the renderer's scroll offsets by hand
+ * (foliate-js/pdf.js). So the `touch-action` narrowing that implements "Lock
+ * Horizontal Panning" cannot constrain it, and on a phone the page kept
+ * drifting sideways with every slightly diagonal drag (#5976). The handler has
+ * to honour the lock the renderer mirrors onto the page document's root.
+ *
+ * A real engine is needed: the handler resolves its scroll target by walking
+ * out of the page iframe and measuring computed overflow and scroll extents.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { setupPanningEvents } from 'foliate-js/pdf.js';
+
+let scroller: HTMLElement | null = null;
+
+const PAGE = `<!doctype html><html><body style="margin:0">
+  <div class="textLayer" style="width:600px;height:600px"></div>
+</body></html>`;
+
+const mountPage = async () => {
+  scroller = document.createElement('div');
+  Object.assign(scroller.style, { overflow: 'auto', width: '200px', height: '200px' });
+  const iframe = document.createElement('iframe');
+  Object.assign(iframe.style, { width: '600px', height: '600px', border: '0' });
+  const loaded = new Promise((resolve) => iframe.addEventListener('load', resolve, { once: true }));
+  iframe.srcdoc = PAGE;
+  scroller.append(iframe);
+  document.body.append(scroller);
+  await loaded;
+  const doc = iframe.contentDocument!;
+  setupPanningEvents(doc);
+  return { doc, container: doc.querySelector('.textLayer')! };
+};
+
+// The handler tracks the pointer in screen coordinates, so a drag up and to the
+// left scrolls the page down and to the right by the same amount.
+const drag = (doc: Document, container: Element, dx: number, dy: number) => {
+  const Pointer = (doc.defaultView as Window & typeof globalThis).PointerEvent;
+  const at = (type: string, screenX: number, screenY: number) =>
+    container.dispatchEvent(new Pointer(type, { screenX, screenY, clientX: 100, clientY: 100 }));
+  at('pointerdown', 300, 300);
+  at('pointermove', 300 + dx, 300 + dy);
+  at('pointerup', 300 + dx, 300 + dy);
+};
+
+afterEach(() => {
+  scroller?.remove();
+  scroller = null;
+});
+
+describe('pdf page panning under the horizontal pan lock', () => {
+  it('pans both axes when the lock is off', async () => {
+    const { doc, container } = await mountPage();
+    drag(doc, container, -40, -30);
+    expect({ x: scroller!.scrollLeft, y: scroller!.scrollTop }).toEqual({ x: 40, y: 30 });
+  });
+
+  it('pans only vertically when the page document is locked', async () => {
+    const { doc, container } = await mountPage();
+    doc.documentElement.style.touchAction = 'pan-y';
+    drag(doc, container, -40, -30);
+    expect({ x: scroller!.scrollLeft, y: scroller!.scrollTop }).toEqual({ x: 0, y: 30 });
+  });
+
+  it('holds the offset the reader panned to instead of resetting it', async () => {
+    const { doc, container } = await mountPage();
+    drag(doc, container, -60, 0);
+    expect(scroller!.scrollLeft).toBe(60);
+
+    doc.documentElement.style.touchAction = 'pan-y';
+    drag(doc, container, -40, -30);
+    expect({ x: scroller!.scrollLeft, y: scroller!.scrollTop }).toEqual({ x: 60, y: 30 });
+  });
+});

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -803,6 +803,7 @@ const FoliateViewer: React.FC<{
         view.renderer.setAttribute('spread', viewSettings.spreadMode);
         view.renderer.setAttribute('scale-factor', viewSettings.zoomLevel);
         view.renderer.setAttribute('scroll-gap', getScrollGapAttr(viewSettings.webtoonMode));
+        view.renderer.toggleAttribute('lock-pan-x', !!viewSettings.lockHorizontalPan);
       } else {
         view.renderer.setAttribute('max-column-count', maxColumnCount);
         view.renderer.setAttribute('max-inline-size', `${maxInlineSize}px`);

--- a/apps/readest-app/src/app/reader/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/ViewMenu.tsx
@@ -72,6 +72,9 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
     viewSettings!.scrolledDirection ?? 'vertical',
   );
   const [webtoonMode, setWebtoonMode] = useState(viewSettings!.webtoonMode ?? false);
+  const [lockHorizontalPan, setLockHorizontalPan] = useState(
+    viewSettings!.lockHorizontalPan ?? false,
+  );
   const [isParagraphMode, setParagraphMode] = useState(
     viewSettings?.paragraphMode?.enabled ?? false,
   );
@@ -96,6 +99,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
   const resetContrast = () => setContrast(100);
   const toggleScrolledMode = () => setScrolledMode(!isScrolledMode);
   const toggleWebtoonMode = () => setWebtoonMode(!webtoonMode);
+  const toggleLockHorizontalPan = () => setLockHorizontalPan(!lockHorizontalPan);
   const toggleParagraphMode = () => {
     setParagraphMode(!isParagraphMode);
     eventDispatcher.dispatch('toggle-paragraph-mode', { bookKey });
@@ -216,6 +220,15 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
     saveViewSettings(envConfig, bookKey, 'webtoonMode', webtoonMode, false, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [webtoonMode]);
+
+  useEffect(() => {
+    if (lockHorizontalPan === (viewSettings.lockHorizontalPan ?? false)) return;
+    viewSettings.lockHorizontalPan = lockHorizontalPan;
+    getView(bookKey)?.renderer.toggleAttribute('lock-pan-x', lockHorizontalPan);
+    setViewSettings(bookKey, viewSettings);
+    saveViewSettings(envConfig, bookKey, 'lockHorizontalPan', lockHorizontalPan, true, false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lockHorizontalPan]);
 
   useEffect(() => {
     if (zoomLevel === viewSettings.zoomLevel) return;
@@ -464,6 +477,14 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
               onClick={() => setRtlSpread(!rtlSpread)}
             />
             <MenuItem label={_('Webtoon Mode')} toggled={webtoonMode} onClick={toggleWebtoonMode} />
+            <MenuItem
+              label={_('Lock Horizontal Panning')}
+              toggled={lockHorizontalPan}
+              onClick={toggleLockHorizontalPan}
+              // Horizontal scrolling reads along the x axis, so locking it there
+              // would strand the reader on one page.
+              disabled={isScrolledMode && scrolledDirection === 'horizontal'}
+            />
           </>
           <hr aria-hidden='true' className='border-base-300 my-1' />
         </>

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -343,6 +343,7 @@ export const DEFAULT_BOOK_LAYOUT: BookLayout = {
   scrolled: false,
   scrolledDirection: 'vertical',
   webtoonMode: false,
+  lockHorizontalPan: false,
   noContinuousScroll: false,
   disableClick: false,
   disableSwipe: false,

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -239,6 +239,9 @@ export interface BookLayout {
   scrolled: boolean;
   scrolledDirection: 'vertical' | 'horizontal';
   webtoonMode: boolean;
+  /* Fixed-layout only: freeze the horizontal pan offset of a zoomed page so it
+     can't drift sideways out of alignment while scrolling (#5976). */
+  lockHorizontalPan: boolean;
   noContinuousScroll: boolean;
   disableClick: boolean;
   disableSwipe: boolean;


### PR DESCRIPTION
Closes #5976

## The problem

Zoom into a PDF on a phone and you pan the page sideways so its wide side margins fall outside the viewport. It does not stay there: every swipe that is even slightly diagonal shifts the page a little to one side, so the text has to be re-centred over and over, and turning the page snaps it back to centre regardless. #5976 asks for a way to lock the horizontal axis while still scrolling vertically, the way Moon+ Reader does.

## The change

**View Options > Lock Horizontal Panning**, next to Webtoon Mode in the fixed-layout block, saved per book. It sets `lock-pan-x` on the renderer, which pins the horizontal offset in both flows: scrolled mode stops the drift, and paginated mode carries the panned offset across page turns instead of re-centring.

The row is disabled in horizontal scroll flow, where x is the reading axis and locking it would strand the reader on one page.

Pinch zoom is unaffected: the renderer already reserved two-finger gestures for JS (`touch-action: pan-x pan-y`), and the lock only drops the `pan-x` token.

## Why the renderer side takes three layers

Renderer PR: readest/foliate-js#89. A zoomed page can move sideways three different ways, and blocking any one alone leaves the bug:

1. `touch-action: pan-y` on the host and `.scroll-page` (the native scroll path)
2. the same value mirrored onto every page frame's root element, because `touch-action` does not cross an iframe boundary and the host's declaration never reaches page content
3. `setupPanningEvents` in `pdf.js` honouring that mirrored value, because panning a zoomed PDF is a pointer handler writing `scrollLeft` directly, which no `touch-action` value can constrain

Layer 3 is the one that matters in practice. A CSS-only version tested green in a desktop browser and did nothing on a real device: the JS pan only engages when there is no text under the pointer, so a swipe starting over text fell through to native scroll and was blocked, while one starting anywhere else was not.

## Verification

Unit tests for `computePaginatedScroll` under the lock, plus real-Chromium tests for the per-frame mirror and the pan handler.

Verified on a Xiaomi 13 (Android 16) with a zoomed PDF:

| check | result |
| --- | --- |
| diagonal swipe (-40, -220) | `dScrollTop 282`, `dScrollLeft 0` |
| vertical fling | `dScrollTop 410`, `dScrollLeft 0`; six flings held the offset exactly |
| same flings before the fix | walked scrollLeft 295 to 190 to 98 |
| pinch zoom under the lock | 175% to 303% to 158%, still works |
| menu row on / off | `dScrollLeft 0` / `dScrollLeft 186` |
| after a reload | attribute re-applied, fresh frames re-mirrored, `dScrollLeft 0` |

`pnpm test` (888 files, 10682 tests), `pnpm test:browser` (54 files, 429 tests), `pnpm lint` and `pnpm format:check` all pass.

The `packages/foliate-js` submodule is pinned to readest/foliate-js#89, now merged (`b1fe9d3` on foliate-js main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Lock Horizontal Panning** setting for zoomed, fixed-layout pages.
  - The setting preserves horizontal positioning while scrolling and can be enabled or disabled from the view menu.
  - Preferences are saved per book and default to off.
  - Added translations for the setting across supported languages.

- **Bug Fixes**
  - Improved horizontal alignment and panning behavior for fixed-layout and PDF pages.
  - Prevented horizontal drift while vertically panning zoomed pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
