### PR TITLE
feat(annotator): import highlights, bookmarks and progress from ReadEra

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2541,5 +2541,10 @@
   "{{name}}'s Readest": "Readest الخاص بـ {{name}}",
   "Gamepad Support": "دعم ذراع الألعاب",
   "Navigate with a connected controller": "التنقل باستخدام ذراع ألعاب متصل",
-  "Lock Horizontal Panning": "قفل التحريك الأفقي"
+  "Lock Horizontal Panning": "قفل التحريك الأفقي",
+  "Select ReadEra Backup File": "اختر ملف النسخة الاحتياطية من ReadEra",
+  "This is not a ReadEra backup file.": "هذا ليس ملف نسخة احتياطية من ReadEra.",
+  "This book was not found in the ReadEra backup.": "لم يتم العثور على هذا الكتاب في النسخة الاحتياطية من ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ملف نسخة احتياطية من ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "{{name}}-এর Readest",
   "Gamepad Support": "গেমপ্যাড সমর্থন",
   "Navigate with a connected controller": "সংযুক্ত কন্ট্রোলার দিয়ে নেভিগেট করুন",
-  "Lock Horizontal Panning": "অনুভূমিক প্যানিং লক করুন"
+  "Lock Horizontal Panning": "অনুভূমিক প্যানিং লক করুন",
+  "Select ReadEra Backup File": "ReadEra ব্যাকআপ ফাইল নির্বাচন করুন",
+  "This is not a ReadEra backup file.": "এটি ReadEra ব্যাকআপ ফাইল নয়।",
+  "This book was not found in the ReadEra backup.": "এই বইটি ReadEra ব্যাকআপে পাওয়া যায়নি।",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra ব্যাকআপ ফাইল (.bak)"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2241,5 +2241,10 @@
   "{{name}}'s Readest": "{{name}}ཡི་ Readest",
   "Gamepad Support": "རྩེད་མོའི་ཚོད་འཛིན་ཆས་རྒྱབ་སྐྱོར།",
   "Navigate with a connected controller": "སྦྲེལ་ཟིན་པའི་ཚོད་འཛིན་ཆས་ཐོག་ནས་གནས་སྤོ་བྱེད་པ།",
-  "Lock Horizontal Panning": "ཐད་ཐིག་སྤོ་འགུལ་བཀག་པ།"
+  "Lock Horizontal Panning": "ཐད་ཐིག་སྤོ་འགུལ་བཀག་པ།",
+  "Select ReadEra Backup File": "ReadEra གྲབས་ཉར་ཡིག་ཆ་འདེམས།",
+  "This is not a ReadEra backup file.": "འདི་ནི་ ReadEra གྲབས་ཉར་ཡིག་ཆ་མིན།",
+  "This book was not found in the ReadEra backup.": "དཔེ་དེབ་འདི་ ReadEra གྲབས་ཉར་ནང་མ་རྙེད།",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra གྲབས་ཉར་ཡིག་ཆ (.bak)"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "Readest von {{name}}",
   "Gamepad Support": "Gamepad-Unterstützung",
   "Navigate with a connected controller": "Mit einem verbundenen Controller navigieren",
-  "Lock Horizontal Panning": "Horizontales Schwenken sperren"
+  "Lock Horizontal Panning": "Horizontales Schwenken sperren",
+  "Select ReadEra Backup File": "ReadEra-Sicherungsdatei auswählen",
+  "This is not a ReadEra backup file.": "Dies ist keine ReadEra-Sicherungsdatei.",
+  "This book was not found in the ReadEra backup.": "Dieses Buch wurde in der ReadEra-Sicherung nicht gefunden.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra-Sicherungsdatei (.bak)"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "Το Readest του {{name}}",
   "Gamepad Support": "Υποστήριξη χειριστηρίου",
   "Navigate with a connected controller": "Πλοήγηση με συνδεδεμένο χειριστήριο",
-  "Lock Horizontal Panning": "Κλείδωμα οριζόντιας μετακίνησης"
+  "Lock Horizontal Panning": "Κλείδωμα οριζόντιας μετακίνησης",
+  "Select ReadEra Backup File": "Επιλογή αρχείου αντιγράφου ασφαλείας ReadEra",
+  "This is not a ReadEra backup file.": "Αυτό δεν είναι αρχείο αντιγράφου ασφαλείας ReadEra.",
+  "This book was not found in the ReadEra backup.": "Αυτό το βιβλίο δεν βρέθηκε στο αντίγραφο ασφαλείας ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "Αρχείο αντιγράφου ασφαλείας ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2361,5 +2361,10 @@
   "{{name}}'s Readest": "Readest de {{name}}",
   "Gamepad Support": "Compatibilidad con mando",
   "Navigate with a connected controller": "Navegar con un mando conectado",
-  "Lock Horizontal Panning": "Bloquear el movimiento horizontal"
+  "Lock Horizontal Panning": "Bloquear el movimiento horizontal",
+  "Select ReadEra Backup File": "Seleccionar archivo de copia de seguridad de ReadEra",
+  "This is not a ReadEra backup file.": "Este no es un archivo de copia de seguridad de ReadEra.",
+  "This book was not found in the ReadEra backup.": "Este libro no se encontró en la copia de seguridad de ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "Archivo de copia de seguridad de ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "Readestِ {{name}}",
   "Gamepad Support": "پشتیبانی از دسته بازی",
   "Navigate with a connected controller": "پیمایش با دسته بازی متصل",
-  "Lock Horizontal Panning": "قفل کردن جابه‌جایی افقی"
+  "Lock Horizontal Panning": "قفل کردن جابه‌جایی افقی",
+  "Select ReadEra Backup File": "انتخاب فایل پشتیبان ReadEra",
+  "This is not a ReadEra backup file.": "این یک فایل پشتیبان ReadEra نیست.",
+  "This book was not found in the ReadEra backup.": "این کتاب در پشتیبان ReadEra پیدا نشد.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "فایل پشتیبان ReadEra ‏(.bak)"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2361,5 +2361,10 @@
   "{{name}}'s Readest": "Readest de {{name}}",
   "Gamepad Support": "Prise en charge des manettes",
   "Navigate with a connected controller": "Naviguer avec une manette connectée",
-  "Lock Horizontal Panning": "Verrouiller le panoramique horizontal"
+  "Lock Horizontal Panning": "Verrouiller le panoramique horizontal",
+  "Select ReadEra Backup File": "Sélectionner le fichier de sauvegarde ReadEra",
+  "This is not a ReadEra backup file.": "Ce n'est pas un fichier de sauvegarde ReadEra.",
+  "This book was not found in the ReadEra backup.": "Ce livre n'a pas été trouvé dans la sauvegarde ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "Fichier de sauvegarde ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2361,5 +2361,10 @@
   "{{name}}'s Readest": "Readest של {{name}}",
   "Gamepad Support": "תמיכה בבקר משחק",
   "Navigate with a connected controller": "ניווט באמצעות בקר מחובר",
-  "Lock Horizontal Panning": "נעל הזזה אופקית"
+  "Lock Horizontal Panning": "נעל הזזה אופקית",
+  "Select ReadEra Backup File": "בחר קובץ גיבוי של ReadEra",
+  "This is not a ReadEra backup file.": "זהו אינו קובץ גיבוי של ReadEra.",
+  "This book was not found in the ReadEra backup.": "הספר הזה לא נמצא בגיבוי של ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "קובץ גיבוי של ReadEra ‏(.bak)"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "{{name}} का Readest",
   "Gamepad Support": "गेमपैड समर्थन",
   "Navigate with a connected controller": "कनेक्टेड कंट्रोलर से नेविगेट करें",
-  "Lock Horizontal Panning": "क्षैतिज पैनिंग लॉक करें"
+  "Lock Horizontal Panning": "क्षैतिज पैनिंग लॉक करें",
+  "Select ReadEra Backup File": "ReadEra बैकअप फ़ाइल चुनें",
+  "This is not a ReadEra backup file.": "यह ReadEra बैकअप फ़ाइल नहीं है।",
+  "This book was not found in the ReadEra backup.": "यह पुस्तक ReadEra बैकअप में नहीं मिली।",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra बैकअप फ़ाइल (.bak)"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "{{name}} Readestje",
   "Gamepad Support": "Kontroller támogatása",
   "Navigate with a connected controller": "Navigálás csatlakoztatott kontrollerrel",
-  "Lock Horizontal Panning": "Vízszintes mozgatás zárolása"
+  "Lock Horizontal Panning": "Vízszintes mozgatás zárolása",
+  "Select ReadEra Backup File": "ReadEra biztonsági mentés kiválasztása",
+  "This is not a ReadEra backup file.": "Ez nem ReadEra biztonsági mentés fájl.",
+  "This book was not found in the ReadEra backup.": "Ez a könyv nem található a ReadEra biztonsági mentésben.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra biztonsági mentés fájlja (.bak)"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2303,7 +2303,7 @@
   "Navigate with a connected controller": "Navigálás csatlakoztatott kontrollerrel",
   "Lock Horizontal Panning": "Vízszintes mozgatás zárolása",
   "Select ReadEra Backup File": "ReadEra biztonsági mentés kiválasztása",
-  "This is not a ReadEra backup file.": "Ez nem ReadEra biztonsági mentés fájl.",
+  "This is not a ReadEra backup file.": "Ez a fájl nem ReadEra biztonsági mentés.",
   "This book was not found in the ReadEra backup.": "Ez a könyv nem található a ReadEra biztonsági mentésben.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra biztonsági mentés fájlja (.bak)"

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2241,5 +2241,10 @@
   "{{name}}'s Readest": "Readest {{name}}",
   "Gamepad Support": "Dukungan Gamepad",
   "Navigate with a connected controller": "Navigasi dengan pengontrol yang terhubung",
-  "Lock Horizontal Panning": "Kunci geser horizontal"
+  "Lock Horizontal Panning": "Kunci geser horizontal",
+  "Select ReadEra Backup File": "Pilih file cadangan ReadEra",
+  "This is not a ReadEra backup file.": "Ini bukan file cadangan ReadEra.",
+  "This book was not found in the ReadEra backup.": "Buku ini tidak ditemukan dalam cadangan ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "File cadangan ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2361,5 +2361,10 @@
   "{{name}}'s Readest": "Readest di {{name}}",
   "Gamepad Support": "Supporto gamepad",
   "Navigate with a connected controller": "Naviga con un controller collegato",
-  "Lock Horizontal Panning": "Blocca il movimento orizzontale"
+  "Lock Horizontal Panning": "Blocca il movimento orizzontale",
+  "Select ReadEra Backup File": "Seleziona il file di backup di ReadEra",
+  "This is not a ReadEra backup file.": "Questo non è un file di backup di ReadEra.",
+  "This book was not found in the ReadEra backup.": "Questo libro non è stato trovato nel backup di ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "File di backup di ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2241,5 +2241,10 @@
   "{{name}}'s Readest": "{{name}}のReadest",
   "Gamepad Support": "ゲームパッド対応",
   "Navigate with a connected controller": "接続したコントローラーで操作する",
-  "Lock Horizontal Panning": "横方向の移動をロック"
+  "Lock Horizontal Panning": "横方向の移動をロック",
+  "Select ReadEra Backup File": "ReadEra のバックアップファイルを選択",
+  "This is not a ReadEra backup file.": "これは ReadEra のバックアップファイルではありません。",
+  "This book was not found in the ReadEra backup.": "この本は ReadEra のバックアップに見つかりませんでした。",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra のバックアップファイル (.bak)"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "{{name}}-ის Readest",
   "Gamepad Support": "გეიმპედის მხარდაჭერა",
   "Navigate with a connected controller": "ნავიგაცია მიერთებული კონტროლერით",
-  "Lock Horizontal Panning": "ჰორიზონტალური გადაადგილების დაბლოკვა"
+  "Lock Horizontal Panning": "ჰორიზონტალური გადაადგილების დაბლოკვა",
+  "Select ReadEra Backup File": "აირჩიეთ ReadEra-ს სარეზერვო ასლის ფაილი",
+  "This is not a ReadEra backup file.": "ეს არ არის ReadEra-ს სარეზერვო ასლის ფაილი.",
+  "This book was not found in the ReadEra backup.": "ეს წიგნი ვერ მოიძებნა ReadEra-ს სარეზერვო ასლში.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra-ს სარეზერვო ასლის ფაილი (.bak)"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2241,5 +2241,10 @@
   "{{name}}'s Readest": "{{name}}의 Readest",
   "Gamepad Support": "게임패드 지원",
   "Navigate with a connected controller": "연결된 컨트롤러로 탐색",
-  "Lock Horizontal Panning": "가로 이동 잠금"
+  "Lock Horizontal Panning": "가로 이동 잠금",
+  "Select ReadEra Backup File": "ReadEra 백업 파일 선택",
+  "This is not a ReadEra backup file.": "ReadEra 백업 파일이 아닙니다.",
+  "This book was not found in the ReadEra backup.": "이 책을 ReadEra 백업에서 찾을 수 없습니다.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra 백업 파일 (.bak)"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2241,5 +2241,10 @@
   "{{name}}'s Readest": "Readest {{name}}",
   "Gamepad Support": "Sokongan Gamepad",
   "Navigate with a connected controller": "Navigasi dengan pengawal yang disambungkan",
-  "Lock Horizontal Panning": "Kunci gerakan mengufuk"
+  "Lock Horizontal Panning": "Kunci gerakan mengufuk",
+  "Select ReadEra Backup File": "Pilih fail sandaran ReadEra",
+  "This is not a ReadEra backup file.": "Ini bukan fail sandaran ReadEra.",
+  "This book was not found in the ReadEra backup.": "Buku ini tidak ditemui dalam sandaran ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "Fail sandaran ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "Readest van {{name}}",
   "Gamepad Support": "Gamepad-ondersteuning",
   "Navigate with a connected controller": "Navigeren met een aangesloten controller",
