### PR TITLE
fix(sync): fit OAuth tokens in Windows keychain

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/desktop.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/desktop.rs
@@ -358,15 +358,17 @@ impl<R: Runtime> NativeBridge<R> {
     //
     // Same keychain backends + fail-loud/fail-soft contract as the sync
     // passphrase above, but each item gets its own keychain entry keyed by
-    // `key` (the item's `user`/account), so many independent secrets (the
-    // Drive token set, future provider tokens) coexist under one service
+    // `key` (the item's `user`/account), so many independent secrets (OAuth
+    // refresh tokens and future provider credentials) coexist under one service
     // without colliding with the passphrase entry (user "default").
 
     pub fn set_secure_item(
         &self,
         payload: SetSecureItemRequest,
     ) -> crate::Result<SecureItemResponse> {
-        match keyring_entry_for(&payload.key).and_then(|e| e.set_password(&payload.value)) {
+        match keyring_entry_for(&payload.key)
+            .and_then(|entry| set_secure_item_value(&entry, &payload.value))
+        {
             Ok(()) => Ok(SecureItemResponse {
                 success: true,
                 error: None,
@@ -382,7 +384,7 @@ impl<R: Runtime> NativeBridge<R> {
         &self,
         payload: GetSecureItemRequest,
     ) -> crate::Result<GetSecureItemResponse> {
-        match keyring_entry_for(&payload.key).and_then(|e| e.get_password()) {
+        match keyring_entry_for(&payload.key).and_then(|entry| get_secure_item_value(&entry)) {
             Ok(value) => Ok(GetSecureItemResponse {
                 value: Some(value),
                 error: None,
@@ -491,4 +493,104 @@ fn keyring_entry() -> std::result::Result<keyring_core::Entry, keyring_core::Err
 /// with the caller's `key` as the per-item account so each secret is distinct.
 fn keyring_entry_for(key: &str) -> std::result::Result<keyring_core::Entry, keyring_core::Error> {
     keyring_core::Entry::new(KEYRING_SERVICE, key)
+}
+
+// Windows Credential Manager caps generic credential blobs at 2,560 bytes.
+// `set_password` encodes strings as UTF-16, halving the usable space for the
+// opaque ASCII tokens stored here. Tagged UTF-8 keeps the full byte budget;
+// untagged entries remain readable through the legacy password path.
+#[cfg(any(target_os = "windows", test))]
+const WINDOWS_SECURE_ITEM_PREFIX: &[u8] = b"readest:utf8:v1:";
+
+#[cfg(any(target_os = "windows", test))]
+fn encode_windows_secure_item_value(value: &str) -> Vec<u8> {
+    [WINDOWS_SECURE_ITEM_PREFIX, value.as_bytes()].concat()
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn decode_windows_secure_item_value(
+    mut encoded: Vec<u8>,
+) -> std::result::Result<Option<String>, keyring_core::Error> {
+    if !encoded.starts_with(WINDOWS_SECURE_ITEM_PREFIX) {
+        return Ok(None);
+    }
+    encoded.drain(..WINDOWS_SECURE_ITEM_PREFIX.len());
+    String::from_utf8(encoded)
+        .map(Some)
+        .map_err(|err| keyring_core::Error::BadEncoding(err.into_bytes()))
+}
+
+fn set_secure_item_value(
+    entry: &keyring_core::Entry,
+    value: &str,
+) -> std::result::Result<(), keyring_core::Error> {
+    #[cfg(target_os = "windows")]
+    {
+        entry.set_secret(&encode_windows_secure_item_value(value))
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        entry.set_password(value)
+    }
+}
+
+fn get_secure_item_value(
+    entry: &keyring_core::Entry,
+) -> std::result::Result<String, keyring_core::Error> {
+    #[cfg(target_os = "windows")]
+    {
+        let encoded = entry.get_secret()?;
+        match decode_windows_secure_item_value(encoded)? {
+            Some(value) => Ok(value),
+            None => entry.get_password(),
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        entry.get_password()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        decode_windows_secure_item_value, encode_windows_secure_item_value,
+        WINDOWS_SECURE_ITEM_PREFIX,
+    };
+
+    #[test]
+    fn windows_secure_item_uses_utf8_without_losing_round_trip_fidelity() {
+        let value = "x".repeat(2_000);
+
+        // The legacy password path doubles ASCII into UTF-16 and exceeds
+        // Credential Manager's 2,560-byte generic-credential limit.
+        assert!(value.encode_utf16().count() * 2 > 2_560);
+
+        let encoded = encode_windows_secure_item_value(&value);
+        assert!(encoded.len() <= 2_560);
+        assert_eq!(
+            decode_windows_secure_item_value(encoded).unwrap(),
+            Some(value)
+        );
+    }
+
+    #[test]
+    fn windows_secure_item_detects_legacy_password_encoding() {
+        let encoded = "legacy"
+            .encode_utf16()
+            .flat_map(u16::to_le_bytes)
+            .collect();
+
+        assert_eq!(decode_windows_secure_item_value(encoded).unwrap(), None);
+    }
+
+    #[test]
+    fn windows_secure_item_rejects_invalid_tagged_utf8() {
+        let encoded = [WINDOWS_SECURE_ITEM_PREFIX, &[0xff]].concat();
+
+        assert!(matches!(
+            decode_windows_secure_item_value(encoded),
+            Err(keyring_core::Error::BadEncoding(_))
+        ));
+    }
 }

--- a/apps/readest-app/src/__tests__/services/sync/providers/oauth/keychainTokenStore.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/providers/oauth/keychainTokenStore.test.ts
@@ -29,18 +29,34 @@ const tokens = { accessToken: 'AT', refreshToken: 'RT', expiresAt: 123 };
 afterEach(() => vi.clearAllMocks());
 
 describe('KeychainTokenPersistence', () => {
-  test('save serialises through the keyed secure-KV and fails loud on rejection', async () => {
+  test('save persists only the refresh token when the full set exceeds the Windows limit', async () => {
+    const windowsOversizedTokens = {
+      accessToken: 'A'.repeat(1_800),
+      refreshToken: 'R'.repeat(600),
+      expiresAt: 123,
+    };
+    expect(JSON.stringify(windowsOversizedTokens).length * 2).toBeGreaterThan(2_560);
+
     vi.mocked(setSecureItem).mockResolvedValueOnce({ success: true });
-    await new KeychainTokenPersistence(KEY, LABEL).save(tokens);
+    await new KeychainTokenPersistence(KEY, LABEL).save(windowsOversizedTokens);
     expect(setSecureItem).toHaveBeenCalledWith({
       key: KEY,
-      value: JSON.stringify(tokens),
+      value: JSON.stringify({ refreshToken: windowsOversizedTokens.refreshToken }),
     });
+  });
 
+  test('save fails loud when the keychain rejects the refresh token', async () => {
     vi.mocked(setSecureItem).mockResolvedValueOnce({ success: false, error: 'denied' });
     await expect(new KeychainTokenPersistence(KEY, LABEL).save(tokens)).rejects.toBeInstanceOf(
       FileSyncError,
     );
+  });
+
+  test('save rejects a token set that cannot survive an app restart', async () => {
+    await expect(
+      new KeychainTokenPersistence(KEY, LABEL).save({ accessToken: 'AT', expiresAt: 123 }),
+    ).rejects.toMatchObject({ code: 'AUTH_FAILED' });
+    expect(setSecureItem).not.toHaveBeenCalled();
   });
 
   test('save error message includes the provider label', async () => {
@@ -48,15 +64,42 @@ describe('KeychainTokenPersistence', () => {
     await expect(new KeychainTokenPersistence(KEY, LABEL).save(tokens)).rejects.toThrow(LABEL);
   });
 
-  test('load parses a stored token set; returns null when absent or on error', async () => {
+  test('load expires a stored refresh token so the access token is reacquired', async () => {
+    vi.mocked(getSecureItem).mockResolvedValueOnce({
+      value: JSON.stringify({ refreshToken: tokens.refreshToken }),
+    });
+    expect(await new KeychainTokenPersistence(KEY, LABEL).load()).toEqual({
+      accessToken: '',
+      refreshToken: 'RT',
+      expiresAt: 0,
+    });
+  });
+
+  test('load migrates a legacy full token set; returns null when absent or on error', async () => {
     vi.mocked(getSecureItem).mockResolvedValueOnce({ value: JSON.stringify(tokens) });
-    expect(await new KeychainTokenPersistence(KEY, LABEL).load()).toEqual(tokens);
+    expect(await new KeychainTokenPersistence(KEY, LABEL).load()).toEqual({
+      accessToken: '',
+      refreshToken: 'RT',
+      expiresAt: 0,
+    });
 
     vi.mocked(getSecureItem).mockResolvedValueOnce({ error: 'no item' });
     expect(await new KeychainTokenPersistence(KEY, LABEL).load()).toBeNull();
 
     vi.mocked(getSecureItem).mockResolvedValueOnce({});
     expect(await new KeychainTokenPersistence(KEY, LABEL).load()).toBeNull();
+  });
+
+  test('load returns null for incomplete or malformed stored values', async () => {
+    vi.mocked(getSecureItem).mockResolvedValueOnce({
+      value: JSON.stringify({ accessToken: 'AT', expiresAt: 123 }),
+    });
+    expect(await new KeychainTokenPersistence(KEY, LABEL).load()).toBeNull();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(getSecureItem).mockResolvedValueOnce({ value: 'not json' });
+    expect(await new KeychainTokenPersistence(KEY, LABEL).load()).toBeNull();
+    expect(warn).toHaveBeenCalledWith(`[${LABEL}] token load failed`, expect.any(SyntaxError));
   });
 
   test('clear delegates to the keyed secure-KV', async () => {

--- a/apps/readest-app/src/services/sync/providers/oauth/keychainTokenStore.ts
+++ b/apps/readest-app/src/services/sync/providers/oauth/keychainTokenStore.ts
@@ -1,10 +1,12 @@
 /**
- * OS-keychain token persistence over the keyed secure-KV bridge, shared by every
- * OAuth provider. Keyed by a caller-supplied storage key so each provider owns a
- * distinct slot; `label` names the provider in error/log messages. `load` is
- * fail-soft (a keychain error reads as "not connected"); `save` is fail-loud (the
- * connect flow must know the token did not persist). No ephemeral fallback for
- * the refresh token — a provider is simply unavailable where secure storage is.
+ * OS-keychain refresh-token persistence over the keyed secure-KV bridge, shared
+ * by every OAuth provider. Access tokens stay in memory and are reacquired from
+ * the persisted refresh token after launch. Keyed by a caller-supplied storage
+ * key so each provider owns a distinct slot; `label` names the provider in
+ * error/log messages. `load` is fail-soft (a keychain error reads as "not
+ * connected"); `save` is fail-loud (the connect flow must know the token did not
+ * persist). No ephemeral fallback for the refresh token — a provider is simply
+ * unavailable where secure storage is.
  */
 import { isTauriAppPlatform } from '@/services/environment';
 import {
@@ -32,7 +34,11 @@ export class KeychainTokenPersistence implements TokenPersistence {
     try {
       const res = await getSecureItem({ key: this.key });
       if (res.error || !res.value) return null;
-      return JSON.parse(res.value) as TokenSet;
+      // Older builds stored the full TokenSet. Reading only refreshToken handles
+      // both formats and deliberately expires any legacy access token.
+      const stored = JSON.parse(res.value) as Partial<TokenSet>;
+      if (!stored.refreshToken) return null;
+      return { accessToken: '', refreshToken: stored.refreshToken, expiresAt: 0 };
     } catch (err) {
       console.warn(`[${this.label}] token load failed`, err);
       return null;
@@ -40,7 +46,16 @@ export class KeychainTokenPersistence implements TokenPersistence {
   }
 
   async save(tokens: TokenSet): Promise<void> {
-    const res = await setSecureItem({ key: this.key, value: JSON.stringify(tokens) });
+    if (!tokens.refreshToken) {
+      throw new FileSyncError(
+        `${this.label} did not issue a refresh token; reconnect`,
+        'AUTH_FAILED',
+      );
+    }
+    const res = await setSecureItem({
+      key: this.key,
+      value: JSON.stringify({ refreshToken: tokens.refreshToken }),
+    });
     if (!res.success) {
       throw new FileSyncError(
         `OS keychain rejected the ${this.label} token: ${res.error ?? 'unknown error'}`,


### PR DESCRIPTION
## Summary

- Persist only OAuth refresh tokens in the native keychain, then reacquire an access token after app restart.
- Store Windows secure-item values as version-tagged UTF-8 so OneDrive tokens fit within Credential Manager's 2,560-byte blob limit.
- Continue reading legacy UTF-16 keychain entries and legacy full-token JSON during migration.
- Add regression coverage for oversized token sets, legacy entries, malformed storage, and encoding boundaries.

Closes #5941

## Test Coverage

```text
CODE PATHS                                                        USER FLOWS
[+] keychainTokenStore.ts                                         [+] Windows OneDrive connection
  ├── save()                                                        ├── [TESTED] OAuth → save orchestration
  │   ├── [TESTED] persist refresh token only                       ├── [TESTED] rejection blocks connection
  │   ├── [TESTED] reject missing refresh token                     └── [GAP] live Windows Credential Manager E2E
  │   └── [TESTED] bridge rejection → AUTH_FAILED
  └── load()                                                       [+] Restart and token refresh
      ├── [TESTED] refresh-only JSON → expired TokenSet              └── [TESTED] expired token refreshes and resaves
      ├── [TESTED] legacy full JSON → expired TokenSet
      ├── [TESTED] missing/incomplete value → null
      └── [TESTED] malformed JSON → warn/null

[+] desktop.rs
  └── Windows secure-item encoding
      ├── [TESTED] 2,000-char tagged UTF-8 round trip fits 2,560 bytes
      ├── [TESTED] untagged legacy UTF-16 blob detection
      └── [TESTED] invalid tagged UTF-8 → BadEncoding
```

AI-assessed coverage: 14/15 paths (93%); all 11 changed code paths are unit-covered. The remaining gap requires a live Windows Credential Manager environment.

## Pre-Landing Review

No issues found. Scope check: clean. An adversarial review traced OneDrive/Google Drive persistence, refresh, connect, and native bridge paths.

## Design Review

No frontend UI files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Plan Completion

No relevant active plan detected.

## Documentation

No documentation changes required. This fix only changes internal OAuth token persistence and Windows keychain encoding; existing architecture and security documentation remains accurate.

## Test plan

- [x] `pnpm test` — full Vitest suite passes
- [x] `pnpm test:rust` — 128 Rust app tests pass
- [x] `pnpm exec vitest run src/__tests__/services/sync/providers/oauth/keychainTokenStore.test.ts` — 11 tests pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p tauri-plugin-native-bridge windows_secure_item --lib` — 3 tests pass
- [x] `cargo check --manifest-path src-tauri/Cargo.toml -p tauri-plugin-native-bridge --target x86_64-pc-windows-msvc`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm clippy:check`
- [x] `pnpm build`
- [ ] Manual OneDrive OAuth and restart test on Windows 11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure credential storage on Windows for larger values.
  * Added compatibility with credentials saved using the previous storage format.
  * OAuth synchronization now persists refresh tokens reliably and reacquires access tokens when needed.
  * Invalid, incomplete, or unavailable stored credentials are handled safely.
  * Saving authentication data without a refresh token now reports an authentication error.

* **Tests**
  * Added coverage for secure-storage compatibility, token persistence, malformed data, and invalid encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->