### PR TITLE
feat(sync): add a manual sync option for BookOrbit (#6029)

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2546,5 +2546,6 @@
   "This is not a ReadEra backup file.": "هذا ليس ملف نسخة احتياطية من ReadEra.",
   "This book was not found in the ReadEra backup.": "لم يتم العثور على هذا الكتاب في النسخة الاحتياطية من ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ملف نسخة احتياطية من ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "ملف نسخة احتياطية من ReadEra (.bak)",
+  "BookOrbit Sync": "مزامنة BookOrbit"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "এটি ReadEra ব্যাকআপ ফাইল নয়।",
   "This book was not found in the ReadEra backup.": "এই বইটি ReadEra ব্যাকআপে পাওয়া যায়নি।",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra ব্যাকআপ ফাইল (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra ব্যাকআপ ফাইল (.bak)",
+  "BookOrbit Sync": "BookOrbit সিঙ্ক"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2246,5 +2246,6 @@
   "This is not a ReadEra backup file.": "འདི་ནི་ ReadEra གྲབས་ཉར་ཡིག་ཆ་མིན།",
   "This book was not found in the ReadEra backup.": "དཔེ་དེབ་འདི་ ReadEra གྲབས་ཉར་ནང་མ་རྙེད།",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra གྲབས་ཉར་ཡིག་ཆ (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra གྲབས་ཉར་ཡིག་ཆ (.bak)",
+  "BookOrbit Sync": "BookOrbit ཟླ་སྒྲིག"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "Dies ist keine ReadEra-Sicherungsdatei.",
   "This book was not found in the ReadEra backup.": "Dieses Buch wurde in der ReadEra-Sicherung nicht gefunden.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra-Sicherungsdatei (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra-Sicherungsdatei (.bak)",
+  "BookOrbit Sync": "BookOrbit-Synchronisierung"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "Αυτό δεν είναι αρχείο αντιγράφου ασφαλείας ReadEra.",
   "This book was not found in the ReadEra backup.": "Αυτό το βιβλίο δεν βρέθηκε στο αντίγραφο ασφαλείας ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "Αρχείο αντιγράφου ασφαλείας ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "Αρχείο αντιγράφου ασφαλείας ReadEra (.bak)",
+  "BookOrbit Sync": "Συγχρονισμός BookOrbit"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2366,5 +2366,6 @@
   "This is not a ReadEra backup file.": "Este no es un archivo de copia de seguridad de ReadEra.",
   "This book was not found in the ReadEra backup.": "Este libro no se encontró en la copia de seguridad de ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "Archivo de copia de seguridad de ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "Archivo de copia de seguridad de ReadEra (.bak)",
+  "BookOrbit Sync": "Sincronización de BookOrbit"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "این یک فایل پشتیبان ReadEra نیست.",
   "This book was not found in the ReadEra backup.": "این کتاب در پشتیبان ReadEra پیدا نشد.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "فایل پشتیبان ReadEra ‏(.bak)"
+  "ReadEra backup file (.bak)": "فایل پشتیبان ReadEra ‏(.bak)",
+  "BookOrbit Sync": "همگام‌سازی BookOrbit"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2366,5 +2366,6 @@
   "This is not a ReadEra backup file.": "Ce n'est pas un fichier de sauvegarde ReadEra.",
   "This book was not found in the ReadEra backup.": "Ce livre n'a pas été trouvé dans la sauvegarde ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "Fichier de sauvegarde ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "Fichier de sauvegarde ReadEra (.bak)",
+  "BookOrbit Sync": "Synchronisation BookOrbit"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2366,5 +2366,6 @@
   "This is not a ReadEra backup file.": "זהו אינו קובץ גיבוי של ReadEra.",
   "This book was not found in the ReadEra backup.": "הספר הזה לא נמצא בגיבוי של ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "קובץ גיבוי של ReadEra ‏(.bak)"
+  "ReadEra backup file (.bak)": "קובץ גיבוי של ReadEra ‏(.bak)",
+  "BookOrbit Sync": "סנכרון BookOrbit"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "यह ReadEra बैकअप फ़ाइल नहीं है।",
   "This book was not found in the ReadEra backup.": "यह पुस्तक ReadEra बैकअप में नहीं मिली।",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra बैकअप फ़ाइल (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra बैकअप फ़ाइल (.bak)",
+  "BookOrbit Sync": "BookOrbit सिंक"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "Ez a fájl nem ReadEra biztonsági mentés.",
   "This book was not found in the ReadEra backup.": "Ez a könyv nem található a ReadEra biztonsági mentésben.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra biztonsági mentés fájlja (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra biztonsági mentés fájlja (.bak)",
+  "BookOrbit Sync": "BookOrbit szinkronizálás"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2246,5 +2246,6 @@
   "This is not a ReadEra backup file.": "Ini bukan file cadangan ReadEra.",
   "This book was not found in the ReadEra backup.": "Buku ini tidak ditemukan dalam cadangan ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "File cadangan ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "File cadangan ReadEra (.bak)",
+  "BookOrbit Sync": "Sinkronisasi BookOrbit"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2366,5 +2366,6 @@
   "This is not a ReadEra backup file.": "Questo non è un file di backup di ReadEra.",
   "This book was not found in the ReadEra backup.": "Questo libro non è stato trovato nel backup di ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "File di backup di ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "File di backup di ReadEra (.bak)",
+  "BookOrbit Sync": "Sincronizzazione BookOrbit"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2246,5 +2246,6 @@
   "This is not a ReadEra backup file.": "これは ReadEra のバックアップファイルではありません。",
   "This book was not found in the ReadEra backup.": "この本は ReadEra のバックアップに見つかりませんでした。",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra のバックアップファイル (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra のバックアップファイル (.bak)",
+  "BookOrbit Sync": "BookOrbit同期"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "ეს არ არის ReadEra-ს სარეზერვო ასლის ფაილი.",
   "This book was not found in the ReadEra backup.": "ეს წიგნი ვერ მოიძებნა ReadEra-ს სარეზერვო ასლში.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra-ს სარეზერვო ასლის ფაილი (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra-ს სარეზერვო ასლის ფაილი (.bak)",
+  "BookOrbit Sync": "BookOrbit სინქრონიზაცია"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2246,5 +2246,6 @@
   "This is not a ReadEra backup file.": "ReadEra 백업 파일이 아닙니다.",
   "This book was not found in the ReadEra backup.": "이 책을 ReadEra 백업에서 찾을 수 없습니다.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra 백업 파일 (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra 백업 파일 (.bak)",
+  "BookOrbit Sync": "BookOrbit 동기화"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2246,5 +2246,6 @@
   "This is not a ReadEra backup file.": "Ini bukan fail sandaran ReadEra.",
   "This book was not found in the ReadEra backup.": "Buku ini tidak ditemui dalam sandaran ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "Fail sandaran ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "Fail sandaran ReadEra (.bak)",
+  "BookOrbit Sync": "Penyegerakan BookOrbit"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "Dit is geen ReadEra-back-upbestand.",
   "This book was not found in the ReadEra backup.": "Dit boek is niet gevonden in de ReadEra-back-up.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra-back-upbestand (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra-back-upbestand (.bak)",
+  "BookOrbit Sync": "BookOrbit-synchronisatie"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2426,5 +2426,6 @@
   "This is not a ReadEra backup file.": "To nie jest plik kopii zapasowej ReadEra.",
   "This book was not found in the ReadEra backup.": "Nie znaleziono tej książki w kopii zapasowej ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "Plik kopii zapasowej ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "Plik kopii zapasowej ReadEra (.bak)",
+  "BookOrbit Sync": "Synchronizacja BookOrbit"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2366,5 +2366,6 @@
   "This is not a ReadEra backup file.": "Este não é um arquivo de backup do ReadEra.",
   "This book was not found in the ReadEra backup.": "Este livro não foi encontrado no backup do ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "Arquivo de backup do ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "Arquivo de backup do ReadEra (.bak)",
+  "BookOrbit Sync": "Sincronização do BookOrbit"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2366,5 +2366,6 @@
   "This is not a ReadEra backup file.": "Este não é um ficheiro de backup do ReadEra.",
   "This book was not found in the ReadEra backup.": "Este livro não foi encontrado no backup do ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "Ficheiro de backup do ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "Ficheiro de backup do ReadEra (.bak)",
+  "BookOrbit Sync": "Sincronização do BookOrbit"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2366,5 +2366,6 @@
   "This is not a ReadEra backup file.": "Acesta nu este un fișier de backup ReadEra.",
   "This book was not found in the ReadEra backup.": "Această carte nu a fost găsită în backupul ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "Fișier de backup ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "Fișier de backup ReadEra (.bak)",
+  "BookOrbit Sync": "Sincronizare BookOrbit"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2426,5 +2426,6 @@
   "This is not a ReadEra backup file.": "Это не файл резервной копии ReadEra.",
   "This book was not found in the ReadEra backup.": "Эта книга не найдена в резервной копии ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "Файл резервной копии ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "Файл резервной копии ReadEra (.bak)",
+  "BookOrbit Sync": "Синхронизация BookOrbit"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "මෙය ReadEra උපස්ථ ගොනුවක් නොවේ.",
   "This book was not found in the ReadEra backup.": "මෙම පොත ReadEra උපස්ථයේ හමු නොවීය.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra උපස්ථ ගොනුව (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra උපස්ථ ගොනුව (.bak)",
+  "BookOrbit Sync": "BookOrbit සමමුහුර්තකරණය"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2426,5 +2426,6 @@
   "This is not a ReadEra backup file.": "To ni datoteka varnostne kopije ReadEra.",
   "This book was not found in the ReadEra backup.": "Te knjige ni v varnostni kopiji ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "Datoteka varnostne kopije ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "Datoteka varnostne kopije ReadEra (.bak)",
+  "BookOrbit Sync": "Sinhronizacija BookOrbit"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "Det här är inte en ReadEra-säkerhetskopia.",
   "This book was not found in the ReadEra backup.": "Den här boken hittades inte i ReadEra-säkerhetskopian.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra-säkerhetskopia (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra-säkerhetskopia (.bak)",
+  "BookOrbit Sync": "BookOrbit-synkronisering"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "இது ReadEra காப்புப்பிரதி கோப்பு அல்ல.",
   "This book was not found in the ReadEra backup.": "இந்தப் புத்தகம் ReadEra காப்புப்பிரதியில் காணப்படவில்லை.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra காப்புப்பிரதி கோப்பு (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra காப்புப்பிரதி கோப்பு (.bak)",
+  "BookOrbit Sync": "BookOrbit ஒத்திசைவு"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2246,5 +2246,6 @@
   "This is not a ReadEra backup file.": "นี่ไม่ใช่ไฟล์สำรองข้อมูลของ ReadEra",
   "This book was not found in the ReadEra backup.": "ไม่พบหนังสือเล่มนี้ในข้อมูลสำรองของ ReadEra",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ไฟล์สำรองข้อมูลของ ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "ไฟล์สำรองข้อมูลของ ReadEra (.bak)",
+  "BookOrbit Sync": "การซิงค์ BookOrbit"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "Bu bir ReadEra yedek dosyası değil.",
   "This book was not found in the ReadEra backup.": "Bu kitap ReadEra yedeğinde bulunamadı.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra yedek dosyası (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra yedek dosyası (.bak)",
+  "BookOrbit Sync": "BookOrbit Senkronizasyonu"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2426,5 +2426,6 @@
   "This is not a ReadEra backup file.": "Це не файл резервної копії ReadEra.",
   "This book was not found in the ReadEra backup.": "Цю книгу не знайдено в резервній копії ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "Файл резервної копії ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "Файл резервної копії ReadEra (.bak)",
+  "BookOrbit Sync": "Синхронізація BookOrbit"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2306,5 +2306,6 @@
   "This is not a ReadEra backup file.": "Bu ReadEra zaxira nusxa fayli emas.",
   "This book was not found in the ReadEra backup.": "Bu kitob ReadEra zaxira nusxasida topilmadi.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra zaxira nusxa fayli (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra zaxira nusxa fayli (.bak)",
+  "BookOrbit Sync": "BookOrbit sinxronlash"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2246,5 +2246,6 @@
   "This is not a ReadEra backup file.": "Đây không phải tệp sao lưu ReadEra.",
   "This book was not found in the ReadEra backup.": "Không tìm thấy cuốn sách này trong bản sao lưu ReadEra.",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "Tệp sao lưu ReadEra (.bak)"
+  "ReadEra backup file (.bak)": "Tệp sao lưu ReadEra (.bak)",
+  "BookOrbit Sync": "Đồng bộ BookOrbit"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2246,5 +2246,6 @@
   "This is not a ReadEra backup file.": "这不是 ReadEra 备份文件。",
   "This book was not found in the ReadEra backup.": "未在 ReadEra 备份中找到本书。",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra 备份文件 (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra 备份文件 (.bak)",
+  "BookOrbit Sync": "BookOrbit 同步"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2246,5 +2246,6 @@
   "This is not a ReadEra backup file.": "這不是 ReadEra 備份檔案。",
   "This book was not found in the ReadEra backup.": "未在 ReadEra 備份中找到本書。",
   "ReadEra": "ReadEra",
-  "ReadEra backup file (.bak)": "ReadEra 備份檔案 (.bak)"
+  "ReadEra backup file (.bak)": "ReadEra 備份檔案 (.bak)",
+  "BookOrbit Sync": "BookOrbit 同步"
 }

--- a/apps/readest-app/src/__tests__/components/ViewMenu-sync-row.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ViewMenu-sync-row.test.tsx
@@ -137,6 +137,13 @@ describe('ViewMenu sync row (issue #5910)', () => {
     expect(events).toContain('push-file-sync');
     expect(events).toContain('pull-file-sync');
     expect(events).toContain('flush-kosync');
+    // BookOrbit's Auto Sync (#6029) can be off, and then nothing is ever
+    // pending for the flush above to send — so the row asks for a real push,
+    // addressed to BookOrbit so KOReader Sync keeps its flush-only behaviour.
+    expect(mockDispatch).toHaveBeenCalledWith('push-kosync', {
+      bookKey: 'book-1',
+      provider: 'bookorbit',
+    });
     expect(mockNavigateToLogin).not.toHaveBeenCalled();
   });
 

--- a/apps/readest-app/src/__tests__/hooks/bookOrbitProgressProvider.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/bookOrbitProgressProvider.test.ts
@@ -33,7 +33,20 @@ describe('bookOrbitProgressProvider.selectConfig', () => {
       deviceName: 'My Device',
       checksumMethod: 'binary',
       strategy: 'silent',
+      autoSync: true,
     });
+  });
+
+  it('carries the manual-sync opt-out through to the kosync engine (#6029)', () => {
+    // Settings written before Auto Sync existed have no flag at all; those
+    // users keep the automatic pushes they already had.
+    const legacy = makeSettings({});
+    delete (legacy.bookorbit as Partial<BookOrbitSettings>).autoSync;
+    expect(bookOrbitProgressProvider.selectConfig(legacy)?.autoSync).toBe(true);
+
+    expect(
+      bookOrbitProgressProvider.selectConfig(makeSettings({ autoSync: false }))?.autoSync,
+    ).toBe(false);
   });
 
   it('returns null when disabled, progress sync is off, or credentials are missing', () => {

--- a/apps/readest-app/src/__tests__/hooks/useKOSync.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useKOSync.test.tsx
@@ -152,7 +152,7 @@ vi.mock('@/utils/event', () => ({
   },
 }));
 
-import { useKOSync } from '@/app/reader/hooks/useKOSync';
+import { useKOSync, type KosyncProgressProvider } from '@/app/reader/hooks/useKOSync';
 
 const flushMicrotasks = async () => {
   for (let i = 0; i < 30; i++) await Promise.resolve();
@@ -384,5 +384,126 @@ describe('useKOSync — no phantom re-prompt after resolving (#5527)', () => {
     });
 
     expect(result.current.syncState).toBe('conflict');
+  });
+});
+
+describe('useKOSync — manual sync mode (#6029)', () => {
+  // Turning BookOrbit's Auto Sync off must stop every push Readest makes on
+  // its own, so the server stops accumulating a progress log entry every few
+  // minutes. Pulls stay automatic — they add no server-side clutter and are
+  // what keeps a second device in step. BookOrbit reaches this hook as a
+  // provider whose config carries the flag; KOReader Sync never sets it.
+  const manualBookOrbit: KosyncProgressProvider = {
+    name: 'bookorbit',
+    selectConfig: (settings) => ({ ...settings.kosync, autoSync: false }),
+  };
+  const turnPage = async (rerender: () => void) => {
+    h.localProgress = {
+      ...(h.localProgress as Record<string, unknown>),
+      location: 'epubcfi(/6/4!/4/2/8)',
+    };
+    rerender();
+    await advance(KOSYNC_PUSH_DEBOUNCE_MS + 500);
+  };
+
+  const fire = async (name: string, detail: Record<string, unknown>) => {
+    await act(async () => {
+      for (const listener of h.eventListeners.get(name) ?? []) {
+        listener({ detail } as CustomEvent);
+      }
+      await flushMicrotasks();
+    });
+  };
+
+  beforeEach(() => {
+    h.settings.kosync.strategy = 'silent';
+  });
+
+  test('does NOT auto-push on a page turn', async () => {
+    const { rerender } = renderHook(() => useKOSync('h1-view1', manualBookOrbit));
+    await settle();
+    await turnPage(rerender);
+
+    expect(h.updateProgressMock).not.toHaveBeenCalled();
+  });
+
+  test('does NOT push when the window is deactivated', async () => {
+    renderHook(() => useKOSync('h1-view1', manualBookOrbit));
+    await settle();
+
+    await act(async () => {
+      h.activeCallback?.(false);
+      await flushMicrotasks();
+    });
+
+    expect(h.updateProgressMock).not.toHaveBeenCalled();
+  });
+
+  test('still pulls automatically on open', async () => {
+    renderHook(() => useKOSync('h1-view1', manualBookOrbit));
+    await settle();
+
+    expect(h.getProgressMock).toHaveBeenCalled();
+    expect(h.goTo).toHaveBeenCalledWith('epubcfi(/6/650!/4/2/6)');
+  });
+
+  test('still pushes on an explicit push-kosync request', async () => {
+    const { rerender } = renderHook(() => useKOSync('h1-view1', manualBookOrbit));
+    await settle();
+    await turnPage(rerender);
+    expect(h.updateProgressMock).not.toHaveBeenCalled();
+
+    await fire('push-kosync', { bookKey: 'h1-view1' });
+
+    expect(h.updateProgressMock).toHaveBeenCalled();
+  });
+});
+
+describe('useKOSync — provider-scoped manual sync events (#6029)', () => {
+  // Both the KOSync and the BookOrbit hook instances listen on the same
+  // event names, so a menu entry meant for one server would otherwise push
+  // to both. A `provider` in the detail addresses exactly one instance;
+  // an event without one still broadcasts (book close, the Sync row).
+  const fire = async (name: string, detail: Record<string, unknown>) => {
+    await act(async () => {
+      for (const listener of h.eventListeners.get(name) ?? []) {
+        listener({ detail } as CustomEvent);
+      }
+      await flushMicrotasks();
+    });
+  };
+
+  beforeEach(() => {
+    h.settings.kosync.strategy = 'silent';
+  });
+
+  test('ignores a push addressed to another provider', async () => {
+    renderHook(() => useKOSync('h1-view1'));
+    await settle();
+    h.updateProgressMock.mockClear();
+
+    await fire('push-kosync', { bookKey: 'h1-view1', provider: 'bookorbit' });
+
+    expect(h.updateProgressMock).not.toHaveBeenCalled();
+  });
+
+  test('honours a push addressed to this provider', async () => {
+    renderHook(() => useKOSync('h1-view1'));
+    await settle();
+    h.updateProgressMock.mockClear();
+
+    await fire('push-kosync', { bookKey: 'h1-view1', provider: 'kosync' });
+
+    expect(h.updateProgressMock).toHaveBeenCalled();
+  });
+
+  test('ignores a pull addressed to another provider', async () => {
+    renderHook(() => useKOSync('h1-view1'));
+    await settle();
+    h.getProgressMock.mockClear();
+
+    await fire('pull-kosync', { bookKey: 'h1-view1', provider: 'bookorbit' });
+
+    expect(h.getProgressMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/readest-app/src/app/reader/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/ViewMenu.tsx
@@ -151,6 +151,9 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
     eventDispatcher.dispatch('push-file-sync', { bookKey });
     eventDispatcher.dispatch('pull-file-sync', { bookKey });
     eventDispatcher.dispatch('flush-kosync', { bookKey });
+    // BookOrbit may be in manual mode (#6029), where nothing is ever pending
+    // and the flush above does nothing, so ask it for a real push.
+    eventDispatcher.dispatch('push-kosync', { bookKey, provider: 'bookorbit' });
   };
 
   const handleStartRSVP = () => {

--- a/apps/readest-app/src/app/reader/components/sidebar/BookMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/BookMenu.tsx
@@ -103,12 +103,14 @@ const BookMenu: React.FC<BookMenuProps> = ({ menuClassName, setIsDropdownOpen })
     setProofreadRulesVisibility(true);
     setIsDropdownOpen?.(false);
   };
-  const handlePullKOSync = () => {
-    eventDispatcher.dispatch('pull-kosync', { bookKey: sideBarBookKey });
+  // `provider` addresses one sync backend: KOSync and BookOrbit speak the same
+  // protocol through the same hook and would otherwise both answer.
+  const handlePullKOSync = (provider: 'kosync' | 'bookorbit') => () => {
+    eventDispatcher.dispatch('pull-kosync', { bookKey: sideBarBookKey, provider });
     setIsDropdownOpen?.(false);
   };
-  const handlePushKOSync = () => {
-    eventDispatcher.dispatch('push-kosync', { bookKey: sideBarBookKey });
+  const handlePushKOSync = (provider: 'kosync' | 'bookorbit') => () => {
+    eventDispatcher.dispatch('push-kosync', { bookKey: sideBarBookKey, provider });
     setIsDropdownOpen?.(false);
   };
   const handlePushReadwise = () => {
@@ -134,6 +136,7 @@ const BookMenu: React.FC<BookMenuProps> = ({ menuClassName, setIsDropdownOpen })
     setIsDropdownOpen?.(false);
   };
   const hardcoverLink = sideBarBookKey ? getConfig(sideBarBookKey)?.hardcover : undefined;
+  const bookOrbitProgressSync = settings.bookorbit.enabled && settings.bookorbit.syncProgress;
   // Routed through Annotator (per-book, long-lived) so that the
   // confirmation dialog isn't unmounted with the dropdown menu.
   const handleClearAnnotations = () => {
@@ -190,6 +193,7 @@ const BookMenu: React.FC<BookMenuProps> = ({ menuClassName, setIsDropdownOpen })
           <MenuItem label={_('Enter Parallel Read')} onClick={handleSetParallel} />
         ))}
       {(settings.kosync.enabled ||
+        bookOrbitProgressSync ||
         settings.readwise.enabled ||
         settings.hardcover.enabled ||
         (settings.notion.enabled && settings.notion.accessToken && settings.notion.databaseId)) && (
@@ -198,8 +202,16 @@ const BookMenu: React.FC<BookMenuProps> = ({ menuClassName, setIsDropdownOpen })
       {settings.kosync.enabled && (
         <MenuItem label={_('KOReader Sync')} detailsOpen={false} buttonClass='py-2'>
           <ul className='flex flex-col ps-1'>
-            <MenuItem label={_('Push Progress')} noIcon onClick={handlePushKOSync} />
-            <MenuItem label={_('Pull Progress')} noIcon onClick={handlePullKOSync} />
+            <MenuItem label={_('Push Progress')} noIcon onClick={handlePushKOSync('kosync')} />
+            <MenuItem label={_('Pull Progress')} noIcon onClick={handlePullKOSync('kosync')} />
+          </ul>
+        </MenuItem>
+      )}
+      {bookOrbitProgressSync && (
+        <MenuItem label={_('BookOrbit Sync')} detailsOpen={false} buttonClass='py-2'>
+          <ul className='flex flex-col ps-1'>
+            <MenuItem label={_('Push Progress')} noIcon onClick={handlePushKOSync('bookorbit')} />
+            <MenuItem label={_('Pull Progress')} noIcon onClick={handlePullKOSync('bookorbit')} />
           </ul>
         </MenuItem>
       )}

--- a/apps/readest-app/src/app/reader/hooks/bookOrbitProgressProvider.ts
+++ b/apps/readest-app/src/app/reader/hooks/bookOrbitProgressProvider.ts
@@ -28,6 +28,9 @@ export const bookOrbitProgressProvider: KosyncProgressProvider = {
       deviceName: bookorbit.deviceName,
       checksumMethod: 'binary',
       strategy: bookorbit.strategy,
+      // Settings saved before Auto Sync existed carry no flag; those users
+      // keep the automatic pushes they already had.
+      autoSync: bookorbit.autoSync ?? true,
     };
   },
 };

--- a/apps/readest-app/src/app/reader/hooks/useKOSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useKOSync.ts
@@ -37,8 +37,22 @@ type SyncState = 'idle' | 'checking' | 'conflict' | 'synced' | 'error';
  */
 export interface KosyncProgressProvider {
   name: 'kosync' | 'bookorbit';
-  selectConfig: (settings: SystemSettings) => KOSyncSettings | null;
+  selectConfig: (settings: SystemSettings) => KosyncEngineConfig | null;
 }
+
+/**
+ * What this hook actually drives: the KOSync wire settings plus the knobs a
+ * provider adds on top. `settings.kosync` satisfies it as-is.
+ */
+export type KosyncEngineConfig = KOSyncSettings & {
+  /**
+   * Manual-sync opt-out (#6029), set by BookOrbit only. When false the hook
+   * never pushes on its own; the server hears from us only on an explicit
+   * 'push-kosync'. Pulls stay automatic. Absent means automatic pushes, which
+   * is what KOReader Sync has always done.
+   */
+  autoSync?: boolean;
+};
 
 export const kosyncProvider: KosyncProgressProvider = {
   name: 'kosync',
@@ -397,16 +411,28 @@ export const useKOSync = (bookKey: string, provider: KosyncProgressProvider = ko
     syncRefs.current = { pushProgress, pullProgress };
   }, [pushProgress, pullProgress]);
 
+  // The KOSync and BookOrbit instances of this hook listen on the same event
+  // names, so a book-menu entry meant for one server would otherwise reach
+  // both. `detail.provider` addresses exactly one instance; an event without
+  // one still broadcasts (book close, the reader's Sync row).
+  const providerName = provider.name;
+  const isAddressedHere = useCallback(
+    (event: CustomEvent) =>
+      event.detail.bookKey === bookKey &&
+      (!event.detail.provider || event.detail.provider === providerName),
+    [bookKey, providerName],
+  );
+
   useEffect(() => {
     const handlePushProgress = (event: CustomEvent) => {
       const { pushProgress } = syncRefs.current;
-      if (event.detail.bookKey !== bookKey) return;
+      if (!isAddressedHere(event)) return;
       pushProgress();
       pushProgress.flush();
     };
     const handleFlush = (event: CustomEvent) => {
       const { pushProgress } = syncRefs.current;
-      if (event.detail.bookKey !== bookKey) return;
+      if (!isAddressedHere(event)) return;
       pushProgress.flush();
     };
     eventDispatcher.on('push-kosync', handlePushProgress);
@@ -417,11 +443,11 @@ export const useKOSync = (bookKey: string, provider: KosyncProgressProvider = ko
       eventDispatcher.off('flush-kosync', handleFlush);
       pushProgress.flush();
     };
-  }, [bookKey]);
+  }, [isAddressedHere]);
 
   useEffect(() => {
     const handlePullProgress = (event: CustomEvent) => {
-      if (event.detail.bookKey !== bookKey) return;
+      if (!isAddressedHere(event)) return;
       const { pullProgress } = syncRefs.current;
       pullProgress();
     };
@@ -429,7 +455,7 @@ export const useKOSync = (bookKey: string, provider: KosyncProgressProvider = ko
     return () => {
       eventDispatcher.off('pull-kosync', handlePullProgress);
     };
-  }, [bookKey]);
+  }, [isAddressedHere]);
 
   // Pull: pull progress once when the book is opened
   useEffect(() => {
@@ -446,7 +472,9 @@ export const useKOSync = (bookKey: string, provider: KosyncProgressProvider = ko
       // via the 'push-kosync' event are still respected (explicit user intent).
       if (useReaderStore.getState().getViewState(bookKey)?.previewMode) return;
       const config = provider.selectConfig(settings);
-      if (config?.enabled && config.strategy !== 'receive') {
+      // Auto Sync off (#6029): the server only hears from us when the user
+      // asks, via 'push-kosync'. Pulls below stay automatic.
+      if (config?.enabled && config.strategy !== 'receive' && config.autoSync !== false) {
         syncRefs.current.pushProgress();
       }
     }
@@ -460,6 +488,9 @@ export const useKOSync = (bookKey: string, provider: KosyncProgressProvider = ko
       hasPulledOnce.current = false;
       pullProgress();
     } else {
+      // Nothing is ever pending in manual mode, so this pair would be the one
+      // automatic push that still got through — schedule then flush.
+      if (provider.selectConfig(useSettingsStore.getState().settings)?.autoSync === false) return;
       pushProgress();
       pushProgress.flush();
     }

--- a/apps/readest-app/src/components/settings/integrations/BookOrbitForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/BookOrbitForm.tsx
@@ -178,6 +178,13 @@ const BookOrbitForm: React.FC<BookOrbitFormProps> = ({ onBack }) => {
     await saveSettings(envConfig, newSettings);
   };
 
+  const handleToggleAutoSync = async () => {
+    const bookorbit = { ...settings.bookorbit, autoSync: settings.bookorbit.autoSync === false };
+    const newSettings = { ...settings, bookorbit };
+    setSettings(newSettings);
+    await saveSettings(envConfig, newSettings);
+  };
+
   const handleStrategyChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const bookorbit = { ...settings.bookorbit, strategy: e.target.value as KOSyncStrategy };
     const newSettings = { ...settings, bookorbit };
@@ -205,6 +212,17 @@ const BookOrbitForm: React.FC<BookOrbitFormProps> = ({ onBack }) => {
               <label className='flex min-h-14 items-center justify-between px-4'>
                 <SettingLabel>{_('Sync Server Connected')}</SettingLabel>
                 <Toggle checked={settings.bookorbit.enabled} onChange={handleToggleEnabled} />
+              </label>
+              {/* Off = manual sync (#6029): progress is only pushed from the
+                  book menu's "Push Progress" or the reader's Sync row, so the
+                  server's reading log isn't filled with debounce-sized
+                  updates. Pulls stay automatic. */}
+              <label className='flex min-h-14 items-center justify-between px-4'>
+                <SettingLabel>{_('Auto Sync')}</SettingLabel>
+                <Toggle
+                  checked={settings.bookorbit.autoSync !== false}
+                  onChange={handleToggleAutoSync}
+                />
               </label>
               <div className='flex min-h-14 items-center justify-between gap-3 px-4'>
                 <SettingLabel>{_('Sync Strategy')}</SettingLabel>

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -94,6 +94,7 @@ export const DEFAULT_BOOKORBIT_SETTINGS = {
   syncNotes: true,
   syncStats: true,
   syncBookStates: true,
+  autoSync: true,
 } as BookOrbitSettings;
 
 export const READWISE_API_BASE_URL = 'https://readwise.io/api/v2';

--- a/apps/readest-app/src/types/settings.ts
+++ b/apps/readest-app/src/types/settings.ts
@@ -113,6 +113,15 @@ export interface BookOrbitSettings {
   syncStats: boolean;
   syncBookStates: boolean;
   customHeaders?: Record<string, string>;
+  /**
+   * Manual-sync opt-out (#6029). BookOrbit records a reading log entry per
+   * push, so a few hours of reading buries the real sessions under
+   * debounce-sized updates. With this off nothing is pushed until the user
+   * asks; pulls stay automatic (they add nothing server-side and are what
+   * keeps a second device in step). Default ON — settings written before this
+   * option existed keep the automatic pushes they already had.
+   */
+  autoSync?: boolean;
 }
 
 export interface ReadwiseSettings {


### PR DESCRIPTION
Closes part of #6029.

BookOrbit records a reading log entry per push, so a few hours of reading buries the real sessions under debounce-sized updates. Hardcover already offers an **Auto Sync** toggle for exactly this; this gives BookOrbit the same opt-out.

**KOReader Sync is deliberately left alone** — it mirrors what KOReader itself does, and `KOSyncForm` / the persisted `KOSyncSettings` shape are untouched.

### Behaviour

With **Auto Sync** off, Readest never pushes progress on its own:

- the auto-push effect and the window-deactivate push are gated
- the book menu's **Push Progress** and the reader's **Sync** row still push

The gate sits in the *callers* of the debounced pusher rather than inside `pushProgress`, so explicit requests always get through (same shape as `useHardcoverSync`).

**Pulls stay automatic.** They add nothing to the server's reading log — which is the actual complaint — and gating them would break cross-device sync and the `hasPulledOnce` guard that prevents #5065-style clobbering.

**Default is on.** Auto-push is the pre-existing behaviour, and settings written before this option existed carry no flag, so an absent value reads as on. The flag lives on a new `KosyncEngineConfig` (`KOSyncSettings & { autoSync? }`), the shape a provider hands the shared hook, so only BookOrbit ever sets it.

### Three fixes needed to make manual sync reachable

- `push-kosync` / `pull-kosync` were answered by **both** instances of `useKOSync`, since KOSync and BookOrbit share the hook and the event names. An optional `detail.provider` now addresses one backend; an event without one still broadcasts (book close, the Sync row).
- BookOrbit had **no** book-menu entries at all, so manual sync was impossible. Adds a **BookOrbit Sync** submenu with Push / Pull Progress (new i18n key across 34 locales).
- The reader's Sync row only dispatched `flush-kosync`, and a debounce flush is a no-op when nothing is pending, so the row did nothing in manual mode. It now also dispatches `push-kosync` addressed to BookOrbit, leaving KOSync's flush-only behaviour intact.

### Not included

The other half of #6029 — pushing only after a ~10% progress increment / on book close — is not implemented here.

### Verification

- `pnpm test` — 892 files passed / 4 skipped, 10753 tests passed / 16 skipped
- `pnpm lint`, `pnpm format:check` — clean
- Browser-verified in `pnpm dev-web`: provider addressing confirmed by endpoint path (`/syncs/progress` vs `/api/v1/koreader/syncs/progress`). Auto-push itself is unit-test-only, since without a reachable server `hasPulledOnce` never flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Auto Sync setting for BookOrbit, enabled by default.
  * Users can disable automatic progress uploads while continuing to receive automatic progress updates.
  * Added BookOrbit synchronization actions to the reader menu, including manual sync support.
  * Sync actions now apply only to the selected synchronization provider.
  * Added BookOrbit Sync translations across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->