-  "Lock Horizontal Panning": "Horizontaal verschuiven vergrendelen"
+  "Lock Horizontal Panning": "Horizontaal verschuiven vergrendelen",
+  "Select ReadEra Backup File": "ReadEra-back-upbestand selecteren",
+  "This is not a ReadEra backup file.": "Dit is geen ReadEra-back-upbestand.",
+  "This book was not found in the ReadEra backup.": "Dit boek is niet gevonden in de ReadEra-back-up.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra-back-upbestand (.bak)"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2421,5 +2421,10 @@
   "{{name}}'s Readest": "Readest użytkownika {{name}}",
   "Gamepad Support": "Obsługa gamepada",
   "Navigate with a connected controller": "Nawigacja podłączonym kontrolerem",
-  "Lock Horizontal Panning": "Zablokuj przesuwanie poziome"
+  "Lock Horizontal Panning": "Zablokuj przesuwanie poziome",
+  "Select ReadEra Backup File": "Wybierz plik kopii zapasowej ReadEra",
+  "This is not a ReadEra backup file.": "To nie jest plik kopii zapasowej ReadEra.",
+  "This book was not found in the ReadEra backup.": "Nie znaleziono tej książki w kopii zapasowej ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "Plik kopii zapasowej ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2361,5 +2361,10 @@
   "{{name}}'s Readest": "Readest de {{name}}",
   "Gamepad Support": "Suporte a gamepad",
   "Navigate with a connected controller": "Navegar com um controle conectado",
-  "Lock Horizontal Panning": "Bloquear deslocamento horizontal"
+  "Lock Horizontal Panning": "Bloquear deslocamento horizontal",
+  "Select ReadEra Backup File": "Selecionar arquivo de backup do ReadEra",
+  "This is not a ReadEra backup file.": "Este não é um arquivo de backup do ReadEra.",
+  "This book was not found in the ReadEra backup.": "Este livro não foi encontrado no backup do ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "Arquivo de backup do ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2361,5 +2361,10 @@
   "{{name}}'s Readest": "Readest de {{name}}",
   "Gamepad Support": "Suporte a gamepad",
   "Navigate with a connected controller": "Navegar com um controle conectado",
-  "Lock Horizontal Panning": "Bloquear deslocamento horizontal"
+  "Lock Horizontal Panning": "Bloquear deslocamento horizontal",
+  "Select ReadEra Backup File": "Selecionar ficheiro de backup do ReadEra",
+  "This is not a ReadEra backup file.": "Este não é um ficheiro de backup do ReadEra.",
+  "This book was not found in the ReadEra backup.": "Este livro não foi encontrado no backup do ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "Ficheiro de backup do ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2361,5 +2361,10 @@
   "{{name}}'s Readest": "Readest al lui {{name}}",
   "Gamepad Support": "Suport pentru gamepad",
   "Navigate with a connected controller": "Navigare cu un controler conectat",
-  "Lock Horizontal Panning": "Blochează deplasarea orizontală"
+  "Lock Horizontal Panning": "Blochează deplasarea orizontală",
+  "Select ReadEra Backup File": "Selectează fișierul de backup ReadEra",
+  "This is not a ReadEra backup file.": "Acesta nu este un fișier de backup ReadEra.",
+  "This book was not found in the ReadEra backup.": "Această carte nu a fost găsită în backupul ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "Fișier de backup ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2421,5 +2421,10 @@
   "{{name}}'s Readest": "Readest пользователя {{name}}",
   "Gamepad Support": "Поддержка геймпада",
   "Navigate with a connected controller": "Навигация с помощью подключённого геймпада",
-  "Lock Horizontal Panning": "Заблокировать горизонтальное перемещение"
+  "Lock Horizontal Panning": "Заблокировать горизонтальное перемещение",
+  "Select ReadEra Backup File": "Выберите файл резервной копии ReadEra",
+  "This is not a ReadEra backup file.": "Это не файл резервной копии ReadEra.",
+  "This book was not found in the ReadEra backup.": "Эта книга не найдена в резервной копии ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "Файл резервной копии ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "{{name}} ගේ Readest",
   "Gamepad Support": "ගේම්පෑඩ් සහාය",
   "Navigate with a connected controller": "සම්බන්ධිත පාලකයක් සමඟ සංචලනය කරන්න",
-  "Lock Horizontal Panning": "තිරස් චලනය අගුළු දමන්න"
+  "Lock Horizontal Panning": "තිරස් චලනය අගුළු දමන්න",
+  "Select ReadEra Backup File": "ReadEra උපස්ථ ගොනුව තෝරන්න",
+  "This is not a ReadEra backup file.": "මෙය ReadEra උපස්ථ ගොනුවක් නොවේ.",
+  "This book was not found in the ReadEra backup.": "මෙම පොත ReadEra උපස්ථයේ හමු නොවීය.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra උපස්ථ ගොනුව (.bak)"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2421,5 +2421,10 @@
   "{{name}}'s Readest": "Readest uporabnika {{name}}",
   "Gamepad Support": "Podpora za igralni plošček",
   "Navigate with a connected controller": "Krmarjenje s priključenim krmilnikom",
-  "Lock Horizontal Panning": "Zakleni vodoravno premikanje"
+  "Lock Horizontal Panning": "Zakleni vodoravno premikanje",
+  "Select ReadEra Backup File": "Izberite datoteko varnostne kopije ReadEra",
+  "This is not a ReadEra backup file.": "To ni datoteka varnostne kopije ReadEra.",
+  "This book was not found in the ReadEra backup.": "Te knjige ni v varnostni kopiji ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "Datoteka varnostne kopije ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "{{name}}s Readest",
   "Gamepad Support": "Stöd för handkontroll",
   "Navigate with a connected controller": "Navigera med en ansluten handkontroll",
-  "Lock Horizontal Panning": "Lås horisontell panorering"
+  "Lock Horizontal Panning": "Lås horisontell panorering",
+  "Select ReadEra Backup File": "Välj ReadEra-säkerhetskopia",
+  "This is not a ReadEra backup file.": "Det här är inte en ReadEra-säkerhetskopia.",
+  "This book was not found in the ReadEra backup.": "Den här boken hittades inte i ReadEra-säkerhetskopian.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra-säkerhetskopia (.bak)"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "{{name}} இன் Readest",
   "Gamepad Support": "கேம்பேட் ஆதரவு",
   "Navigate with a connected controller": "இணைக்கப்பட்ட கன்ட்ரோலரைக் கொண்டு வழிசெலுத்தவும்",
-  "Lock Horizontal Panning": "கிடைமட்ட நகர்வைப் பூட்டவும்"
+  "Lock Horizontal Panning": "கிடைமட்ட நகர்வைப் பூட்டவும்",
+  "Select ReadEra Backup File": "ReadEra காப்புப்பிரதி கோப்பைத் தேர்ந்தெடுக்கவும்",
+  "This is not a ReadEra backup file.": "இது ReadEra காப்புப்பிரதி கோப்பு அல்ல.",
+  "This book was not found in the ReadEra backup.": "இந்தப் புத்தகம் ReadEra காப்புப்பிரதியில் காணப்படவில்லை.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra காப்புப்பிரதி கோப்பு (.bak)"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2241,5 +2241,10 @@
   "{{name}}'s Readest": "Readest ของ {{name}}",
   "Gamepad Support": "รองรับเกมแพด",
   "Navigate with a connected controller": "นำทางด้วยคอนโทรลเลอร์ที่เชื่อมต่อ",
-  "Lock Horizontal Panning": "ล็อคการเลื่อนแนวนอน"
+  "Lock Horizontal Panning": "ล็อคการเลื่อนแนวนอน",
+  "Select ReadEra Backup File": "เลือกไฟล์สำรองข้อมูลของ ReadEra",
+  "This is not a ReadEra backup file.": "นี่ไม่ใช่ไฟล์สำรองข้อมูลของ ReadEra",
+  "This book was not found in the ReadEra backup.": "ไม่พบหนังสือเล่มนี้ในข้อมูลสำรองของ ReadEra",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ไฟล์สำรองข้อมูลของ ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "{{name}} Readest'i",
   "Gamepad Support": "Oyun Kumandası Desteği",
   "Navigate with a connected controller": "Bağlı bir kumandayla gezinin",
-  "Lock Horizontal Panning": "Yatay hareketi kilitle"
+  "Lock Horizontal Panning": "Yatay hareketi kilitle",
+  "Select ReadEra Backup File": "ReadEra yedek dosyasını seçin",
+  "This is not a ReadEra backup file.": "Bu bir ReadEra yedek dosyası değil.",
+  "This book was not found in the ReadEra backup.": "Bu kitap ReadEra yedeğinde bulunamadı.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra yedek dosyası (.bak)"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2421,5 +2421,10 @@
   "{{name}}'s Readest": "Readest користувача {{name}}",
   "Gamepad Support": "Підтримка геймпада",
   "Navigate with a connected controller": "Навігація за допомогою підключеного геймпада",
-  "Lock Horizontal Panning": "Заблокувати горизонтальне переміщення"
+  "Lock Horizontal Panning": "Заблокувати горизонтальне переміщення",
+  "Select ReadEra Backup File": "Виберіть файл резервної копії ReadEra",
+  "This is not a ReadEra backup file.": "Це не файл резервної копії ReadEra.",
+  "This book was not found in the ReadEra backup.": "Цю книгу не знайдено в резервній копії ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "Файл резервної копії ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2301,5 +2301,10 @@
   "{{name}}'s Readest": "{{name}}ning Readest'i",
   "Gamepad Support": "Geympad qoʻllab-quvvatlashi",
   "Navigate with a connected controller": "Ulangan boshqaruv pulti bilan harakatlanish",
-  "Lock Horizontal Panning": "Gorizontal siljitishni quflash"
+  "Lock Horizontal Panning": "Gorizontal siljitishni quflash",
+  "Select ReadEra Backup File": "ReadEra zaxira nusxa faylini tanlang",
+  "This is not a ReadEra backup file.": "Bu ReadEra zaxira nusxa fayli emas.",
+  "This book was not found in the ReadEra backup.": "Bu kitob ReadEra zaxira nusxasida topilmadi.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra zaxira nusxa fayli (.bak)"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2241,5 +2241,10 @@
   "{{name}}'s Readest": "Readest của {{name}}",
   "Gamepad Support": "Hỗ trợ tay cầm chơi game",
   "Navigate with a connected controller": "Điều hướng bằng tay cầm đã kết nối",
-  "Lock Horizontal Panning": "Khóa di chuyển ngang"
+  "Lock Horizontal Panning": "Khóa di chuyển ngang",
+  "Select ReadEra Backup File": "Chọn tệp sao lưu ReadEra",
+  "This is not a ReadEra backup file.": "Đây không phải tệp sao lưu ReadEra.",
+  "This book was not found in the ReadEra backup.": "Không tìm thấy cuốn sách này trong bản sao lưu ReadEra.",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "Tệp sao lưu ReadEra (.bak)"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2241,5 +2241,10 @@
   "{{name}}'s Readest": "{{name}} 的 Readest",
   "Gamepad Support": "手柄支持",
   "Navigate with a connected controller": "使用已连接的手柄进行导航",
-  "Lock Horizontal Panning": "锁定水平平移"
+  "Lock Horizontal Panning": "锁定水平平移",
+  "Select ReadEra Backup File": "选择 ReadEra 备份文件",
+  "This is not a ReadEra backup file.": "这不是 ReadEra 备份文件。",
+  "This book was not found in the ReadEra backup.": "未在 ReadEra 备份中找到本书。",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra 备份文件 (.bak)"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2241,5 +2241,10 @@
   "{{name}}'s Readest": "{{name}} 的 Readest",
   "Gamepad Support": "手把支援",
   "Navigate with a connected controller": "使用已連接的手把進行導覽",
-  "Lock Horizontal Panning": "鎖定水平平移"
+  "Lock Horizontal Panning": "鎖定水平平移",
+  "Select ReadEra Backup File": "選擇 ReadEra 備份檔案",
+  "This is not a ReadEra backup file.": "這不是 ReadEra 備份檔案。",
+  "This book was not found in the ReadEra backup.": "未在 ReadEra 備份中找到本書。",
+  "ReadEra": "ReadEra",
+  "ReadEra backup file (.bak)": "ReadEra 備份檔案 (.bak)"
 }

