### PR TITLE
fix(annotator): keep the annotation toolbar below the range handles

### DIFF
--- a/apps/readest-app/e2e/tests/annotation.spec.ts
+++ b/apps/readest-app/e2e/tests/annotation.spec.ts
@@ -107,8 +107,11 @@ test.describe('Annotation', () => {
   // ever on top is that both layers were z-50 in one stacking context, so the
   // tie broke on DOM order and the range editors are rendered last. Any surface
   // that forgets to join that gate — the note editor did — gets handles drawn
-  // over it. Pin the layer order itself, read off the live DOM.
-  test('draws the range-edit handles below the popup layer', async ({ openBook }) => {
+  // over it. The selection toolbar is the exception: it opens against the
+  // selection, so it overlaps the handles hanging off it, and the handles must
+  // keep those pixels or the covered part of a handle stops dragging and fires
+  // a tool button instead. Pin both halves of that order, read off the live DOM.
+  test('draws the range-edit handles above the selection toolbar', async ({ openBook }) => {
     const reader = await openBook();
 
     await reader.selectText();
@@ -120,19 +123,23 @@ test.describe('Annotation', () => {
     await expect(reader.rangeHandles).toHaveCount(2);
 
     const layers = await reader.page.evaluate(() => {
-      const handleLayer = document
-        .querySelector('[data-testid="selection-handle"]')
-        ?.closest('div.fixed');
+      const zIndexOf = (el: Element | null | undefined) =>
+        el ? getComputedStyle(el).zIndex : null;
+      const handle = document.querySelector('[data-testid="selection-handle"]');
       const popup = document.querySelector('.selection-popup');
       return {
-        handles: handleLayer ? getComputedStyle(handleLayer).zIndex : null,
-        popup: popup ? getComputedStyle(popup).zIndex : null,
+        handles: zIndexOf(handle?.closest('div.fixed')),
+        toolbar: zIndexOf(popup?.closest('div.fixed')),
+        // Where the lookup popups and the note editor sheet sit. They unmount
+        // the handles, but the layer they share must still outrank them.
+        popupLayer: zIndexOf(popup),
       };
     });
 
     expect(layers.handles).not.toBeNull();
-    expect(layers.popup).not.toBeNull();
-    expect(Number(layers.handles)).toBeLessThan(Number(layers.popup));
+    expect(layers.toolbar).not.toBeNull();
+    expect(Number(layers.toolbar)).toBeLessThan(Number(layers.handles));
+    expect(Number(layers.handles)).toBeLessThan(Number(layers.popupLayer));
   });
 
   test('hides the range-edit handles while the dictionary popup is open (#5815)', async ({

--- a/apps/readest-app/src/__tests__/android/helpers/reader.ts
+++ b/apps/readest-app/src/__tests__/android/helpers/reader.ts
@@ -428,10 +428,16 @@ export const getSelectionState = (page: CdpPage) =>
     return { exists: false, collapsed: true, text: '', startOffset: -1, startText: '' };
   `);
 
-/** The app's own selection drag handles (SelectionRangeEditor) in the top document. */
+/**
+ * The app's own selection drag handles (SelectionRangeEditor) in the top
+ * document. Keyed on the handle's test id, not on its `cursor-grab` class:
+ * the highlight style/color strip in the annotation popup carries the same
+ * class, so a class-based query counts it as a third handle whenever the
+ * highlight tool is on the toolbar (#6031).
+ */
 export const getCustomHandles = (page: CdpPage) =>
   page.evaluate<{ x: number; y: number }[]>(`
-    return [...document.querySelectorAll('div.cursor-grab')].map((el) => {
+    return [...document.querySelectorAll('[data-testid="selection-handle"]')].map((el) => {
       const r = el.getBoundingClientRect();
       return { x: r.x, y: r.y, w: r.width, h: r.height };
     });

--- a/apps/readest-app/src/__tests__/android/selection.android.test.ts
+++ b/apps/readest-app/src/__tests__/android/selection.android.test.ts
@@ -156,6 +156,46 @@ describe.runIf(env)('Android text selection over CDP (#1553)', () => {
     expect(sel.text.endsWith(targets.dragWord.word)).toBe(true);
   });
 
+  // The toolbar opens against the selection, which is exactly where the end
+  // handle's stem and ball hang. When the toolbar won that overlap the covered
+  // part of the handle stopped dragging and started firing whichever tool
+  // button was under the finger: the drag test above fails, but only after a
+  // 15s timeout that says nothing about why. Pin the hit test itself.
+  it('keeps the annotation toolbar out of the handles grab area', async () => {
+    await longPressWord(page, targets.prefix, targets.firstWord);
+    await waitFor(async () => (await getCustomHandles(page)).length === 2, {
+      label: 'app handles',
+    });
+
+    const probe = await page.evaluate<{ overlapping: number; swallowed: string[] }>(`
+      const popup = document.querySelector('.selection-popup')?.getBoundingClientRect();
+      const swallowed = [];
+      let overlapping = 0;
+      for (const handle of document.querySelectorAll('[data-testid="selection-handle"]')) {
+        const r = handle.getBoundingClientRect();
+        if (!popup || r.left >= popup.right || r.right <= popup.left ||
+            r.top >= popup.bottom || r.bottom <= popup.top) continue;
+        overlapping++;
+        for (const [fx, fy] of [[0.5, 0.2], [0.5, 0.5], [0.5, 0.8], [0.25, 0.5], [0.75, 0.5]]) {
+          const x = r.left + r.width * fx;
+          const y = r.top + r.height * fy;
+          if (document.elementFromPoint(x, y)?.closest('.selection-popup')) {
+            swallowed.push(Math.round(x) + ',' + Math.round(y));
+          }
+        }
+      }
+      return { overlapping, swallowed };
+    `);
+
+    // Guard the premise: with no overlap there is nothing for the layer order
+    // to decide and the assertion below would pass for the wrong reason.
+    expect(probe.overlapping).toBeGreaterThan(0);
+    expect(
+      probe.swallowed,
+      `the toolbar intercepts points inside a handle: ${probe.swallowed.join(' ')}`,
+    ).toEqual([]);
+  });
+
   it('keeps native selection handles for mid-paragraph selections', async () => {
     await longPressWord(page, targets.prefix, targets.midWord);
     const sel = await getSelectionState(page);

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationPopup.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationPopup.tsx
@@ -78,14 +78,28 @@ const AnnotationPopup: React.FC<AnnotationPopupProps> = ({
   const boxWidth = isVertical ? popupHeight : popupWidth;
   const boxHeight = isVertical ? popupWidth : popupHeight;
   return (
-    <div dir={dir}>
+    // The toolbar opens against the selection, which is where the range
+    // editors' handles hang: the two overlap by design, and whichever layer
+    // wins owns those pixels. The handles are grab targets, so they take it —
+    // under the toolbar their covered part stops dragging and fires whichever
+    // tool button it landed on instead. Hence z-[43], below the handle layer
+    // (z-[44]) but still above the paragraph/TTS chrome (z-40). Every other
+    // popup surface stays at z-50 and above the handles, which is why the
+    // wrapper is `fixed inset-0`: it makes the stacking context without
+    // moving the popup, whose containing block is still the viewport.
+    // `pointer-events-none` keeps the full-screen wrapper from swallowing the
+    // taps outside the popup that dismiss it.
+    <div dir={dir} className='pointer-events-none fixed inset-0 z-[43]'>
       <Popup
         width={boxWidth}
         height={boxHeight}
         minHeight={boxHeight}
         position={position}
         trianglePosition={trianglePosition}
-        className={clsx('selection-popup', (notes.length > 0 || noteEditor) && 'bg-transparent')}
+        className={clsx(
+          'selection-popup pointer-events-auto',
+          (notes.length > 0 || noteEditor) && 'bg-transparent',
+        )}
         onDismiss={onDismiss}
       >
         <div className={clsx('flex h-full gap-4', isVertical ? 'flex-row' : 'flex-col')}>


### PR DESCRIPTION
Fixes the red [Android E2E (CDP)](https://github.com/readest/readest/actions/runs/33673882019/job/100393802442) lane. Two independent causes, one of them a real UX regression.

## 1. The handle helper counted the wrong elements

`getCustomHandles` matched `div.cursor-grab`. #6031 made `HighlightOptions`' style/colour strip render on every selection when the highlight tool is on the toolbar, and that strip carries the same class, so every count came back one too high (`expected 1 to be +0`) and the `length === 2` / `length === 0` waits timed out after 15s with a message that said nothing about why.

Now keyed on the handle's own `data-testid="selection-handle"`.

## 2. The selection toolbar was swallowing the end handle

With the count fixed, both end-handle drag tests stayed red for a real reason. #6013 demoted the range-editor layer from `z-50` to `z-[44]` but left `.selection-popup` at `z-50`. The toolbar opens against the selection, which is exactly where the end handle's stem and ball hang, so it took those pixels. Measured on device at the drag test's grab point:

```
endHandle rect = 15,277,30,45 ; grab point = 30.3,309.6
elementFromPoint -> DIV.selection-buttons  (.popup-container z=50, rect 13,305,367,55)
```

The covered bottom ~17px of the handle stopped dragging and fired whichever tool button was under the finger instead. That ships today; CI only stayed quiet because the count wait failed first.

Fix is a band for the toolbar below the handles rather than a revert of #6013: `AnnotationPopup`'s `Popup` now renders inside `<div className='pointer-events-none fixed inset-0 z-[43]'>`. `fixed inset-0` makes the stacking context without moving the popup (its padding box is the viewport, so the absolutely-positioned popup keeps its exact coordinates), and `pointer-events-none` keeps the full-screen wrapper from eating the outside taps that dismiss it.

Everything #6013 gained is preserved: handles stay under the footnote popup, the side panels (`z-[45]`) and dialogs (`z-50`), and `overlaySurfaceOpen` already unmounts them for the dictionary, translator, proofread and note editor.

Layers after this change:

| layer | z |
|---|---|
| paragraph overlay, TTS mini player | `z-40` |
| annotation/selection toolbar | `z-[43]` |
| range-edit handles | `z-[44]` |
| sidebar / notebook panel | `z-[45]` |
| every other popup, dialogs, sheets | `z-50` |

## Tests

- `selection.android.test.ts` gains a hit test that probes 5 points per overlapping handle with `elementFromPoint`, plus a premise guard that the boxes actually overlap. Against the pre-fix build it fails with `the toolbar intercepts points inside a handle: 30,313`.
- `e2e/tests/annotation.spec.ts` pinned the now-inverted order, so it is rewritten to read the computed z-index of all three bands off the live DOM. The hit test itself cannot live in the web lane: `clickHighlight()` puts those handles at x = -3762 at 1280x720, so the overlap is always zero there.

## Verification

- `selection.android.test.ts` on a Xiaomi: 7 passed, no retries
- full Android lane: 15 passed, 3 skipped (the 2 suite errors are a local release APK only, `run-as: package not debuggable`; CI builds `--debug`)
- `playwright test annotation.spec.ts`: 13 passed
- `pnpm test`: 10754 passed, 16 skipped
- `pnpm lint`, `pnpm format:check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved annotation selection controls so drag handles remain accessible when they overlap the annotation toolbar.
  - Adjusted the toolbar’s layering to keep it interactive without blocking handle interactions.
  - Refined handle detection during Android selection workflows, preventing annotation styling elements from being mistaken for handles.

- **Tests**
  - Added coverage to verify correct toolbar and handle layering across supported selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->