### PR TITLE
feat(annotator): show highlight options immediately when highlight tool is present

### DIFF
--- a/apps/readest-app/e2e/pages/ReaderPage.ts
+++ b/apps/readest-app/e2e/pages/ReaderPage.ts
@@ -452,9 +452,14 @@ export class ReaderPage extends BasePage {
     await this.page.getByRole('menuitem', { name: `Instant ${action}` }).click();
   }
 
-  /** A tool button inside the annotation popup, by its accessible name. */
+  /**
+   * A tool button inside the annotation popup, by its accessible name. The
+   * match is exact for string names: the highlight style/color strip shows
+   * alongside the toolbar since #5983, and its "Select highlight style"
+   * button would also answer to a substring match on 'Highlight'.
+   */
   popupTool(name: string | RegExp): Locator {
-    return this.annotationPopup.getByRole('button', { name });
+    return this.annotationPopup.getByRole('button', { name, exact: typeof name === 'string' });
   }
 
   async highlightSelection(): Promise<void> {

--- a/apps/readest-app/src/__tests__/utils/annotationToolbar.test.ts
+++ b/apps/readest-app/src/__tests__/utils/annotationToolbar.test.ts
@@ -8,6 +8,7 @@ import {
   addToolToToolbar,
   removeToolFromToolbar,
   reorderToolbar,
+  shouldShowHighlightOptions,
   supportsProofread,
 } from '@/utils/annotationToolbar';
 
@@ -113,5 +114,39 @@ describe('supportsProofread', () => {
 
   test('excludes a book whose format is not known yet', () => {
     expect(supportsProofread(undefined)).toBe(false);
+  });
+});
+
+describe('shouldShowHighlightOptions (#5983)', () => {
+  const toolbarWithHighlight = DEFAULT_ANNOTATION_TOOLBAR_ITEMS;
+  const toolbarWithoutHighlight = removeToolFromToolbar(
+    DEFAULT_ANNOTATION_TOOLBAR_ITEMS,
+    'highlight',
+  );
+
+  test('shown for a fresh selection when the highlight tool is on the toolbar', () => {
+    expect(shouldShowHighlightOptions(toolbarWithHighlight, {})).toBe(true);
+  });
+
+  test('hidden for a fresh selection when the highlight tool is off the toolbar', () => {
+    expect(shouldShowHighlightOptions(toolbarWithoutHighlight, {})).toBe(false);
+  });
+
+  test('always shown for an already-annotated selection', () => {
+    expect(shouldShowHighlightOptions(toolbarWithoutHighlight, { annotated: true })).toBe(true);
+  });
+
+  test('hidden for a popup-window selection without a CFI, which cannot anchor a highlight', () => {
+    expect(shouldShowHighlightOptions(toolbarWithHighlight, { popup: true })).toBe(false);
+  });
+
+  test('shown for a popup-window selection that carries a CFI', () => {
+    expect(
+      shouldShowHighlightOptions(toolbarWithHighlight, { popup: true, cfi: 'epubcfi(/6/4!/4/2)' }),
+    ).toBe(true);
+  });
+
+  test('hidden with no selection', () => {
+    expect(shouldShowHighlightOptions(toolbarWithHighlight, null)).toBe(false);
   });
 });

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -61,7 +61,11 @@ import { writeTextToClipboard } from '@/utils/clipboard';
 import { buildAnnotationUrl } from '@/utils/deeplink';
 import { DEFAULT_NOTE_EXPORT_CONFIG } from '@/services/constants';
 import { canShareText, shareSelectedText } from '@/utils/share';
-import { getToolbarToolTypes, supportsProofread } from '@/utils/annotationToolbar';
+import {
+  getToolbarToolTypes,
+  shouldShowHighlightOptions,
+  supportsProofread,
+} from '@/utils/annotationToolbar';
 import { AnnotationToolType } from '@/types/annotator';
 import { TransformContext } from '@/services/transformers/types';
 import { transformContent } from '@/services/transformService';
@@ -233,17 +237,16 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   const canShare = canShareText(appService);
   // The toolbar is now customizable, so size the selection popup to the number
   // of visible tools (responsive) up to a max — otherwise a 2-tool toolbar
-  // renders a sparse, full-width bar. Annotated selections keep the max width
-  // since they show the wider highlight options / notes instead of the buttons.
+  // renders a sparse, full-width bar. Selections that show the highlight
+  // style/color strip (or an annotated selection's notes) keep the max width,
+  // since the strip needs the room the buttons alone don't.
   const annotPopupMaxWidth = Math.min(useResponsiveSize(300), maxWidth);
   const annotPopupToolSize = useResponsiveSize(44);
-  const visibleToolCount = getToolbarToolTypes(
-    viewSettings.annotationToolbarItems,
-    canShare,
-  ).length;
-  const annotPopupWidth = selection?.annotated
+  const toolbarToolTypes = getToolbarToolTypes(viewSettings.annotationToolbarItems, canShare);
+  const highlightOptionsAvailable = shouldShowHighlightOptions(toolbarToolTypes, selection ?? null);
+  const annotPopupWidth = highlightOptionsAvailable
     ? annotPopupMaxWidth
-    : Math.min(Math.max(visibleToolCount, 1) * annotPopupToolSize, annotPopupMaxWidth);
+    : Math.min(Math.max(toolbarToolTypes.length, 1) * annotPopupToolSize, annotPopupMaxWidth);
   const annotPopupHeight = useResponsiveSize(44);
   const androidSelectionHandlerHeight = 0;
 
@@ -1059,7 +1062,11 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   };
 
   useEffect(() => {
-    setHighlightOptionsVisible(!!(selection && selection.annotated));
+    // One-tap highlighting (#5983): with the highlight tool on the toolbar the
+    // style/color strip opens with the popup, so a color pick highlights the
+    // fresh selection directly (HighlightOptions calls handleHighlight, which
+    // creates the record when none exists at the CFI yet).
+    setHighlightOptionsVisible(highlightOptionsAvailable);
     if (selection && selection.text.trim().length > 0) {
       // Read-and-reset the Word Lens dictionary flag up front so it can never
       // stick to a later selection if an early return below fires (e.g. a gloss
@@ -2204,7 +2211,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     }
   };
 
-  const toolButtons = getToolbarToolTypes(viewSettings.annotationToolbarItems, canShare)
+  const toolButtons = toolbarToolTypes
     .map(buildToolButton)
     .filter((button): button is NonNullable<typeof button> => button !== null);
 

--- a/apps/readest-app/src/utils/annotationToolbar.ts
+++ b/apps/readest-app/src/utils/annotationToolbar.ts
@@ -60,6 +60,20 @@ export const getToolbarToolTypes = (
   canShare: boolean,
 ): AnnotationToolType[] => sanitize(items).filter((type) => canShare || type !== 'share');
 
+// One-tap highlighting (#5983): whenever the highlight tool is on the toolbar,
+// the style/color strip shows as soon as text is selected, so picking a color
+// needs no prior tap on Highlight. A popup-window selection without a CFI
+// (synthesized footnote text) can't anchor a highlight and keeps the plain
+// bar; an already-annotated selection always gets the strip, as before.
+export const shouldShowHighlightOptions = (
+  toolTypes: AnnotationToolType[],
+  selection: { annotated?: boolean; popup?: boolean; cfi?: string } | null,
+): boolean => {
+  if (!selection) return false;
+  if (selection.annotated) return true;
+  return toolTypes.includes('highlight') && !(selection.popup && !selection.cfi);
+};
+
 // Hidden tools (the "Available" tray), in canonical order.
 export const getAvailableToolTypes = (
   items: AnnotationToolType[] | undefined,


### PR DESCRIPTION
### What

One-tap highlighting: when text is selected, the annotation popup now opens with the highlight style/color strip already visible whenever the highlight tool is on the annotation toolbar. Tapping a color on a fresh selection creates the highlight directly, so applying a highlight takes one tap instead of two (Highlight, then color).

Fixes #5983

### How

- New predicate `shouldShowHighlightOptions(toolTypes, selection)` in `src/utils/annotationToolbar.ts`: shows the strip for any selection when `highlight` is in the visible toolbar; always shows it for an already-annotated selection (unchanged behavior); keeps the plain bar for a popup-window selection without a CFI, which cannot anchor a highlight.
- `Annotator.tsx` derives `highlightOptionsVisible` from the predicate and widens the popup to max width when the strip is shown. Tapping a color path already creates the annotation when none exists at the CFI (`handleHighlight(update=true)`), so no new creation logic was needed.
- If the highlight tool is removed in Customize Toolbar, the popup keeps today's compact toolbar-only behavior.

### Testing

- Unit tests: new `shouldShowHighlightOptions` cases in `src/__tests__/utils/annotationToolbar.test.ts` (fresh selection with/without the highlight tool, annotated selection, popup selection with/without CFI, null selection). Full suite green: 888 files / 10685 tests passed.
- `pnpm lint` and `pnpm format:check` pass.
- Browser-verified in the web reader: strip appears immediately on selection, one tap on a color creates the highlight (toolbar swaps Highlight to Delete, chosen color checked), annotated-selection behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Highlight style options now appear for eligible fresh text selections, not only previously annotated text.
  - Annotation toolbars adapt their available controls and width based on the current selection and enabled tools.

- **Bug Fixes**
  - Preserved the simpler toolbar for popup selections without location information.
  - Improved consistency in displaying highlight options across different selection states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->