--- a/apps/readest-app/src/__tests__/app/reader/annotator/ImportAnnotationsDialog.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/annotator/ImportAnnotationsDialog.test.tsx
@@ -36,6 +36,7 @@ describe('ImportAnnotationsDialog', () => {
         isOpen
         onClose={vi.fn()}
         onImportMoonReader={vi.fn()}
+        onImportReadEra={vi.fn()}
         onImportReadest={vi.fn()}
       />,
     );
@@ -43,6 +44,7 @@ describe('ImportAnnotationsDialog', () => {
     expect(screen.getByRole('dialog', { name: 'Import Annotations' })).toBeTruthy();
     expect(screen.getByText('Readest')).toBeTruthy();
     expect(screen.getByText('Moon+ Reader')).toBeTruthy();
+    expect(screen.getByText('ReadEra')).toBeTruthy();
   });
 
   it('invokes onImportMoonReader when the Moon+ Reader row is clicked', () => {
@@ -52,12 +54,29 @@ describe('ImportAnnotationsDialog', () => {
         isOpen
         onClose={vi.fn()}
         onImportMoonReader={onImportMoonReader}
+        onImportReadEra={vi.fn()}
         onImportReadest={vi.fn()}
       />,
     );
 
     fireEvent.click(screen.getByText('Moon+ Reader'));
     expect(onImportMoonReader).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onImportReadEra when the ReadEra row is clicked', () => {
+    const onImportReadEra = vi.fn();
+    render(
+      <ImportAnnotationsDialog
+        isOpen
+        onClose={vi.fn()}
+        onImportMoonReader={vi.fn()}
+        onImportReadEra={onImportReadEra}
+        onImportReadest={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('ReadEra'));
+    expect(onImportReadEra).toHaveBeenCalledTimes(1);
   });
 
   it('invokes onImportReadest when the Readest row is clicked', () => {
@@ -67,6 +86,7 @@ describe('ImportAnnotationsDialog', () => {
         isOpen
         onClose={vi.fn()}
         onImportMoonReader={vi.fn()}
+        onImportReadEra={vi.fn()}
         onImportReadest={onImportReadest}
       />,
     );

--- a/apps/readest-app/src/__tests__/services/readera-import-real-book.test.ts
+++ b/apps/readest-app/src/__tests__/services/readera-import-real-book.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join as joinPath, resolve as resolvePath } from 'path';
+
+import * as CFI from 'foliate-js/epubcfi.js';
+import { DocumentLoader } from '@/libs/document';
+import type { BookDoc } from '@/libs/document';
+import { convertReadEraDocToBookNotes } from '@/services/annotation/providers/readera';
+import {
+  extractReadEraLibrary,
+  findReadEraDocForBook,
+  parseReadEraBackup,
+  type ReadEraDoc,
+} from '@/utils/readera';
+
+/**
+ * End-to-end import of a ReadEra backup into the book it belongs to.
+ *
+ * The backup is built here rather than committed as a fixture because a real
+ * one carries the whole library, but every field, and every XPointer shape,
+ * is copied from the sample backup attached to issue #5982 — including the
+ * `body/body` level ReadEra keeps inside each `DocFragment`, the legacy
+ * `body/html/body` form, and the synthetic `autoBoxing` steps. Those shapes
+ * only resolve against a real XHTML section document, which is what makes
+ * this test worth the EPUB parse.
+ */
+
+const collapse = (text: string) => text.replace(/\s+/g, ' ').trim();
+
+const noteData = (xPath: string, xPathEnd?: string) =>
+  JSON.stringify({ xPath, ...(xPathEnd ? { xPathEnd } : {}) });
+
+const ALICE_OPENING =
+  'Alice was beginning to get very tired of sitting by her sister on the bank, ' +
+  'and of having nothing to do';
+
+const buildLibraryJson = () =>
+  JSON.stringify({
+    version: 1,
+    docs: [
+      {
+        uri: 'file:///storage/emulated/0/Books/other.epub',
+        data: { doc_format: 'EPUB', doc_title: 'Through the Looking-Glass' },
+        citations: [],
+        bookmarks: [],
+      },
+      {
+        uri: 'file:///storage/emulated/0/Books/sample-alice.epub',
+        data: {
+          doc_format: 'EPUB',
+          doc_title: "Alice's Adventures in Wonderland",
+          doc_authors: 'Lewis Carroll',
+          doc_file_name_title: 'sample-alice',
+          doc_file_size: 1234567,
+          doc_position: JSON.stringify({
+            ratio: 0.1234,
+            page: 12,
+            pagesCount: 140,
+            xPath: '/body/DocFragment[5]/body/body/div/div/div/p[1]/text().0',
+          }),
+        },
+        citations: [
+          {
+            note_uri: 'citation-opening',
+            note_type: 3,
+            note_body: ALICE_OPENING,
+            note_extra: 'the first sentence',
+            note_mark: 2,
+            note_page: 12,
+            note_insert_time: 1662042803762,
+            note_modified_time: 1662042900000,
+            note_data: noteData(
+              '/body/DocFragment[4]/body/body/div/div/div/p[1]/text().0',
+              `/body/DocFragment[4]/body/body/div/div/div/p[1]/text().${ALICE_OPENING.length}`,
+            ),
+          },
+          {
+            note_uri: 'citation-reflowed',
+            note_type: 3,
+            note_body: 'a sentence from a different edition of this book',
+            note_extra: '',
+            note_mark: 3,
+            note_insert_time: 1662042803763,
+            note_modified_time: 1662042803763,
+            note_data: noteData(
+              '/body/DocFragment[4]/body/body/div/div/div/p[2]/autoBoxing/text().0',
+            ),
+          },
+          {
+            note_uri: 'citation-legacy-dom',
+            note_type: 3,
+            note_body: 'another sentence that is not in this edition',
+            note_extra: '',
+            note_mark: 0,
+            note_insert_time: 1662042803764,
+            note_modified_time: 1662042803764,
+            note_data: noteData('/body/DocFragment[5]/body/html/body/div/div/div/p[1]/text().0'),
+          },
+          {
+            note_uri: 'citation-missing-chapter',
+            note_type: 3,
+            note_body: 'a highlight from a chapter this edition does not have',
+            note_extra: '',
+            note_mark: 1,
+            note_insert_time: 1662042803765,
+            note_modified_time: 1662042803765,
+            note_data: noteData('/body/DocFragment[99]/body/body/p[1]/text().0'),
+          },
+        ],
+        bookmarks: [
+          {
+            note_uri: 'bookmark-pool-of-tears',
+            note_type: 2,
+            note_body: 'The Pool of Tears',
+            note_extra: '',
+            note_insert_time: 1662042803766,
+            note_modified_time: 1662042803766,
+            note_data: noteData('/body/DocFragment[5]/body/body/div/div/div/p[2]/text().0'),
+          },
+        ],
+      },
+      {
+        uri: 'file:///storage/emulated/0/Books/deleted.epub',
+        data: {
+          doc_format: 'EPUB',
+          doc_title: "Alice's Adventures in Wonderland",
+          doc_delete_time: 1662042803700,
+        },
+        citations: [],
+        bookmarks: [],
+      },
+    ],
+  });
+
+/** Resolve an imported CFI back to the text it covers in the real book. */
+const anchorText = async (book: BookDoc, cfi: string): Promise<string> => {
+  const resolved = book.resolveCFI!(cfi);
+  expect(resolved).not.toBeNull();
+  const section = book.sections![resolved!.index]!;
+  const doc = await section.createDocument();
+  const anchored = resolved!.anchor!(doc);
+  if (typeof anchored === 'number') return '';
+  return collapse(anchored.toString() || (anchored.startContainer.textContent ?? ''));
+};
+
+const buildBackup = async (libraryJson: string): Promise<ArrayBuffer> => {
+  const { configureZip } = await import('@/utils/zip');
+  await configureZip();
+  const { BlobWriter, TextReader, ZipWriter } = await import('@zip.js/zip.js');
+  const writer = new ZipWriter(new BlobWriter('application/zip'));
+  await writer.add('library.json', new TextReader(libraryJson));
+  await writer.add('meta.json', new TextReader('{"app_version":"25.8.1"}'));
+  return (await writer.close()).arrayBuffer();
+};
+
+describe('importing a real ReadEra backup into the book it belongs to', () => {
+  let bookDoc: BookDoc;
+  let readEraDoc: ReadEraDoc;
+
+  beforeAll(async () => {
+    const buffer = readFileSync(resolvePath(__dirname, '../fixtures/data/sample-alice.epub'));
+    const file = new File([buffer], 'sample-alice.epub', { type: 'application/epub+zip' });
+    ({ book: bookDoc } = await new DocumentLoader(file).open());
+
+    const library = await extractReadEraLibrary(await buildBackup(buildLibraryJson()));
+    const docs = parseReadEraBackup(library!)!;
+    // The deleted duplicate must not be a candidate for the same book.
+    expect(docs).toHaveLength(2);
+    readEraDoc = findReadEraDocForBook(docs, {
+      title: "Alice's Adventures in Wonderland",
+      author: 'Lewis Carroll',
+      format: 'EPUB',
+    })!;
+  }, 60000);
+
+  it('picks the right document out of the backup', () => {
+    expect(readEraDoc).toBeDefined();
+    expect(readEraDoc.citations).toHaveLength(4);
+    expect(readEraDoc.bookmarks).toHaveLength(1);
+  });
+
+  it('anchors a highlight on the words it covers in the real book', async () => {
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    const note = result.notes.find((n) => n.id === 'readera-citation-opening')!;
+    expect(note.type).toBe('annotation');
+    expect(note.style).toBe('highlight');
+    expect(note.note).toBe('the first sentence');
+    expect(await anchorText(bookDoc, note.cfi)).toBe(collapse(ALICE_OPENING));
+  });
+
+  it('falls back to the XPointer, autoBoxing and all, when the text has changed', async () => {
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    const note = result.notes.find((n) => n.id === 'readera-citation-reflowed')!;
+    expect(await anchorText(bookDoc, note.cfi)).toContain('So she was considering');
+  });
+
+  it('resolves the legacy html/body XPointer of an older ReadEra DOM', async () => {
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    const note = result.notes.find((n) => n.id === 'readera-citation-legacy-dom')!;
+    expect(await anchorText(bookDoc, note.cfi)).toContain('Curiouser and curiouser');
+  });
+
+  it('places a bookmark on its own paragraph and keeps its label', async () => {
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    const bookmark = result.notes.find((n) => n.id === 'readera-bookmark-pool-of-tears')!;
+    expect(bookmark.type).toBe('bookmark');
+    expect(bookmark.text).toBe('The Pool of Tears');
+    expect(bookmark.color).toBeUndefined();
+    expect(await anchorText(bookDoc, bookmark.cfi)).toContain(
+      'And she went on planning to herself',
+    );
+  });
+
+  it('carries the reading position over to a location in the right chapter', async () => {
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    expect(await anchorText(bookDoc, result.location!)).toContain('Curiouser and curiouser');
+  });
+
+  it('skips the highlight whose chapter this edition does not have', async () => {
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    expect(result.total).toBe(5);
+    expect(result.notes).toHaveLength(4);
+    expect(result.unmatched).toBe(1);
+    expect(result.notes.some((n) => n.id === 'readera-citation-missing-chapter')).toBe(false);
+  });
+
+  it('is idempotent: importing the same backup twice yields identical anchors', async () => {
+    const first = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    const second = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    expect(second.notes).toEqual(first.notes);
+    expect(second.location).toBe(first.location);
+  });
+});
+
+/**
+ * The same import against a real PDF. ReadEra locates PDF notes with MuPDF page
+ * paths whose page index is 0-based, and drops the locator entirely for most
+ * bookmarks and reading positions, leaving only the page number.
+ */
+const PDF_PAGE_TEXT = 'beautifully printed on it in large letters.';
+
+const buildPdfLibraryJson = () =>
+  JSON.stringify({
+    version: 1,
+    docs: [
+      {
+        uri: 'sha-1:0f8ac0d0eb8f0be4c2a2ab7ee97b7cc6cdd4d0c4',
+        data: {
+          doc_format: 'PDF',
+          // PDFs carry no title of their own, so ReadEra and Readest both fall
+          // back to the file name.
+          doc_file_name_title: 'sample-alice',
+          doc_position: JSON.stringify({ ratio: 0.0434, page: 3, pagesCount: 69 }),
+        },
+        citations: [
+          {
+            note_uri: 'pdf-citation',
+            note_type: 3,
+            note_body: PDF_PAGE_TEXT,
+            note_extra: '',
+            note_mark: 1,
+            note_page: 4,
+            note_insert_time: 1662042803762,
+            note_modified_time: 1662042803762,
+            note_data: JSON.stringify({
+              page: 4,
+              xPath: '/page[4]/block[3]/line[1]/char[0]@0.0980:0.3422',
+            }),
+          },
+        ],
+        bookmarks: [
+          {
+            note_uri: 'pdf-bookmark',
+            note_type: 2,
+            note_body: 'Bookmark 1',
+            note_extra: '',
+            note_insert_time: 1662042803766,
+            note_modified_time: 1662042803766,
+            note_data: JSON.stringify({ ratio: 0.0434, page: 3, pagesCount: 69 }),
+          },
+        ],
+      },
+    ],
+  });
+
+/** PDF sections carry no spine CFI, so the import anchors onto a synthetic one. */
+const sectionIndexOf = (cfi: string): number => {
+  const parsed = CFI.parse(cfi);
+  return CFI.fake.toIndex((Array.isArray(parsed) ? parsed : parsed.parent)[0]);
+};
+
+describe('importing a ReadEra backup into a real PDF', () => {
+  let bookDoc: BookDoc;
+  let readEraDoc: ReadEraDoc;
+
+  beforeAll(async () => {
+    await import('@pdfjs/pdf.min.mjs');
+    const pdfjsLib = (globalThis as Record<string, unknown>)['pdfjsLib'] as {
+      GlobalWorkerOptions: { workerSrc: string };
+    };
+    pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+      `file://${joinPath(process.cwd(), 'public/vendor/pdfjs/pdf.worker.min.mjs')}`,
+    ).href;
+
+    const buffer = readFileSync(resolvePath(__dirname, '../fixtures/data/sample-alice.pdf'));
+    const file = new File([buffer], 'sample-alice.pdf', { type: 'application/pdf' });
+    ({ book: bookDoc } = await new DocumentLoader(file).open());
+
+    const library = await extractReadEraLibrary(await buildBackup(buildPdfLibraryJson()));
+    const docs = parseReadEraBackup(library!)!;
+    readEraDoc = findReadEraDocForBook(docs, {
+      title: 'sample-alice',
+      sourceTitle: 'sample-alice',
+      format: 'PDF',
+    })!;
+  }, 60000);
+
+  it('anchors a PDF highlight on the page ReadEra put it on', async () => {
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    const note = result.notes.find((n) => n.id === 'readera-pdf-citation')!;
+    const parsed = CFI.parse(note.cfi);
+    const parts = Array.isArray(parsed) ? parsed : parsed.parent;
+    const doc = await bookDoc.sections![CFI.fake.toIndex(parts.shift())]!.createDocument();
+    expect(collapse(CFI.toRange(doc, parsed)?.toString() ?? '')).toContain('beautifully printed');
+  });
+
+  it('places a page-only bookmark and reading position on that very page', async () => {
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    const bookmark = result.notes.find((n) => n.id === 'readera-pdf-bookmark')!;
+    // The page is the whole locator, so nothing was lost placing it there.
+    expect(result.unmatched).toBe(0);
+    expect(sectionIndexOf(bookmark.cfi)).toBe(3);
+    expect(sectionIndexOf(result.location!)).toBe(3);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/readera-import.test.ts
+++ b/apps/readest-app/src/__tests__/services/readera-import.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest';
+import type { BookDoc } from '@/libs/document';
+import type { ReadEraDoc, ReadEraNote } from '@/utils/readera';
+import {
+  convertReadEraDocToBookNotes,
+  findReadEraTextRange,
+  mapReadEraColor,
+} from '@/services/annotation/providers/readera';
+
+const parseDoc = (html: string) => new DOMParser().parseFromString(html, 'text/html');
+
+/** A reflowable book whose sections carry real spine CFIs, as EPUB does. */
+const makeEpubDoc = (htmls: string[]): BookDoc =>
+  ({
+    sections: htmls.map((html, index) => ({
+      id: `section-${index}`,
+      cfi: `epubcfi(/6/${(index + 1) * 2})`,
+      size: 1000,
+      linear: 'yes',
+      createDocument: async () => parseDoc(html),
+    })),
+  }) as unknown as BookDoc;
+
+/** A paged book whose sections have no spine CFI, as the PDF adapter builds. */
+const makePdfDoc = (pages: string[]): BookDoc =>
+  ({
+    sections: pages.map((html, index) => ({
+      id: `${index}`,
+      size: 1000,
+      linear: 'yes',
+      createDocument: async () => parseDoc(`<div class="textLayer">${html}</div>`),
+    })),
+  }) as unknown as BookDoc;
+
+const makeNote = (overrides: Partial<ReadEraNote> = {}): ReadEraNote => ({
+  uri: 'note-1',
+  body: 'All grown-ups used to be children once.',
+  note: '',
+  mark: 2,
+  page: 6,
+  position: { xPath: '/body/DocFragment[2]/body/html/body/p[1]/text().0' },
+  createdAt: 1662042803762,
+  updatedAt: 1662042900000,
+  ...overrides,
+});
+
+const makeReadEraDoc = (overrides: Partial<ReadEraDoc> = {}): ReadEraDoc => ({
+  format: 'EPUB',
+  title: 'The Little Prince',
+  citations: [],
+  bookmarks: [],
+  ...overrides,
+});
+
+describe('findReadEraTextRange', () => {
+  it('locates text that spans several inline elements', () => {
+    const doc = parseDoc('<p>Grown-ups <em>never</em> understand anything by themselves.</p>');
+    const range = findReadEraTextRange(doc, 'never understand anything');
+    expect(range).not.toBeNull();
+    expect(range!.toString()).toBe('never understand anything');
+  });
+
+  it('ignores case and whitespace differences in the ReadEra copy of the text', () => {
+    const doc = parseDoc('<p>All grown-ups\n   used to be children once.</p>');
+    const range = findReadEraTextRange(doc, 'All grown-ups used to be  children once.');
+    expect(range).not.toBeNull();
+    expect(range!.toString()).toBe('All grown-ups\n   used to be children once.');
+  });
+
+  it('returns null when the text is not in the document', () => {
+    const doc = parseDoc('<p>Nothing to see here.</p>');
+    expect(findReadEraTextRange(doc, 'a passage from another book')).toBeNull();
+  });
+});
+
+describe('mapReadEraColor', () => {
+  it('maps every ReadEra marker to a distinct Readest color', () => {
+    const colors = [0, 1, 2, 3, 4].map(mapReadEraColor);
+    expect(new Set(colors).size).toBe(5);
+  });
+
+  it('falls back to yellow for an unknown marker', () => {
+    expect(mapReadEraColor(undefined)).toBe('yellow');
+    expect(mapReadEraColor(42)).toBe('yellow');
+  });
+});
+
+describe('convertReadEraDocToBookNotes', () => {
+  const bookDoc = makeEpubDoc([
+    '<p>Once upon a time.</p>',
+    '<p>All grown-ups used to be children once.</p><p>Second paragraph.</p>',
+  ]);
+
+  it('converts a highlight into a range CFI inside the right section', async () => {
+    const readEraDoc = makeReadEraDoc({ citations: [makeNote({ note: 'my note' })] });
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+
+    expect(result.total).toBe(1);
+    expect(result.unmatched).toBe(0);
+    expect(result.notes).toHaveLength(1);
+    const note = result.notes[0]!;
+    expect(note.type).toBe('annotation');
+    expect(note.cfi.startsWith('epubcfi(/6/4!')).toBe(true);
+    expect(note.cfi.includes(',')).toBe(true);
+    expect(note.text).toBe('All grown-ups used to be children once.');
+    expect(note.note).toBe('my note');
+    expect(note.color).toBe(mapReadEraColor(2));
+    expect(note.createdAt).toBe(1662042803762);
+    expect(note.updatedAt).toBe(1662042900000);
+  });
+
+  it('keeps a stable id so a second import changes nothing', async () => {
+    const readEraDoc = makeReadEraDoc({ citations: [makeNote()] });
+    const first = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    const second = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    expect(first.notes[0]!.id).toBe(second.notes[0]!.id);
+  });
+
+  it('falls back to the XPointer when the highlighted text is gone', async () => {
+    const readEraDoc = makeReadEraDoc({
+      citations: [
+        makeNote({
+          body: 'text that is not in this book',
+          position: { xPath: '/body/DocFragment[2]/body/html/body/p[2]/text().0' },
+        }),
+      ],
+    });
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    expect(result.unmatched).toBe(0);
+    expect(result.notes[0]!.cfi.startsWith('epubcfi(/6/4!')).toBe(true);
+    expect(result.notes[0]!.cfi).not.toBe('epubcfi(/6/4!)');
+  });
+
+  it('anchors at the chapter start when neither the text nor the XPointer resolves', async () => {
+    const readEraDoc = makeReadEraDoc({
+      citations: [
+        makeNote({
+          body: 'text that is not in this book',
+          position: { xPath: '/body/DocFragment[2]/body/html/body/p[9]/text().0' },
+        }),
+      ],
+    });
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    expect(result.unmatched).toBe(1);
+    expect(result.notes).toHaveLength(1);
+    expect(result.notes[0]!.cfi).toBe('epubcfi(/6/4!)');
+  });
+
+  it('converts a bookmark through its XPointer and keeps the ReadEra label', async () => {
+    const readEraDoc = makeReadEraDoc({
+      bookmarks: [
+        makeNote({
+          uri: 'bookmark-1',
+          body: 'Chapter start',
+          mark: undefined,
+          position: { xPath: '/body/DocFragment[2]/body/html/body/p[2]/text().0' },
+        }),
+      ],
+    });
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    expect(result.notes).toHaveLength(1);
+    const bookmark = result.notes[0]!;
+    expect(bookmark.type).toBe('bookmark');
+    expect(bookmark.text).toBe('Chapter start');
+    expect(bookmark.cfi.startsWith('epubcfi(/6/4!')).toBe(true);
+    expect(bookmark.color).toBeUndefined();
+  });
+
+  it('locates a PDF highlight on its page', async () => {
+    const pdfDoc = makePdfDoc([
+      '<span>Cover page</span>',
+      '<span>Chapter 13 </span><span>The Respiratory System</span>',
+    ]);
+    const readEraDoc = makeReadEraDoc({
+      format: 'PDF',
+      citations: [
+        makeNote({
+          body: 'Chapter 13 The Respiratory System',
+          page: 1,
+          position: { page: 1, xPath: '/page[1]/block[10]/line[0]/char[1]@0.0980:0.3422' },
+        }),
+      ],
+    });
+    const result = await convertReadEraDocToBookNotes(readEraDoc, pdfDoc);
+    expect(result.unmatched).toBe(0);
+    // PDF sections have no spine CFI, so the locator uses the synthetic one.
+    expect(result.notes[0]!.cfi.startsWith('epubcfi(/6/4!')).toBe(true);
+  });
+
+  it('places a PDF bookmark that only knows which page it is on', async () => {
+    const pdfDoc = makePdfDoc(['<span>Cover page</span>', '<span>Chapter 13</span>']);
+    const readEraDoc = makeReadEraDoc({
+      format: 'PDF',
+      bookmarks: [
+        makeNote({
+          uri: 'bookmark-page',
+          body: 'Bookmark 1',
+          mark: undefined,
+          // Paged formats drop the locator entirely for a bookmark and keep
+          // only the page it sits on.
+          position: { page: 1, pagesCount: 2, ratio: 0.5 },
+        }),
+      ],
+    });
+    const result = await convertReadEraDocToBookNotes(readEraDoc, pdfDoc);
+    expect(result.notes).toHaveLength(1);
+    // The page start is exactly what the bookmark pointed at, not a fallback.
+    expect(result.unmatched).toBe(0);
+    expect(result.notes[0]!.cfi).toBe('epubcfi(/6/4!)');
+  });
+
+  it('carries a page-only reading position over on a paged book', async () => {
+    const pdfDoc = makePdfDoc(['<span>Cover page</span>', '<span>Chapter 13</span>']);
+    const readEraDoc = makeReadEraDoc({
+      format: 'PDF',
+      position: { page: 1, pagesCount: 2, ratio: 0.5 },
+    });
+    const result = await convertReadEraDocToBookNotes(readEraDoc, pdfDoc);
+    expect(result.location).toBe('epubcfi(/6/4!)');
+  });
+
+  it('never guesses a location from a reflowable page number', async () => {
+    // ReadEra paginates reflowable books itself, so its page number says
+    // nothing about the spine. Guessing one would be the #5980 mistake.
+    const readEraDoc = makeReadEraDoc({ position: { page: 1, pagesCount: 300, ratio: 0.5 } });
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    expect(result.location).toBeUndefined();
+  });
+
+  it('carries the reading position over as a CFI', async () => {
+    const readEraDoc = makeReadEraDoc({
+      position: { xPath: '/body/DocFragment[2]/body/html/body/p[2]/text().0', ratio: 0.5 },
+    });
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    expect(result.location?.startsWith('epubcfi(/6/4!')).toBe(true);
+  });
+
+  it('skips notes whose section is not in the book', async () => {
+    const readEraDoc = makeReadEraDoc({
+      citations: [makeNote({ position: { xPath: '/body/DocFragment[99]/body/p[1]/text().0' } })],
+    });
+    const result = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+    expect(result.notes).toHaveLength(0);
+    expect(result.unmatched).toBe(1);
+    expect(result.total).toBe(1);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/readera-import.test.ts
+++ b/apps/readest-app/src/__tests__/services/readera-import.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import * as CFI from 'foliate-js/epubcfi.js';
 import type { BookDoc } from '@/libs/document';
 import type { ReadEraDoc, ReadEraNote } from '@/utils/readera';
 import {
@@ -8,6 +9,14 @@ import {
 } from '@/services/annotation/providers/readera';
 
 const parseDoc = (html: string) => new DOMParser().parseFromString(html, 'text/html');
+
+/** Resolve a CFI back to the range it covers inside its section document. */
+const rangeInSection = async (bookDoc: BookDoc, index: number, cfi: string): Promise<Range> => {
+  const doc = await bookDoc.sections![index]!.createDocument();
+  const parsed = CFI.parse(cfi);
+  (Array.isArray(parsed) ? parsed : parsed.parent).shift();
+  return CFI.toRange(doc, parsed);
+};
 
 /** A reflowable book whose sections carry real spine CFIs, as EPUB does. */
 const makeEpubDoc = (htmls: string[]): BookDoc =>
@@ -65,6 +74,12 @@ describe('findReadEraTextRange', () => {
     const range = findReadEraTextRange(doc, 'All grown-ups used to be  children once.');
     expect(range).not.toBeNull();
     expect(range!.toString()).toBe('All grown-ups\n   used to be children once.');
+  });
+
+  it('rejects an ambiguous match for a caller that has a locator to fall back on', () => {
+    const doc = parseDoc('<p>She saw Alice first.</p><p>Then Alice waited.</p>');
+    expect(findReadEraTextRange(doc, 'Alice', true)).toBeNull();
+    expect(findReadEraTextRange(doc, 'Alice')).not.toBeNull();
   });
 
   it('returns null when the text is not in the document', () => {
@@ -166,6 +181,25 @@ describe('convertReadEraDocToBookNotes', () => {
     expect(bookmark.color).toBeUndefined();
   });
 
+  it('prefers the XPointer when the highlighted text appears more than once', async () => {
+    const ambiguous = makeEpubDoc([
+      '<p>Once upon a time.</p>',
+      '<p>She saw Alice first.</p><p>Then Alice waited.</p>',
+    ]);
+    const readEraDoc = makeReadEraDoc({
+      citations: [
+        makeNote({
+          body: 'Alice',
+          position: { xPath: '/body/DocFragment[2]/body/html/body/p[2]/text().5' },
+        }),
+      ],
+    });
+    const result = await convertReadEraDocToBookNotes(readEraDoc, ambiguous);
+    expect(result.unmatched).toBe(0);
+    const range = await rangeInSection(ambiguous, 1, result.notes[0]!.cfi);
+    expect(range.startContainer.textContent).toBe('Then Alice waited.');
+  });
+
   it('locates a PDF highlight on its page', async () => {
     const pdfDoc = makePdfDoc([
       '<span>Cover page</span>',
@@ -214,6 +248,21 @@ describe('convertReadEraDocToBookNotes', () => {
     const readEraDoc = makeReadEraDoc({
       format: 'PDF',
       position: { page: 1, pagesCount: 2, ratio: 0.5 },
+    });
+    const result = await convertReadEraDocToBookNotes(readEraDoc, pdfDoc);
+    expect(result.location).toBe('epubcfi(/6/4!)');
+  });
+
+  it('carries a PDF reading position whose locator names a block over to its page', async () => {
+    const pdfDoc = makePdfDoc(['<span>Cover page</span>', '<span>Chapter 13</span>']);
+    const readEraDoc = makeReadEraDoc({
+      format: 'PDF',
+      position: {
+        page: 1,
+        pagesCount: 2,
+        ratio: 0.5,
+        xPath: '/page[1]/block[2]/line[0]/char[3]@0.0980:0.3422',
+      },
     });
     const result = await convertReadEraDocToBookNotes(readEraDoc, pdfDoc);
     expect(result.location).toBe('epubcfi(/6/4!)');

--- a/apps/readest-app/src/__tests__/utils/md5.test.ts
+++ b/apps/readest-app/src/__tests__/utils/md5.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { md5, fullMD5 } from '@/utils/md5';
+
+describe('fullMD5', () => {
+  it('hashes the whole file', async () => {
+    expect(await fullMD5(new File(['hello world'], 'a.txt'))).toBe(
+      '5eb63bbbe01eeed093cb22bb8f5acdc3',
+    );
+  });
+
+  it('hashes a file larger than one chunk in order', async () => {
+    const bytes = new Uint8Array(5 * 1024 * 1024);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = i % 251;
+    expect(await fullMD5(new File([bytes], 'big.epub'))).toBe(md5(bytes));
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/readera.test.ts
+++ b/apps/readest-app/src/__tests__/utils/readera.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
+  findReadEraDocByFileMd5,
   findReadEraDocForBook,
+  getReadEraFileMd5,
   normalizeReadEraXPointer,
   parseReadEraBackup,
   parseReadEraPosition,
@@ -24,6 +26,7 @@ const littlePrince = {
   data: {
     doc_format: 'EPUB',
     doc_active: 1,
+    doc_md5: 'd867e1b99a55fab2255dff631d7bb572',
     doc_delete_time: 0,
     doc_file_name_title: 'Antoine de Saint-Exupéry - The Little Prince (Illustrated)',
     doc_title: 'The Little Prince',
@@ -94,6 +97,7 @@ describe('parseReadEraBackup', () => {
     expect(doc.title).toBe('The Little Prince');
     expect(doc.fileName).toBe('Antoine de Saint-Exupéry - The Little Prince (Illustrated)');
     expect(doc.author).toBe('Antoine de Saint-Exupéry');
+    expect(doc.md5).toBe('d867e1b99a55fab2255dff631d7bb572');
     expect(doc.position?.xPath).toContain('DocFragment[6]');
 
     expect(doc.citations).toHaveLength(1);
@@ -177,6 +181,24 @@ describe('findReadEraDocForBook', () => {
     expect(findReadEraDocForBook(docs, { title: 'The Little Prince', format: 'PDF' })).toBeNull();
   });
 
+  it('rejects a short title that another title merely starts with', () => {
+    const sequel = {
+      ...littlePrince,
+      uri: 'sha-1:dune-2',
+      data: {
+        ...littlePrince.data,
+        doc_title: 'Dune 2',
+        doc_file_name_title: 'Dune 2',
+        doc_authors: 'Frank Herbert',
+        user_authors: 'Frank Herbert',
+      },
+    };
+    const sequels = parseReadEraBackup(backup([sequel]))!;
+    expect(
+      findReadEraDocForBook(sequels, { title: 'Dune', author: 'Frank Herbert', format: 'EPUB' }),
+    ).toBeNull();
+  });
+
   it('rejects a sequel whose title merely contains the book title', () => {
     const messiah = {
       ...littlePrince,
@@ -209,5 +231,33 @@ describe('findReadEraDocForBook', () => {
     const both = parseReadEraBackup(backup([empty, littlePrince]))!;
     const match = findReadEraDocForBook(both, { title: 'The Little Prince', format: 'EPUB' });
     expect(match?.citations).toHaveLength(1);
+  });
+});
+
+describe('findReadEraDocByFileMd5', () => {
+  const docs = parseReadEraBackup(backup([littlePrince]))!;
+
+  it('matches the document ReadEra stored under the same file md5', () => {
+    expect(findReadEraDocByFileMd5(docs, 'D867E1B99A55FAB2255DFF631D7BB572')).toBe(docs[0]);
+  });
+
+  it('returns null when no document has that md5', () => {
+    expect(findReadEraDocByFileMd5(docs, '0'.repeat(32))).toBeNull();
+  });
+
+  it('never matches a document the backup has no md5 for', () => {
+    const noHash = { ...littlePrince, data: { ...littlePrince.data, doc_md5: undefined } };
+    const parsed = parseReadEraBackup(backup([noHash]))!;
+    expect(parsed[0]!.md5).toBeUndefined();
+    expect(findReadEraDocByFileMd5(parsed, '')).toBeNull();
+  });
+});
+
+describe('getReadEraFileMd5', () => {
+  it('hashes a book only once, however often the import asks for it', async () => {
+    const first = await getReadEraFileMd5('book-hash', new File(['hello world'], 'a.epub'));
+    const second = await getReadEraFileMd5('book-hash', new File(['something else'], 'a.epub'));
+    expect(first).toBe('5eb63bbbe01eeed093cb22bb8f5acdc3');
+    expect(second).toBe(first);
   });
 });

--- a/apps/readest-app/src/__tests__/utils/readera.test.ts
+++ b/apps/readest-app/src/__tests__/utils/readera.test.ts
@@ -177,6 +177,24 @@ describe('findReadEraDocForBook', () => {
     expect(findReadEraDocForBook(docs, { title: 'The Little Prince', format: 'PDF' })).toBeNull();
   });
 
+  it('rejects a sequel whose title merely contains the book title', () => {
+    const messiah = {
+      ...littlePrince,
+      uri: 'sha-1:messiah',
+      data: {
+        ...littlePrince.data,
+        doc_title: 'Dune Messiah',
+        doc_file_name_title: 'Frank Herbert - Dune Messiah',
+        doc_authors: 'Frank Herbert',
+        user_authors: 'Frank Herbert',
+      },
+    };
+    const sequels = parseReadEraBackup(backup([messiah]))!;
+    expect(
+      findReadEraDocForBook(sequels, { title: 'Dune', author: 'Frank Herbert', format: 'EPUB' }),
+    ).toBeNull();
+  });
+
   it('rejects an unrelated book', () => {
     expect(findReadEraDocForBook(docs, { title: 'Moby Dick', format: 'EPUB' })).toBeNull();
   });

--- a/apps/readest-app/src/__tests__/utils/readera.test.ts
+++ b/apps/readest-app/src/__tests__/utils/readera.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findReadEraDocForBook,
+  normalizeReadEraXPointer,
+  parseReadEraBackup,
+  parseReadEraPosition,
+} from '@/utils/readera';
+
+const position = (extra: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    ratio: 0.0288,
+    configHash: -166378613,
+    page: 6,
+    pagesCount: 208,
+    xPath: '/body/DocFragment[6]/body/html/body/p[2]/text().467',
+    pageEnd: 7,
+    ...extra,
+  });
+
+const backup = (docs: unknown[]) => JSON.stringify({ docs, colls: [], words: [] });
+
+const littlePrince = {
+  uri: 'sha-1:8808d7cb',
+  data: {
+    doc_format: 'EPUB',
+    doc_active: 1,
+    doc_delete_time: 0,
+    doc_file_name_title: 'Antoine de Saint-Exupéry - The Little Prince (Illustrated)',
+    doc_title: 'The Little Prince',
+    doc_authors: 'Alan Wakeman',
+    user_authors: 'Antoine de Saint-Exupéry',
+    doc_file_size: 4920894,
+    doc_position: position(),
+  },
+  bookmarks: [
+    {
+      note_type: 2,
+      note_uri: 'bookmark-uri',
+      note_body: 'Bookmark 1',
+      note_data: position({ xPath: '/body/DocFragment[32]/body/html/body/p[28]/text().350' }),
+      note_index: 0.58,
+      note_page: 566,
+      note_insert_time: 1662042803000,
+      note_modified_time: 1662042803000,
+    },
+  ],
+  citations: [
+    {
+      note_type: 3,
+      note_uri: '24d579c5-f112-4b88-b7ab-7bf51cf16f77',
+      note_body: 'All grown-ups used to be children once.',
+      note_extra: 'my note',
+      note_data: position({ xPathEnd: '/body/DocFragment[6]/body/html/body/p[2]/text().540' }),
+      note_index: 0.0288,
+      note_page: 6,
+      note_mark: 2,
+      note_insert_time: 1662042803762,
+      note_modified_time: 1662042900000,
+    },
+  ],
+  reviews: [],
+  links: [],
+};
+
+describe('parseReadEraPosition', () => {
+  it('parses the embedded JSON locator', () => {
+    const parsed = parseReadEraPosition(position());
+    expect(parsed).toEqual({
+      ratio: 0.0288,
+      page: 6,
+      pagesCount: 208,
+      xPath: '/body/DocFragment[6]/body/html/body/p[2]/text().467',
+    });
+  });
+
+  it('keeps the range end when present', () => {
+    const parsed = parseReadEraPosition(position({ xPathEnd: '/body/DocFragment[6]/body/p[3]' }));
+    expect(parsed?.xPathEnd).toBe('/body/DocFragment[6]/body/p[3]');
+  });
+
+  it('returns undefined for malformed or missing input', () => {
+    expect(parseReadEraPosition(undefined)).toBeUndefined();
+    expect(parseReadEraPosition('not json')).toBeUndefined();
+    expect(parseReadEraPosition('[]')).toBeUndefined();
+  });
+});
+
+describe('parseReadEraBackup', () => {
+  it('parses documents with their highlights and bookmarks', () => {
+    const docs = parseReadEraBackup(backup([littlePrince]));
+    expect(docs).toHaveLength(1);
+    const doc = docs![0]!;
+    expect(doc.format).toBe('EPUB');
+    expect(doc.title).toBe('The Little Prince');
+    expect(doc.fileName).toBe('Antoine de Saint-Exupéry - The Little Prince (Illustrated)');
+    expect(doc.author).toBe('Antoine de Saint-Exupéry');
+    expect(doc.position?.xPath).toContain('DocFragment[6]');
+
+    expect(doc.citations).toHaveLength(1);
+    const citation = doc.citations[0]!;
+    expect(citation.body).toBe('All grown-ups used to be children once.');
+    expect(citation.note).toBe('my note');
+    expect(citation.mark).toBe(2);
+    expect(citation.createdAt).toBe(1662042803762);
+    expect(citation.updatedAt).toBe(1662042900000);
+    expect(citation.position?.xPathEnd).toContain('text().540');
+
+    expect(doc.bookmarks).toHaveLength(1);
+    expect(doc.bookmarks[0]!.position?.xPath).toContain('DocFragment[32]');
+  });
+
+  it('skips documents the user deleted in ReadEra', () => {
+    const deleted = {
+      ...littlePrince,
+      data: { ...littlePrince.data, doc_active: 0, doc_delete_time: 1768035669083 },
+    };
+    expect(parseReadEraBackup(backup([deleted]))).toHaveLength(0);
+  });
+
+  it('returns null for anything that is not a ReadEra backup', () => {
+    expect(parseReadEraBackup('not json')).toBeNull();
+    expect(parseReadEraBackup('{"annotations":[]}')).toBeNull();
+    expect(parseReadEraBackup('[]')).toBeNull();
+  });
+});
+
+describe('normalizeReadEraXPointer', () => {
+  it('drops the source body ReadEra keeps inside the fragment', () => {
+    expect(normalizeReadEraXPointer('/body/DocFragment[6]/body/body/p[2]/text().467')).toBe(
+      '/body/DocFragment[6]/body/p[2]/text().467',
+    );
+  });
+
+  it('drops the html/body wrapper CREngine keeps on older DOM versions', () => {
+    expect(normalizeReadEraXPointer('/body/DocFragment[6]/body/html/body/p[2]/text().467')).toBe(
+      '/body/DocFragment[6]/body/p[2]/text().467',
+    );
+  });
+
+  it('drops autoBoxing pseudo elements that only exist in the CREngine DOM', () => {
+    expect(
+      normalizeReadEraXPointer('/body/DocFragment[3]/body/body/p[3]/autoBoxing/span[3]/text().447'),
+    ).toBe('/body/DocFragment[3]/body/p[3]/span[3]/text().447');
+    expect(
+      normalizeReadEraXPointer(
+        '/body/DocFragment[3]/body/body/p[3]/autoBoxing[2]/span[1]/text().4',
+      ),
+    ).toBe('/body/DocFragment[3]/body/p[3]/span[1]/text().4');
+  });
+
+  it('leaves a plain KOReader-shaped XPointer untouched', () => {
+    const xpointer = '/body/DocFragment[9]/body/p[27]/text()[2].503';
+    expect(normalizeReadEraXPointer(xpointer)).toBe(xpointer);
+  });
+});
+
+describe('findReadEraDocForBook', () => {
+  const docs = parseReadEraBackup(backup([littlePrince]))!;
+
+  it('matches on the metadata title', () => {
+    expect(findReadEraDocForBook(docs, { title: 'The Little Prince', format: 'EPUB' })).toBe(
+      docs[0],
+    );
+  });
+
+  it('matches when the ReadEra file name embeds the title', () => {
+    expect(
+      findReadEraDocForBook(docs, {
+        title: 'The Little Prince (Illustrated)',
+        author: 'Antoine de Saint-Exupéry',
+        format: 'EPUB',
+      }),
+    ).toBe(docs[0]);
+  });
+
+  it('rejects a book of a different format', () => {
+    expect(findReadEraDocForBook(docs, { title: 'The Little Prince', format: 'PDF' })).toBeNull();
+  });
+
+  it('rejects an unrelated book', () => {
+    expect(findReadEraDocForBook(docs, { title: 'Moby Dick', format: 'EPUB' })).toBeNull();
+  });
+
+  it('prefers the candidate carrying annotations when titles tie', () => {
+    const empty = {
+      ...littlePrince,
+      uri: 'sha-1:other',
+      citations: [],
+      bookmarks: [],
+    };
+    const both = parseReadEraBackup(backup([empty, littlePrince]))!;
+    const match = findReadEraDocForBook(both, { title: 'The Little Prince', format: 'EPUB' });
+    expect(match?.citations).toHaveLength(1);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -106,6 +106,8 @@ import {
   convertAnnotationExportToBookNotes,
   parseAnnotationExport,
 } from '@/services/annotation/providers/readest';
+import { extractReadEraLibrary, findReadEraDocForBook, parseReadEraBackup } from '@/utils/readera';
+import { convertReadEraDocToBookNotes } from '@/services/annotation/providers/readera';
 
 const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   bookKey,
@@ -1870,6 +1872,143 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     }
   };
 
+  /** Read the picked file as bytes on both Web (File) and Tauri (path). */
+  const readSelectedFileBytes = async (selectedFile: SelectedFile): Promise<ArrayBuffer | null> => {
+    try {
+      if (selectedFile.file) return await selectedFile.file.arrayBuffer();
+      if (selectedFile.path) {
+        return (await appService?.readFile(selectedFile.path, 'None', 'binary')) as ArrayBuffer;
+      }
+    } catch (e) {
+      console.warn('Failed to read the selected backup file:', e);
+    }
+    return null;
+  };
+
+  const importFromReadEra = async () => {
+    setShowImportDialog(false);
+
+    const { bookDoc, book } = bookData;
+    if (!bookDoc || !book) {
+      eventDispatcher.dispatch('toast', {
+        type: 'warning',
+        message: _('Book is not ready yet, please try again.'),
+        timeout: 2000,
+      });
+      return;
+    }
+
+    const result = await selectFiles({
+      type: 'generic',
+      accept: '.bak',
+      extensions: ['bak'],
+      multiple: false,
+      dialogTitle: _('Select ReadEra Backup File'),
+    });
+    if (result.error || result.files.length === 0) return;
+
+    setImportingAnnotations(true);
+    try {
+      const data = await readSelectedFileBytes(result.files[0]!);
+      if (!data) {
+        eventDispatcher.dispatch('toast', {
+          type: 'warning',
+          message: _('Failed to read the selected file.'),
+          timeout: 2000,
+        });
+        return;
+      }
+
+      const library = await extractReadEraLibrary(data);
+      const docs = library ? parseReadEraBackup(library) : null;
+      if (!docs) {
+        eventDispatcher.dispatch('toast', {
+          type: 'warning',
+          message: _('This is not a ReadEra backup file.'),
+          timeout: 3000,
+        });
+        return;
+      }
+
+      // The backup carries no book files and keys documents by a hash scheme
+      // of its own, so the entry for this book is found by title/author.
+      const readEraDoc = findReadEraDocForBook(docs, book);
+      if (!readEraDoc) {
+        eventDispatcher.dispatch('toast', {
+          type: 'warning',
+          message: _('This book was not found in the ReadEra backup.'),
+          timeout: 3000,
+        });
+        return;
+      }
+      if (readEraDoc.citations.length === 0 && readEraDoc.bookmarks.length === 0) {
+        eventDispatcher.dispatch('toast', {
+          type: 'info',
+          message: _('No annotations found in the file.'),
+          timeout: 2000,
+        });
+        return;
+      }
+
+      let conversion;
+      try {
+        conversion = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
+      } catch (e) {
+        console.warn('Failed to convert ReadEra annotations:', e);
+        eventDispatcher.dispatch('toast', {
+          type: 'warning',
+          message: _('Failed to import annotations.'),
+          timeout: 3000,
+        });
+        return;
+      }
+
+      const config = getConfig(bookKey)!;
+      const { merged, applied, added, updated } = mergeImportedBookNotes(
+        config.booknotes ?? [],
+        conversion.notes,
+      );
+      let updatedConfig = updateBooknotes(bookKey, merged);
+      // Same rule as the Readest importer: only adopt ReadEra's reading
+      // position when this book has none of its own, so importing into a book
+      // you are midway through never moves you.
+      if (updatedConfig && conversion.location && !config.location) {
+        const position = { location: conversion.location };
+        setConfig(bookKey, position);
+        updatedConfig = { ...updatedConfig, ...position };
+      }
+      if (updatedConfig) {
+        saveConfig(envConfig, bookKey, updatedConfig, settings);
+      }
+
+      const views = getViewsById(bookKey.split('-')[0]!);
+      for (const note of applied) {
+        try {
+          views.forEach((v) => v?.addAnnotation(note));
+        } catch (err) {
+          console.warn('Failed to add imported annotation', { note, err });
+        }
+      }
+
+      const imported = added + updated;
+      const parts: string[] = [
+        imported > 0
+          ? _('Imported {{count}} annotations', { count: imported })
+          : _('No new annotations to import'),
+      ];
+      if (conversion.unmatched > 0) {
+        parts.push(_('{{count}} not found in this book', { count: conversion.unmatched }));
+      }
+      eventDispatcher.dispatch('toast', {
+        type: conversion.unmatched > 0 ? 'warning' : 'info',
+        message: parts.join(' · '),
+        timeout: 3500,
+      });
+    } finally {
+      setImportingAnnotations(false);
+    }
+  };
+
   const importFromReadest = async () => {
     setShowImportDialog(false);
 
@@ -2407,6 +2546,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
           isOpen={showImportDialog}
           onClose={() => setShowImportDialog(false)}
           onImportMoonReader={importFromMoonReader}
+          onImportReadEra={importFromReadEra}
           onImportReadest={importFromReadest}
         />
       )}

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -106,7 +106,13 @@ import {
   convertAnnotationExportToBookNotes,
   parseAnnotationExport,
 } from '@/services/annotation/providers/readest';
-import { extractReadEraLibrary, findReadEraDocForBook, parseReadEraBackup } from '@/utils/readera';
+import {
+  extractReadEraLibrary,
+  findReadEraDocByFileMd5,
+  findReadEraDocForBook,
+  getReadEraFileMd5,
+  parseReadEraBackup,
+} from '@/utils/readera';
 import { convertReadEraDocToBookNotes } from '@/services/annotation/providers/readera';
 
 const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
@@ -1888,7 +1894,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   const importFromReadEra = async () => {
     setShowImportDialog(false);
 
-    const { bookDoc, book } = bookData;
+    const { bookDoc, book, file } = bookData;
     if (!bookDoc || !book) {
       eventDispatcher.dispatch('toast', {
         type: 'warning',
@@ -1930,9 +1936,14 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
         return;
       }
 
-      // The backup carries no book files and keys documents by a hash scheme
-      // of its own, so the entry for this book is found by title/author.
-      const readEraDoc = findReadEraDocForBook(docs, book);
+      // The backup carries no book files, so the entry for this book is found
+      // by title/author. When that decides nothing - a renamed file, a title
+      // too short to match on - fall back to the md5 of the whole file, which
+      // is what ReadEra keys its documents by.
+      let readEraDoc = findReadEraDocForBook(docs, book);
+      if (!readEraDoc && file) {
+        readEraDoc = findReadEraDocByFileMd5(docs, await getReadEraFileMd5(book.hash, file));
+      }
       if (!readEraDoc) {
         eventDispatcher.dispatch('toast', {
           type: 'warning',

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -1941,15 +1941,6 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
         });
         return;
       }
-      if (readEraDoc.citations.length === 0 && readEraDoc.bookmarks.length === 0) {
-        eventDispatcher.dispatch('toast', {
-          type: 'info',
-          message: _('No annotations found in the file.'),
-          timeout: 2000,
-        });
-        return;
-      }
-
       let conversion;
       try {
         conversion = await convertReadEraDocToBookNotes(readEraDoc, bookDoc);
@@ -1959,6 +1950,17 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
           type: 'warning',
           message: _('Failed to import annotations.'),
           timeout: 3000,
+        });
+        return;
+      }
+
+      // A ReadEra document may carry nothing but a reading position, which is
+      // still worth importing.
+      if (conversion.notes.length === 0 && !conversion.location) {
+        eventDispatcher.dispatch('toast', {
+          type: 'info',
+          message: _('No annotations found in the file.'),
+          timeout: 2000,
         });
         return;
       }

--- a/apps/readest-app/src/app/reader/components/annotator/ImportAnnotationsDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/ImportAnnotationsDialog.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MdDataObject, MdNightlightRound } from 'react-icons/md';
+import { MdDataObject, MdMenuBook, MdNightlightRound } from 'react-icons/md';
 import { useTranslation } from '@/hooks/useTranslation';
 import { BoxedList, NavigationRow } from '@/components/settings/primitives';
 import Dialog from '@/components/Dialog';
@@ -8,6 +8,7 @@ interface ImportAnnotationsDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onImportMoonReader: () => void;
+  onImportReadEra: () => void;
   onImportReadest: () => void;
 }
 
@@ -20,6 +21,7 @@ const ImportAnnotationsDialog: React.FC<ImportAnnotationsDialogProps> = ({
   isOpen,
   onClose,
   onImportMoonReader,
+  onImportReadEra,
   onImportReadest,
 }) => {
   const _ = useTranslation();
@@ -47,6 +49,12 @@ const ImportAnnotationsDialog: React.FC<ImportAnnotationsDialogProps> = ({
           title={_('Moon+ Reader')}
           status={_('Moon+ Reader export file (.mrexpt)')}
           onClick={onImportMoonReader}
+        />
+        <NavigationRow
+          icon={MdMenuBook}
+          title={_('ReadEra')}
+          status={_('ReadEra backup file (.bak)')}
+          onClick={onImportReadEra}
         />
       </BoxedList>
     </Dialog>

--- a/apps/readest-app/src/services/annotation/providers/readera.ts
+++ b/apps/readest-app/src/services/annotation/providers/readera.ts
@@ -138,14 +138,22 @@ const normalizeNeedle = (text: string): string => text.replace(/\s+/g, ' ').trim
  *
  * ReadEra copies the highlighted text with its own whitespace handling and the
  * match often spans several inline elements, so we search a whitespace-collapsed
- * flattening of the document rather than individual text nodes.
+ * flattening of the document rather than individual text nodes. Pass
+ * `requireUnique` when the caller has a locator to fall back on.
  */
-export const findReadEraTextRange = (doc: Document, text: string): Range | null => {
+export const findReadEraTextRange = (
+  doc: Document,
+  text: string,
+  requireUnique = false,
+): Range | null => {
   const needle = normalizeNeedle(text);
   if (!needle) return null;
   const { text: haystack, positions } = buildHaystack(collectTextNodes(doc));
   const start = haystack.indexOf(needle);
   if (start < 0) return null;
+  // A phrase that occurs more than once says nothing about which occurrence was
+  // highlighted, so a note that carries a locator is better served by it.
+  if (requireUnique && haystack.indexOf(needle, start + 1) >= 0) return null;
   const first = positions[start];
   const last = positions[start + needle.length - 1];
   if (!first || !last) return null;
@@ -236,7 +244,7 @@ export const convertReadEraDocToBookNotes = async (
 
     let cfi: string | null = null;
     if (type === 'annotation') {
-      const range = findReadEraTextRange(doc, note.body);
+      const range = findReadEraTextRange(doc, note.body, Boolean(note.position?.xPath));
       if (range) {
         try {
           const rangeCfi = CFI.fromRange(range);
@@ -276,7 +284,11 @@ export const convertReadEraDocToBookNotes = async (
     if (doc) {
       location = cfiFromXPointer(readEraDoc.position, positionIndex, section, doc) ?? undefined;
     }
-    location ??= readEraDoc.position?.xPath ? undefined : sectionStartCfi(positionIndex, section);
+    // A paged locator resolves no finer than the page it names, so the page
+    // start loses nothing. A reflowable XPointer that failed to resolve must
+    // not fall back to the chapter start, per the #5980 rule.
+    const reflowable = readEraDoc.position?.xPath?.startsWith('/body/DocFragment[');
+    location ??= reflowable ? undefined : sectionStartCfi(positionIndex, section);
   }
 
   return { notes, unmatched, total: entries.length, location };

--- a/apps/readest-app/src/services/annotation/providers/readera.ts
+++ b/apps/readest-app/src/services/annotation/providers/readera.ts
@@ -1,0 +1,283 @@
+import * as CFI from 'foliate-js/epubcfi.js';
+import { BookDoc, SectionItem } from '@/libs/document';
+import { BookNote, HighlightColor } from '@/types/book';
+import { XCFI } from '@/utils/xcfi';
+import {
+  ReadEraDoc,
+  ReadEraNote,
+  ReadEraPosition,
+  normalizeReadEraXPointer,
+} from '@/utils/readera';
+
+export interface ReadEraConversionResult {
+  /** Generated BookNotes ready to merge into the book config. */
+  notes: BookNote[];
+  /** Notes that could not be placed any better than the start of their chapter. */
+  unmatched: number;
+  /** Total number of ReadEra notes processed. */
+  total: number;
+  /** The reading position from the backup, as a CFI, when it could be resolved. */
+  location?: string;
+}
+
+/**
+ * ReadEra stores the highlight marker as an index into its own palette. The
+ * palette order is not part of the backup, so this is a best-effort bijection
+ * onto Readest's five colors: what matters is that two highlights the user
+ * marked differently stay different after the import.
+ */
+const READERA_COLORS: HighlightColor[] = ['yellow', 'green', 'blue', 'red', 'violet'];
+
+export const mapReadEraColor = (mark: number | undefined): HighlightColor =>
+  (mark !== undefined && READERA_COLORS[mark]) || 'yellow';
+
+/**
+ * The 0-based section index a ReadEra locator points at:
+ * - `/body/DocFragment[N]/...` is CREngine's 1-based spine fragment, so `N - 1`
+ *   (see the note on section numbering in `utils/xcfi.ts`);
+ * - `/page[N]/...` is MuPDF's 0-based page index, which is already the index of
+ *   the matching foliate section for a fixed-layout book;
+ * - a paged book's bookmarks, and most of its reading positions, carry no
+ *   locator at all and only say which page they are on.
+ *
+ * A reflowable position always carries an XPointer, and its `page` is ReadEra's
+ * own pagination, which says nothing about the spine: guessing a section from
+ * it would repeat the percentage-drift mistake removed in #5980.
+ */
+const readEraSectionIndex = (position: ReadEraPosition | undefined, paged: boolean): number => {
+  const xpath = position?.xPath;
+  if (!xpath) return paged && position?.page !== undefined ? position.page : -1;
+  const fragment = xpath.match(/^\/body\/DocFragment\[(\d+)\]/);
+  if (fragment) return parseInt(fragment[1]!, 10) - 1;
+  const page = xpath.match(/^\/page\[(\d+)\]/);
+  if (page) return parseInt(page[1]!, 10);
+  return -1;
+};
+
+/**
+ * The CFI prefix a section's in-document paths hang off. EPUB sections carry
+ * their own spine-step CFI; PDF (and other fixed-layout) sections have none, so
+ * we synthesize the same `/6/{2(i+1)}` step foliate-js uses for them.
+ */
+const sectionBaseCfi = (index: number, section: SectionItem | undefined): string => {
+  const cfi = section?.cfi;
+  // Defensive: a section CFI is a plain spine step, but strip the indirection
+  // marker if one ever shows up so joining doesn't produce `!!`.
+  if (cfi) return cfi.replace(/!(\))?$/, '$1');
+  return CFI.fake.fromIndex(index);
+};
+
+/** A CFI pointing at the very start of a section. */
+const sectionStartCfi = (index: number, section: SectionItem | undefined): string =>
+  CFI.joinIndir(sectionBaseCfi(index, section), '');
+
+/**
+ * Re-hang an in-document CFI path onto the section's real spine step. `XCFI`
+ * always emits `/6/{2(i+1)}`, which only matches books whose spine itemrefs are
+ * the package document's only relevant children.
+ */
+const rebaseOntoSection = (cfi: string, base: string): string => {
+  const inner = cfi.match(/^epubcfi\((.*)\)$/)?.[1];
+  if (!inner) return cfi;
+  const indirection = inner.indexOf('!');
+  return CFI.joinIndir(base, indirection >= 0 ? inner.slice(indirection + 1) : inner);
+};
+
+interface TextPosition {
+  node: Text;
+  offset: number;
+}
+
+const collectTextNodes = (doc: Document): Text[] => {
+  const body = doc.body;
+  if (!body) return [];
+  const walker = doc.createTreeWalker(body, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node) => {
+      const tag = node.parentElement?.tagName.toLowerCase();
+      return tag === 'script' || tag === 'style'
+        ? NodeFilter.FILTER_REJECT
+        : NodeFilter.FILTER_ACCEPT;
+    },
+  });
+  const nodes: Text[] = [];
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) nodes.push(node as Text);
+  return nodes;
+};
+
+/**
+ * Flatten a document into one lowercased string with runs of whitespace
+ * collapsed to a single space, keeping the source position of every character
+ * so a match can be turned back into a Range.
+ */
+const buildHaystack = (nodes: Text[]): { text: string; positions: TextPosition[] } => {
+  let text = '';
+  const positions: TextPosition[] = [];
+  let afterSpace = true;
+  for (const node of nodes) {
+    const data = node.data;
+    for (let offset = 0; offset < data.length; offset++) {
+      const char = data[offset]!;
+      if (/\s/.test(char)) {
+        if (afterSpace) continue;
+        text += ' ';
+        afterSpace = true;
+      } else {
+        text += char.toLowerCase();
+        afterSpace = false;
+      }
+      positions.push({ node, offset });
+    }
+  }
+  return { text, positions };
+};
+
+const normalizeNeedle = (text: string): string => text.replace(/\s+/g, ' ').trim().toLowerCase();
+
+/**
+ * Locate `text` in a section document and return the Range covering it.
+ *
+ * ReadEra copies the highlighted text with its own whitespace handling and the
+ * match often spans several inline elements, so we search a whitespace-collapsed
+ * flattening of the document rather than individual text nodes.
+ */
+export const findReadEraTextRange = (doc: Document, text: string): Range | null => {
+  const needle = normalizeNeedle(text);
+  if (!needle) return null;
+  const { text: haystack, positions } = buildHaystack(collectTextNodes(doc));
+  const start = haystack.indexOf(needle);
+  if (start < 0) return null;
+  const first = positions[start];
+  const last = positions[start + needle.length - 1];
+  if (!first || !last) return null;
+  const range = doc.createRange();
+  range.setStart(first.node, first.offset);
+  range.setEnd(last.node, last.offset + 1);
+  return range;
+};
+
+/** Convert a ReadEra XPointer pair into a CFI within `section`. */
+const cfiFromXPointer = (
+  position: ReadEraPosition | undefined,
+  index: number,
+  section: SectionItem | undefined,
+  doc: Document,
+): string | null => {
+  const xPath = position?.xPath;
+  if (!xPath || !xPath.startsWith('/body/DocFragment[')) return null;
+  try {
+    const converter = new XCFI(doc, index);
+    const xPathEnd = position?.xPathEnd;
+    const cfi = converter.xPointerToCFI(
+      normalizeReadEraXPointer(xPath),
+      xPathEnd ? normalizeReadEraXPointer(xPathEnd) : undefined,
+    );
+    return rebaseOntoSection(cfi, sectionBaseCfi(index, section));
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Convert one ReadEra document's highlights, bookmarks and reading position
+ * into Readest BookNotes.
+ *
+ * A highlight is anchored by searching the section for the text ReadEra saved
+ * with it, which survives a different edition of the same book. When that
+ * fails we fall back to the CREngine XPointer, and finally to the start of the
+ * section so the note is at least in the right chapter.
+ */
+export const convertReadEraDocToBookNotes = async (
+  readEraDoc: ReadEraDoc,
+  bookDoc: BookDoc,
+): Promise<ReadEraConversionResult> => {
+  const sections = bookDoc.sections ?? [];
+  // Fixed-layout sections are pages and carry no spine CFI of their own.
+  const paged = sections.length > 0 && !sections.some((section) => section.cfi);
+  const notes: BookNote[] = [];
+  let unmatched = 0;
+
+  const docCache = new Map<number, Document | null>();
+  const loadSectionDoc = async (index: number): Promise<Document | null> => {
+    if (docCache.has(index)) return docCache.get(index) ?? null;
+    let doc: Document | null = null;
+    try {
+      doc = (await sections[index]?.createDocument()) ?? null;
+    } catch {
+      doc = null;
+    }
+    docCache.set(index, doc);
+    return doc;
+  };
+
+  const entries: Array<{ note: ReadEraNote; type: 'annotation' | 'bookmark' }> = [
+    ...readEraDoc.citations.map((note) => ({ note, type: 'annotation' as const })),
+    ...readEraDoc.bookmarks.map((note) => ({ note, type: 'bookmark' as const })),
+  ];
+
+  // Yield to the event loop every few notes so the UI stays responsive during
+  // a large import; parsing section documents is synchronous and expensive.
+  const YIELD_EVERY = 5;
+  for (let i = 0; i < entries.length; i++) {
+    if (i > 0 && i % YIELD_EVERY === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    const { note, type } = entries[i]!;
+    const index = readEraSectionIndex(note.position, paged);
+    if (index < 0 || index >= sections.length) {
+      unmatched += 1;
+      continue;
+    }
+    const doc = await loadSectionDoc(index);
+    if (!doc) {
+      unmatched += 1;
+      continue;
+    }
+    const section = sections[index];
+
+    let cfi: string | null = null;
+    if (type === 'annotation') {
+      const range = findReadEraTextRange(doc, note.body);
+      if (range) {
+        try {
+          const rangeCfi = CFI.fromRange(range);
+          if (rangeCfi) cfi = rebaseOntoSection(rangeCfi, sectionBaseCfi(index, section));
+        } catch (error) {
+          console.warn('Failed to build range CFI for ReadEra note:', error);
+        }
+      }
+    }
+    if (!cfi) cfi = cfiFromXPointer(note.position, index, section, doc);
+    if (!cfi) {
+      cfi = sectionStartCfi(index, section);
+      // A page-only locator has no finer anchor to lose: the page it named is
+      // exactly where it pointed.
+      if (note.position?.xPath) unmatched += 1;
+    }
+
+    notes.push({
+      id: `readera-${note.uri}`,
+      type,
+      cfi,
+      text: note.body,
+      note: note.note,
+      ...(type === 'annotation'
+        ? { style: 'highlight' as const, color: mapReadEraColor(note.mark) }
+        : {}),
+      createdAt: note.createdAt,
+      updatedAt: note.updatedAt,
+    });
+  }
+
+  let location: string | undefined;
+  const positionIndex = readEraSectionIndex(readEraDoc.position, paged);
+  if (positionIndex >= 0 && positionIndex < sections.length) {
+    const section = sections[positionIndex];
+    const doc = await loadSectionDoc(positionIndex);
+    if (doc) {
+      location = cfiFromXPointer(readEraDoc.position, positionIndex, section, doc) ?? undefined;
+    }
+    location ??= readEraDoc.position?.xPath ? undefined : sectionStartCfi(positionIndex, section);
+  }
+
+  return { notes, unmatched, total: entries.length, location };
+};

--- a/apps/readest-app/src/utils/md5.ts
+++ b/apps/readest-app/src/utils/md5.ts
@@ -29,4 +29,19 @@ export async function partialMD5(file: File): Promise<string> {
   return hasher.hex();
 }
 
+/**
+ * md5 of the whole file, read in chunks so a large book is never held in
+ * memory twice. Far more expensive than `partialMD5`, so hash a book at most
+ * once.
+ */
+export async function fullMD5(file: File): Promise<string> {
+  const chunkSize = 4 * 1024 * 1024;
+  const hasher = md5.create();
+  for (let start = 0; start < file.size; start += chunkSize) {
+    const chunk = await file.slice(start, start + chunkSize).arrayBuffer();
+    hasher.update(new Uint8Array(chunk));
+  }
+  return hasher.hex();
+}
+
 export { md5 };

--- a/apps/readest-app/src/utils/readera.ts
+++ b/apps/readest-app/src/utils/readera.ts
@@ -1,0 +1,237 @@
+/**
+ * ReadEra backup (`ReadEra-*.bak`) parser.
+ *
+ * A ReadEra backup is a plain zip whose `library.json` carries the whole
+ * library: one entry per document with its metadata, reading position,
+ * highlights (`citations`) and `bookmarks`. The book files themselves are not
+ * part of the backup, so an import can only attach data to books the user
+ * already has in Readest — hence the title/author matching below.
+ *
+ * Locators come in two shapes:
+ * - reflowable formats use CREngine XPointers, the same family KOReader emits
+ *   (`/body/DocFragment[6]/body/p[2]/text().467`, see `utils/xcfi.ts`);
+ * - PDFs use MuPDF page paths (`/page[402]/block[10]/line[0]/char[1]@x:y`)
+ *   where the page index is 0-based.
+ */
+
+export interface ReadEraPosition {
+  ratio?: number;
+  page?: number;
+  pagesCount?: number;
+  xPath?: string;
+  xPathEnd?: string;
+}
+
+export interface ReadEraNote {
+  uri: string;
+  /** The highlighted text, or a generated label like "Bookmark 1". */
+  body: string;
+  /** The user's own note attached to a highlight (`note_extra`). */
+  note: string;
+  /** Highlight color index, 0-4. */
+  mark?: number;
+  page?: number;
+  position?: ReadEraPosition;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ReadEraDoc {
+  format?: string;
+  /** Original file name without extension. */
+  fileName?: string;
+  title?: string;
+  author?: string;
+  fileSize?: number;
+  position?: ReadEraPosition;
+  citations: ReadEraNote[];
+  bookmarks: ReadEraNote[];
+}
+
+export interface ReadEraBookMatch {
+  title?: string;
+  sourceTitle?: string;
+  author?: string;
+  format?: string;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value ? value : undefined;
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+
+export const parseReadEraPosition = (raw: unknown): ReadEraPosition | undefined => {
+  const text = asString(raw);
+  if (!text) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  const record = asRecord(parsed);
+  if (!record) return undefined;
+  const position: ReadEraPosition = {};
+  const ratio = asNumber(record['ratio']);
+  const page = asNumber(record['page']);
+  const pagesCount = asNumber(record['pagesCount']);
+  const xPath = asString(record['xPath']);
+  const xPathEnd = asString(record['xPathEnd']);
+  if (ratio !== undefined) position.ratio = ratio;
+  if (page !== undefined) position.page = page;
+  if (pagesCount !== undefined) position.pagesCount = pagesCount;
+  if (xPath) position.xPath = xPath;
+  if (xPathEnd) position.xPathEnd = xPathEnd;
+  return position;
+};
+
+const parseNote = (value: unknown): ReadEraNote | null => {
+  const record = asRecord(value);
+  if (!record) return null;
+  const uri = asString(record['note_uri']);
+  if (!uri) return null;
+  const createdAt = asNumber(record['note_insert_time']) ?? Date.now();
+  return {
+    uri,
+    body: asString(record['note_body']) ?? '',
+    note: asString(record['note_extra']) ?? '',
+    mark: asNumber(record['note_mark']),
+    page: asNumber(record['note_page']),
+    position: parseReadEraPosition(record['note_data']),
+    createdAt,
+    updatedAt: asNumber(record['note_modified_time']) ?? createdAt,
+  };
+};
+
+const parseNotes = (value: unknown): ReadEraNote[] => {
+  if (!Array.isArray(value)) return [];
+  return value.map(parseNote).filter((note): note is ReadEraNote => note !== null);
+};
+
+const parseDoc = (value: unknown): ReadEraDoc | null => {
+  const record = asRecord(value);
+  const data = asRecord(record?.['data']);
+  if (!data) return null;
+  // Documents the user deleted stay in the backup with a delete timestamp.
+  if (asNumber(data['doc_delete_time'])) return null;
+  return {
+    format: asString(data['doc_format']),
+    fileName: asString(data['doc_file_name_title']),
+    title: asString(data['user_title']) ?? asString(data['doc_title']),
+    author: asString(data['user_authors']) ?? asString(data['doc_authors']),
+    fileSize: asNumber(data['doc_file_size']),
+    position: parseReadEraPosition(data['doc_position']),
+    citations: parseNotes(record?.['citations']),
+    bookmarks: parseNotes(record?.['bookmarks']),
+  };
+};
+
+/** Parse the `library.json` payload of a ReadEra backup. */
+export const parseReadEraBackup = (content: string): ReadEraDoc[] | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  const root = asRecord(parsed);
+  if (!root || !Array.isArray(root['docs'])) return null;
+  return root['docs'].map(parseDoc).filter((doc): doc is ReadEraDoc => doc !== null);
+};
+
+/**
+ * Read `library.json` out of a ReadEra backup archive. Returns null when the
+ * archive is not a ReadEra backup (or not a zip at all).
+ */
+export const extractReadEraLibrary = async (data: ArrayBuffer): Promise<string | null> => {
+  const { configureZip } = await import('./zip');
+  await configureZip();
+  const { ZipReader, BlobReader, TextWriter } = await import('@zip.js/zip.js');
+  const reader = new ZipReader(new BlobReader(new Blob([data])));
+  try {
+    const entries = await reader.getEntries();
+    const entry = entries.find(
+      (item) =>
+        !item.directory &&
+        (item.filename === 'library.json' || item.filename.endsWith('/library.json')),
+    );
+    if (!entry || entry.directory) return null;
+    return await entry.getData(new TextWriter());
+  } catch {
+    return null;
+  } finally {
+    await reader.close();
+  }
+};
+
+/**
+ * Rewrite a ReadEra XPointer into the shape `utils/xcfi.ts` resolves against a
+ * real XHTML section document, i.e. `/body/DocFragment[N]/body` followed by a
+ * path relative to the section's `<body>`:
+ * - ReadEra's CREngine keeps the source document's own `body` (in the sample
+ *   backup for issue #5982, either `/body/body/...` or, on older DOM versions,
+ *   `/body/html/body/...`) inside the fragment. KOReader's XPointers have no
+ *   such level, so it has to go before the rest of the path can be resolved;
+ * - `autoBoxing` elements are synthetic boxes CREngine inserts around runs of
+ *   inline content and never exist in the source markup.
+ */
+export const normalizeReadEraXPointer = (xpointer: string): string =>
+  xpointer
+    .replace(/^(\/body\/DocFragment\[\d+\]\/body)\/(?:html\/)?body/, '$1')
+    .replace(/\/autoBoxing(\[\d+\])?/g, '');
+
+const normalizeText = (value: string | undefined): string =>
+  (value ?? '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim();
+
+/** ReadEra formats that map onto a Readest book format of the same name. */
+const matchesFormat = (docFormat: string | undefined, bookFormat: string | undefined): boolean => {
+  if (!docFormat || !bookFormat) return true;
+  return docFormat.toUpperCase() === bookFormat.toUpperCase();
+};
+
+/**
+ * Pick the backup entry that belongs to `book`. ReadEra keys documents by the
+ * sha1/md5 of the whole file while Readest uses a partial md5, so the hashes
+ * never line up: we match on title, file name and author instead.
+ */
+export const findReadEraDocForBook = (
+  docs: ReadEraDoc[],
+  book: ReadEraBookMatch,
+): ReadEraDoc | null => {
+  const titles = [book.title, book.sourceTitle].map(normalizeText).filter(Boolean);
+  if (!titles.length) return null;
+  const author = normalizeText(book.author);
+
+  let best: { doc: ReadEraDoc; score: number; notes: number } | null = null;
+  for (const doc of docs) {
+    if (!matchesFormat(doc.format, book.format)) continue;
+    const candidates = [doc.title, doc.fileName].map(normalizeText).filter(Boolean);
+    let score = 0;
+    for (const title of titles) {
+      for (const candidate of candidates) {
+        if (candidate === title) score = Math.max(score, 2);
+        else if (candidate.includes(title) || title.includes(candidate)) score = Math.max(score, 1);
+      }
+    }
+    if (!score) continue;
+    if (author && author === normalizeText(doc.author)) score += 1;
+    if (score < 2) continue;
+
+    const notes = doc.citations.length + doc.bookmarks.length;
+    if (!best || score > best.score || (score === best.score && notes > best.notes)) {
+      best = { doc, score, notes };
+    }
+  }
+  return best?.doc ?? null;
+};

--- a/apps/readest-app/src/utils/readera.ts
+++ b/apps/readest-app/src/utils/readera.ts
@@ -5,7 +5,8 @@
  * library: one entry per document with its metadata, reading position,
  * highlights (`citations`) and `bookmarks`. The book files themselves are not
  * part of the backup, so an import can only attach data to books the user
- * already has in Readest — hence the title/author matching below.
+ * already has in Readest — hence the title/author matching below, and the
+ * `doc_md5` fallback for the books it cannot name.
  *
  * Locators come in two shapes:
  * - reflowable formats use CREngine XPointers, the same family KOReader emits
@@ -13,6 +14,8 @@
  * - PDFs use MuPDF page paths (`/page[402]/block[10]/line[0]/char[1]@x:y`)
  *   where the page index is 0-based.
  */
+
+import { fullMD5, isMd5 } from './md5';
 
 export interface ReadEraPosition {
   ratio?: number;
@@ -40,6 +43,8 @@ export interface ReadEraDoc {
   format?: string;
   /** Original file name without extension. */
   fileName?: string;
+  /** md5 of the whole book file, as ReadEra recorded it. */
+  md5?: string;
   title?: string;
   author?: string;
   fileSize?: number;
@@ -123,6 +128,7 @@ const parseDoc = (value: unknown): ReadEraDoc | null => {
   return {
     format: asString(data['doc_format']),
     fileName: asString(data['doc_file_name_title']),
+    md5: asString(data['doc_md5']),
     title: asString(data['user_title']) ?? asString(data['doc_title']),
     author: asString(data['user_authors']) ?? asString(data['doc_authors']),
     fileSize: asNumber(data['doc_file_size']),
@@ -198,12 +204,18 @@ const normalizeText = (value: string | undefined): string =>
  * Whether one title contains the other closely enough to be the same book. An
  * edition or subtitle suffix keeps most of the longer string ("The Little
  * Prince" inside "The Little Prince (Illustrated)"); a sequel does not ("Dune"
- * inside "Dune Messiah"), and importing its annotations would write another
- * book's highlights into this one.
+ * inside "Dune Messiah" or "Dune 2"), and importing its annotations would write
+ * another book's highlights into this one. A short title carries too little of
+ * either signal, so it has to match exactly. Books this rejects are still found
+ * by `findReadEraDocByFileMd5` when the file is the one ReadEra read.
  */
+const MIN_CONTAINED_TITLE_LENGTH = 12;
+
 const containsTitle = (a: string, b: string): boolean => {
+  const shorter = Math.min(a.length, b.length);
+  if (shorter < MIN_CONTAINED_TITLE_LENGTH) return false;
   if (!a.includes(b) && !b.includes(a)) return false;
-  return Math.min(a.length, b.length) / Math.max(a.length, b.length) >= 0.5;
+  return shorter / Math.max(a.length, b.length) >= 0.5;
 };
 
 /** ReadEra formats that map onto a Readest book format of the same name. */
@@ -213,9 +225,10 @@ const matchesFormat = (docFormat: string | undefined, bookFormat: string | undef
 };
 
 /**
- * Pick the backup entry that belongs to `book`. ReadEra keys documents by the
- * sha1/md5 of the whole file while Readest uses a partial md5, so the hashes
- * never line up: we match on title, file name and author instead.
+ * Pick the backup entry that belongs to `book` by title, file name and author.
+ * ReadEra keys documents by the sha1/md5 of the whole file while Readest uses a
+ * partial md5, so the two hashes never line up on their own; when this decides
+ * nothing the caller hashes the file itself and uses `findReadEraDocByFileMd5`.
  */
 export const findReadEraDocForBook = (
   docs: ReadEraDoc[],
@@ -246,4 +259,32 @@ export const findReadEraDocForBook = (
     }
   }
   return best?.doc ?? null;
+};
+
+const fileMd5Cache = new Map<string, Promise<string>>();
+
+/**
+ * The md5 ReadEra keys a document by: of the whole file, not the `partialMD5`
+ * Readest keys books by. Reading a whole book is expensive, so the result is
+ * kept for the session, keyed by the book's own hash.
+ */
+export const getReadEraFileMd5 = (bookHash: string, file: File): Promise<string> => {
+  let hash = fileMd5Cache.get(bookHash);
+  if (!hash) {
+    hash = fullMD5(file);
+    fileMd5Cache.set(bookHash, hash);
+  }
+  return hash;
+};
+
+/**
+ * Pick the backup entry whose file is byte for byte the book being read. This
+ * is exact where the title matching above can only guess, but it costs a full
+ * read of the book, so the import reaches for it only when the titles decide
+ * nothing.
+ */
+export const findReadEraDocByFileMd5 = (docs: ReadEraDoc[], md5: string): ReadEraDoc | null => {
+  const wanted = md5.toLowerCase();
+  if (!isMd5(wanted)) return null;
+  return docs.find((doc) => doc.md5?.toLowerCase() === wanted) ?? null;
 };

--- a/apps/readest-app/src/utils/readera.ts
+++ b/apps/readest-app/src/utils/readera.ts
@@ -194,6 +194,18 @@ const normalizeText = (value: string | undefined): string =>
     .replace(/[^\p{L}\p{N}]+/gu, ' ')
     .trim();
 
+/**
+ * Whether one title contains the other closely enough to be the same book. An
+ * edition or subtitle suffix keeps most of the longer string ("The Little
+ * Prince" inside "The Little Prince (Illustrated)"); a sequel does not ("Dune"
+ * inside "Dune Messiah"), and importing its annotations would write another
+ * book's highlights into this one.
+ */
+const containsTitle = (a: string, b: string): boolean => {
+  if (!a.includes(b) && !b.includes(a)) return false;
+  return Math.min(a.length, b.length) / Math.max(a.length, b.length) >= 0.5;
+};
+
 /** ReadEra formats that map onto a Readest book format of the same name. */
 const matchesFormat = (docFormat: string | undefined, bookFormat: string | undefined): boolean => {
   if (!docFormat || !bookFormat) return true;
@@ -221,7 +233,7 @@ export const findReadEraDocForBook = (
     for (const title of titles) {
       for (const candidate of candidates) {
         if (candidate === title) score = Math.max(score, 2);
-        else if (candidate.includes(title) || title.includes(candidate)) score = Math.max(score, 1);
+        else if (containsTitle(candidate, title)) score = Math.max(score, 1);
       }
     }
     if (!score) continue;


### PR DESCRIPTION
Closes #5982

## The problem

#5982 asks for a way to bring a library over from another reader, ReadEra in particular: years of highlights, notes, bookmarks and reading progress that today have to be re-created by hand.

## The change

**ReadEra** joins Readest and Moon+ Reader in the per-book **Import Annotations** dialog. Open the book, pick the backup, and that book's highlights, notes, bookmarks and reading position land in it.

A ReadEra backup is `ReadEra-<plan>_<date>_<time>.bak`, a plain zip whose `library.json` carries the whole library: one entry per document with its metadata, `citations` (highlights, `note_type` 3) and `bookmarks` (`note_type` 2). It holds no book files at all, and ReadEra keys documents on the whole file's sha1/md5 while Readest uses a partial md5, so the hashes never line up: the entry for the open book is found by title, file name and author, filtered by format. Documents the user deleted stay in the backup with a `doc_delete_time` and are skipped.

Scope is the three things people actually lose in a move: highlights with their notes and colors, bookmarks, reading progress. Collections and reading status/rating are not imported.

## Anchoring

A note goes into the section its locator names, and inside that section it is placed by, in order: a whitespace-collapsed case-insensitive search for the highlighted text, then the recorded locator, then the start of the chapter. Only that last case counts as "not found" in the result toast. Bookmarks skip the text search, since their body is a label ("Bookmark 1") rather than an excerpt.

There are two shapes of locator, each with a trap:

- Reflowable formats use CREngine XPointers, the same family KOReader emits, except that ReadEra keeps the source document's own `body` inside the fragment (`/body/DocFragment[6]/body/body/...`, or `/body/html/body/...` on older DOM versions) and adds synthetic `autoBoxing` steps. `XCFI.resolveXPointerPath` resolves the tail against the section's own `<body>`, so both have to be stripped or every XPointer fallback misses. This is not an edge case: in the sample backup it is every reflowable locator.
- PDFs use MuPDF page paths (`/page[402]/block[10]/line[0]/char[1]@x:y`) whose page index is 0-based, while `DocFragment[N]` is 1-based.

Most reading positions, and every PDF bookmark in the sample backup, carry no path at all, only a page number. On a paged book the page is the section, so those are placed exactly and are not reported as unmatched. On a reflowable book that page number is ReadEra's own pagination and says nothing about the spine, so it is dropped rather than turned into a guess: #5980 was that mistake.

Since `XCFI` emits its own synthetic spine step, every result is rebased onto the section's real `cfi`, or onto `CFI.fake.fromIndex(index)` for PDF sections, which have none.

The reading position is adopted only when the book has no location of its own, so importing into a book you are midway through never moves you. Note ids are `readera-<note_uri>`, so importing the same backup twice is a no-op.

## Verification

`pnpm test`, `pnpm lint` and `pnpm format:check` are green.

- Unit tests for the parser, the book matcher, XPointer normalization, color mapping, the anchoring order and page-only locators.
- End to end: a ReadEra-shaped backup built inside the test and imported into the real `sample-alice.epub` and `sample-alice.pdf` through `DocumentLoader`, with every CFI it produces resolved back to the text it should cover. Both quirks above are load-bearing there: reverting the extra-`body` strip fails 4 of the 8 EPUB cases, and making the PDF page index 1-based fails both PDF cases.

The locator shapes and their proportions were established against the sample backup attached to the issue, a real personal library. That file is not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing annotations, bookmarks, and reading progress from ReadEra `.bak` backup files.
  * Added ReadEra as an import option in the annotation import dialog.
  * Added validation and feedback for invalid backups and books not found in a backup.
  * Added localized ReadEra import and horizontal panning lock text across supported languages.

* **Tests**
  * Added coverage for ReadEra backup parsing, annotation conversion, matching, and EPUB/PDF imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->