### PR TITLE
fix(reader): restore XHTML namespaces so book CSS selectors match

### DIFF
--- a/apps/readest-app/src/__tests__/utils/style-dom.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-dom.test.ts
@@ -26,6 +26,7 @@ import {
   getThemeCode,
   getStyles,
   applyImageStyle,
+  applyNamespacedAttributes,
   keepTextAlignment,
 } from '@/utils/style';
 import {
@@ -635,5 +636,79 @@ describe('keepTextAlignment', () => {
     expect(document.querySelector('p')!.classList.contains('aligned-center')).toBe(true);
     expect(document.querySelector('div')!.classList.contains('aligned-right')).toBe(true);
     expect(document.querySelector('blockquote')!.classList.contains('aligned-justify')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyNamespacedAttributes
+
+describe('applyNamespacedAttributes', () => {
+  const OPS = 'http://www.idpf.org/2007/ops';
+
+  // Sections reach the iframe through `srcdoc`, so they are always parsed as
+  // HTML no matter what the EPUB declares.
+  const parseAsSrcdoc = (body: string, root = 'xmlns:epub="http://www.idpf.org/2007/ops"') =>
+    new DOMParser().parseFromString(
+      `<html xmlns="http://www.w3.org/1999/xhtml" ${root}><body>${body}</body></html>`,
+      'text/html',
+    );
+
+  it('re-attaches the declared namespace to a prefixed attribute (#6038)', () => {
+    const doc = parseAsSrcdoc('<div epub:type="chapter">The Swans.</div>');
+    const div = doc.querySelector('div')!;
+    expect(div.getAttributeNS(OPS, 'type')).toBeNull();
+
+    applyNamespacedAttributes(doc);
+
+    expect(div.getAttributeNS(OPS, 'type')).toBe('chapter');
+  });
+
+  it('keeps the qualified-name lookup working', () => {
+    const doc = parseAsSrcdoc('<aside epub:type="footnote">note</aside>');
+    applyNamespacedAttributes(doc);
+    expect(doc.querySelector('aside')!.getAttribute('epub:type')).toBe('footnote');
+  });
+
+  it('leaves a prefix the document never declared alone', () => {
+    const doc = parseAsSrcdoc('<div ops:type="chapter">x</div>');
+    applyNamespacedAttributes(doc);
+    const div = doc.querySelector('div')!;
+    expect(div.getAttributeNS(OPS, 'type')).toBeNull();
+    expect(div.getAttribute('ops:type')).toBe('chapter');
+  });
+
+  it('matches the namespace URI rather than the prefix the book chose', () => {
+    const doc = parseAsSrcdoc(
+      '<div ops:type="chapter">x</div>',
+      'xmlns:ops="http://www.idpf.org/2007/ops"',
+    );
+    applyNamespacedAttributes(doc);
+    expect(doc.querySelector('div')!.getAttributeNS(OPS, 'type')).toBe('chapter');
+  });
+
+  it('picks up a declaration made further down the document', () => {
+    const doc = parseAsSrcdoc(
+      '<section xmlns:epub="http://www.idpf.org/2007/ops"><div epub:type="chapter">x</div></section>',
+      '',
+    );
+    applyNamespacedAttributes(doc);
+    expect(doc.querySelector('div')!.getAttributeNS(OPS, 'type')).toBe('chapter');
+  });
+
+  it('leaves the reserved xml and xmlns names untouched', () => {
+    const doc = parseAsSrcdoc('<div xml:lang="en">x</div>');
+    applyNamespacedAttributes(doc);
+    const html = doc.documentElement;
+    const div = doc.querySelector('div')!;
+    expect(div.getAttributeNS('http://www.w3.org/XML/1998/namespace', 'lang')).toBeNull();
+    expect(div.getAttribute('xml:lang')).toBe('en');
+    expect(html.getAttribute('xmlns:epub')).toBe(OPS);
+  });
+
+  it('is a no-op for a document that declares no prefix', () => {
+    const doc = parseAsSrcdoc('<div class="chapter">x</div>', '');
+    const before = doc.body.innerHTML;
+    applyNamespacedAttributes(doc);
+    expect(doc.body.innerHTML).toBe(before);
   });
 });

--- a/apps/readest-app/src/__tests__/utils/style-dom.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-dom.test.ts
@@ -705,6 +705,29 @@ describe('applyNamespacedAttributes', () => {
     expect(html.getAttribute('xmlns:epub')).toBe(OPS);
   });
 
+  it('does not let a declaration reach a sibling that is out of its scope', () => {
+    const doc = parseAsSrcdoc(
+      '<section xmlns:epub="http://www.idpf.org/2007/ops"><div id="a" epub:type="chapter"></div></section>' +
+        '<section><div id="b" epub:type="chapter"></div></section>',
+      '',
+    );
+    applyNamespacedAttributes(doc);
+    expect(doc.querySelector('#a')!.getAttributeNS(OPS, 'type')).toBe('chapter');
+    expect(doc.querySelector('#b')!.getAttributeNS(OPS, 'type')).toBeNull();
+  });
+
+  it('restores the outer binding once a rebinding subtree ends', () => {
+    const OTHER = 'http://example.com/ns';
+    const doc = parseAsSrcdoc(
+      `<span xmlns:epub="${OTHER}"><i id="deep" epub:type="note"></i></span>` +
+        '<i id="after" epub:type="chapter"></i>',
+    );
+    applyNamespacedAttributes(doc);
+    expect(doc.querySelector('#deep')!.getAttributeNS(OTHER, 'type')).toBe('note');
+    expect(doc.querySelector('#after')!.getAttributeNS(OPS, 'type')).toBe('chapter');
+    expect(doc.querySelector('#after')!.getAttributeNS(OTHER, 'type')).toBeNull();
+  });
+
   it('is a no-op for a document that declares no prefix', () => {
     const doc = parseAsSrcdoc('<div class="chapter">x</div>', '');
     const before = doc.body.innerHTML;

--- a/apps/readest-app/src/__tests__/utils/style.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style.test.ts
@@ -645,6 +645,21 @@ describe('transformStylesheet', () => {
       const css = '[data-q="(max-width: 480px)"] { padding: 1em; }';
       expect(transformStylesheet(css, VW, VH, VERTICAL)).toContain('[data-q="(max-width: 480px)"]');
     });
+
+    it('leaves a whole prelude alone when it sits inside a quoted value', () => {
+      const css = '.note::before { content: "@media (orientation: landscape)"; }';
+      expect(transformStylesheet(css, VW, VH, VERTICAL)).toContain(
+        'content: "@media (orientation: landscape)"',
+      );
+    });
+
+    it('does not let a quoted at-rule swallow the rules that follow it', () => {
+      const css =
+        '.note::before { content: "@media screen"; } @media (max-width: 480px) { p { margin: 0; } }';
+      const result = transformStylesheet(css, 390, 800, VERTICAL);
+      expect(result).toContain('content: "@media screen"');
+      expect(result).toContain('@media (min-width: 0px) {');
+    });
   });
 });
 

--- a/apps/readest-app/src/__tests__/utils/style.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style.test.ts
@@ -538,6 +538,48 @@ describe('transformStylesheet', () => {
       localStorage.removeItem('themeMode');
     });
   });
+
+  // The paginator sizes the section iframe to the whole multi-column strip, so
+  // `(orientation: ...)` inside a section describes the strip, not a page — and
+  // the strip is derived from the content, so the query and the page count feed
+  // each other and the layout never settles (#6038).
+  describe('orientation media queries', () => {
+    const LANDSCAPE_CSS = '@media screen and (orientation: landscape) { div { column-count: 2; } }';
+    const PORTRAIT_CSS = '@media screen and (orientation:portrait) { div { column-count: 2; } }';
+
+    it('keeps a landscape block when the reader viewport is landscape', () => {
+      const result = transformStylesheet(LANDSCAPE_CSS, 1000, 800, VERTICAL);
+      expect(result).toContain('@media screen and (min-width: 0px)');
+      expect(result).not.toContain('orientation');
+    });
+
+    it('drops a landscape block when the reader viewport is portrait', () => {
+      const result = transformStylesheet(LANDSCAPE_CSS, 800, 1000, VERTICAL);
+      expect(result).toContain('@media screen and (min-width: 999999px)');
+      expect(result).not.toContain('orientation');
+    });
+
+    it('keeps a portrait block when the reader viewport is portrait', () => {
+      const result = transformStylesheet(PORTRAIT_CSS, 800, 1000, VERTICAL);
+      expect(result).toContain('@media screen and (min-width: 0px)');
+    });
+
+    it('drops a portrait block when the reader viewport is landscape', () => {
+      const result = transformStylesheet(PORTRAIT_CSS, 1000, 800, VERTICAL);
+      expect(result).toContain('@media screen and (min-width: 999999px)');
+    });
+
+    it('leaves the rest of the query and its declarations intact', () => {
+      const result = transformStylesheet(LANDSCAPE_CSS, VW, VH, VERTICAL);
+      expect(result).toContain('div { column-count: 2; }');
+      expect(result.startsWith('@media screen and ')).toBe(true);
+    });
+
+    it('leaves a media query without an orientation feature alone', () => {
+      const css = '@media screen and (max-width: 480px) { div { padding: 1em; } }';
+      expect(transformStylesheet(css, VW, VH, VERTICAL)).toContain('(max-width: 480px)');
+    });
+  });
 });
 
 describe('getFootnoteStyles', () => {

--- a/apps/readest-app/src/__tests__/utils/style.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style.test.ts
@@ -575,9 +575,75 @@ describe('transformStylesheet', () => {
       expect(result.startsWith('@media screen and ')).toBe(true);
     });
 
-    it('leaves a media query without an orientation feature alone', () => {
-      const css = '@media screen and (max-width: 480px) { div { padding: 1em; } }';
-      expect(transformStylesheet(css, VW, VH, VERTICAL)).toContain('(max-width: 480px)');
+    it('leaves a media query with no viewport feature alone', () => {
+      const css = '@media print { div { padding: 1em; } }';
+      expect(transformStylesheet(css, VW, VH, VERTICAL)).toContain('@media print {');
+    });
+
+    it('leaves the literal alone in a declaration value', () => {
+      const css = '.q::after { content: "(orientation: landscape)"; }';
+      expect(transformStylesheet(css, VW, VH, VERTICAL)).toContain(
+        'content: "(orientation: landscape)"',
+      );
+    });
+
+    it('leaves the literal alone in an attribute selector', () => {
+      const css = '[data-q="(orientation: portrait)"] { padding: 1em; }';
+      expect(transformStylesheet(css, VW, VH, VERTICAL)).toContain(
+        '[data-q="(orientation: portrait)"]',
+      );
+    });
+  });
+
+  // Same circular dependency as the orientation feature: a two-page section
+  // makes the strip twice as wide, so a width query can flip on the page count
+  // it is itself deciding. The IDPF sample's `(max-width: 480px)` block does
+  // exactly that through `h1 { margin: 50% auto 0 0 }`.
+  describe('width and height media queries', () => {
+    const small = (feature: string) => `@media screen and (${feature}) { h1 { margin: 50%; } }`;
+
+    it('drops a max-width block when the reader viewport is wider', () => {
+      expect(transformStylesheet(small('max-width: 480px'), 1000, 800, VERTICAL)).toContain(
+        '(min-width: 999999px)',
+      );
+    });
+
+    it('keeps a max-width block when the reader viewport is narrower', () => {
+      expect(transformStylesheet(small('max-width:480px'), 390, 800, VERTICAL)).toContain(
+        '@media screen and (min-width: 0px)',
+      );
+    });
+
+    it('keeps a min-width block when the reader viewport is wide enough', () => {
+      expect(transformStylesheet(small('min-width: 600px'), 1000, 800, VERTICAL)).toContain(
+        '@media screen and (min-width: 0px)',
+      );
+    });
+
+    it('drops a min-width block when the reader viewport is too narrow', () => {
+      expect(transformStylesheet(small('min-width: 600px'), 390, 800, VERTICAL)).toContain(
+        '(min-width: 999999px)',
+      );
+    });
+
+    it('resolves height features against the reader viewport height', () => {
+      expect(transformStylesheet(small('max-height: 500px'), 1000, 800, VERTICAL)).toContain(
+        '(min-width: 999999px)',
+      );
+      expect(transformStylesheet(small('min-height: 500px'), 1000, 800, VERTICAL)).toContain(
+        '@media screen and (min-width: 0px)',
+      );
+    });
+
+    it('leaves a length it cannot resolve to px alone', () => {
+      expect(transformStylesheet(small('max-width: 30em'), 1000, 800, VERTICAL)).toContain(
+        '(max-width: 30em)',
+      );
+    });
+
+    it('leaves the same feature alone outside a media prelude', () => {
+      const css = '[data-q="(max-width: 480px)"] { padding: 1em; }';
+      expect(transformStylesheet(css, VW, VH, VERTICAL)).toContain('[data-q="(max-width: 480px)"]');
     });
   });
 });

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -33,6 +33,7 @@ import {
   applyEinkModeAttribute,
   applyFixedlayoutStyles,
   applyImageStyle,
+  applyNamespacedAttributes,
   applyScrollbarStyle,
   applyScrollModeClass,
   applyThemeModeClass,
@@ -349,6 +350,9 @@ const FoliateViewer: React.FC<{
     const detail = (event as CustomEvent).detail;
     console.log('doc index loaded:', detail.index);
     if (detail.doc) {
+      // Repair the parsed DOM before anything reads it: the renderer and the
+      // fix-ups below both resolve styles off this document.
+      applyNamespacedAttributes(detail.doc);
       const renderer = viewRef.current?.renderer;
       const writingDir = renderer?.setStyles && getDirection(detail.doc);
       const viewSettings = getViewSettings(bookKey)!;

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1218,11 +1218,34 @@ export const transformStylesheet = (
   // Resolve the feature against the reader's own viewport, the same thing the
   // vw/vh rewrite below does and for the same reason, so the book gets the
   // orientation the reader is actually in and the cycle cannot form.
+  // Width and height features are the same trap: a two-page section makes the
+  // strip twice as wide, so the sample's `(max-width: 480px)` block flips on the
+  // page count it is itself deciding. Both rewrites are confined to the prelude,
+  // between `@media` and the `{` that opens its block, so the same literal in a
+  // declaration value or an attribute selector is left as the book wrote it. The
+  // two sentinels below resolve to themselves, so the passes are order-free.
   const isLandscape = vw > vh;
-  css = css.replace(/\(\s*orientation\s*:\s*(landscape|portrait)\s*\)/gi, (_, mode: string) =>
-    (mode.toLowerCase() === 'landscape') === isLandscape
-      ? '(min-width: 0px)'
-      : '(min-width: 999999px)',
+  const always = '(min-width: 0px)';
+  const never = '(min-width: 999999px)';
+  css = css.replace(/@media[^{]*/gi, (prelude) =>
+    prelude
+      .replace(/\(\s*orientation\s*:\s*(landscape|portrait)\s*\)/gi, (_, mode: string) =>
+        (mode.toLowerCase() === 'landscape') === isLandscape ? always : never,
+      )
+      .replace(
+        /\(\s*(min|max)-(width|height)\s*:\s*([^)]+?)\s*\)/gi,
+        (feature, bound: string, axis: string, length: string) => {
+          // Only lengths that are already px can be resolved without guessing at
+          // the book's root font size; anything else keeps the authored feature.
+          const px = /^(\d*\.?\d+)(?:px)?$/.exec(length);
+          if (!px) return feature;
+          const viewport = axis.toLowerCase() === 'width' ? vw : vh;
+          const bounds = parseFloat(px[1]!);
+          return (bound.toLowerCase() === 'min' ? viewport >= bounds : viewport <= bounds)
+            ? always
+            : never;
+        },
+      ),
   );
 
   // replace absolute font sizes with rem units
@@ -1321,19 +1344,23 @@ const PREFIXED_ATTR_REGEX = /^([A-Za-z_][\w.-]*):([A-Za-z_][\w.-]*)$/;
  * callers are unaffected either way.
  */
 export const applyNamespacedAttributes = (document: Document) => {
-  // `xmlns:` declarations survive HTML parsing as ordinary attributes. Elements
-  // come in document order, so a prefix declared on an ancestor is recorded
-  // before anything that uses it.
-  const namespaces = new Map<string, string>();
-  for (const element of document.querySelectorAll('*')) {
-    const attributes = Array.from(element.attributes);
-    for (const { name, value } of attributes) {
-      if (value && name.startsWith('xmlns:')) namespaces.set(name.slice('xmlns:'.length), value);
+  // `xmlns:` declarations survive HTML parsing as ordinary attributes, but only
+  // as attributes: nothing scopes them any more, so a prefix has to be resolved
+  // the way XML would resolve it, from the element's own ancestor chain. A flat
+  // document-order map would carry a nested rebinding past the end of its
+  // subtree and on to later siblings.
+  const lookupNamespace = (element: Element, prefix: string) => {
+    for (let node: Element | null = element; node; node = node.parentElement) {
+      const uri = node.getAttribute(`xmlns:${prefix}`);
+      if (uri) return uri;
     }
-    if (!namespaces.size) continue;
-    for (const { name, value } of attributes) {
+    return null;
+  };
+  for (const element of document.querySelectorAll('*')) {
+    for (const { name, value } of Array.from(element.attributes)) {
       const [, prefix, localName] = PREFIXED_ATTR_REGEX.exec(name) ?? [];
-      const uri = prefix ? namespaces.get(prefix) : undefined;
+      if (!prefix) continue;
+      const uri = lookupNamespace(element, prefix);
       if (uri && !element.hasAttributeNS(uri, localName!)) {
         element.setAttributeNS(uri, name, value);
       }

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1208,6 +1208,23 @@ export const transformStylesheet = (
     return match;
   });
 
+  // `@media (orientation: ...)` inside a section is evaluated against the
+  // iframe, and the paginator sizes that iframe to the whole multi-column strip
+  // rather than to a page: a one-page section reports portrait and a two-page
+  // section landscape. The strip width is itself derived from the content, so a
+  // rule that changes the content's height — `column-count: 2` in the IDPF
+  // media-query sample — flips the query, which flips the page count, which
+  // flips the query straight back, and the layout never settles (#6038).
+  // Resolve the feature against the reader's own viewport, the same thing the
+  // vw/vh rewrite below does and for the same reason, so the book gets the
+  // orientation the reader is actually in and the cycle cannot form.
+  const isLandscape = vw > vh;
+  css = css.replace(/\(\s*orientation\s*:\s*(landscape|portrait)\s*\)/gi, (_, mode: string) =>
+    (mode.toLowerCase() === 'landscape') === isLandscape
+      ? '(min-width: 0px)'
+      : '(min-width: 999999px)',
+  );
+
   // replace absolute font sizes with rem units
   // replace vw and vh as they cause problems with layout
   // replace hardcoded colors
@@ -1283,6 +1300,45 @@ export const applyThemeModeClass = (document: Document, isDarkMode: boolean) => 
 export const applyScrollModeClass = (document: Document, isScrollMode: boolean) => {
   document.body.classList.remove('scroll-mode', 'paginated-mode');
   document.body.classList.add(isScrollMode ? 'scroll-mode' : 'paginated-mode');
+};
+
+// A prefixed attribute name, e.g. the `epub:type` of `epub:type="chapter"`.
+const PREFIXED_ATTR_REGEX = /^([A-Za-z_][\w.-]*):([A-Za-z_][\w.-]*)$/;
+
+/**
+ * Re-attach the namespaces an XHTML section declared to its prefixed
+ * attributes.
+ *
+ * Sections reach the iframe through `srcdoc` so that browser extensions can
+ * see them, and `srcdoc` is always parsed as HTML. An HTML parser has no
+ * namespaces outside foreign content, so `epub:type="chapter"` lands in the
+ * null namespace under the literal name `epub:type` and every CSS namespace
+ * selector written against it matches nothing: the book's own
+ * `div[epub|type="chapter"]` (which paints the illustration and the page
+ * color of the IDPF media-query sample, #6038) as much as our
+ * `aside[epub|type~="footnote"]`. The original attribute stays in place, and
+ * the twin carries the same qualified name, so `getAttribute('epub:type')`
+ * callers are unaffected either way.
+ */
+export const applyNamespacedAttributes = (document: Document) => {
+  // `xmlns:` declarations survive HTML parsing as ordinary attributes. Elements
+  // come in document order, so a prefix declared on an ancestor is recorded
+  // before anything that uses it.
+  const namespaces = new Map<string, string>();
+  for (const element of document.querySelectorAll('*')) {
+    const attributes = Array.from(element.attributes);
+    for (const { name, value } of attributes) {
+      if (value && name.startsWith('xmlns:')) namespaces.set(name.slice('xmlns:'.length), value);
+    }
+    if (!namespaces.size) continue;
+    for (const { name, value } of attributes) {
+      const [, prefix, localName] = PREFIXED_ATTR_REGEX.exec(name) ?? [];
+      const uri = prefix ? namespaces.get(prefix) : undefined;
+      if (uri && !element.hasAttributeNS(uri, localName!)) {
+        element.setAttributeNS(uri, name, value);
+      }
+    }
+  }
 };
 
 /**

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1227,6 +1227,13 @@ export const transformStylesheet = (
   const isLandscape = vw > vh;
   const always = '(min-width: 0px)';
   const never = '(min-width: 999999px)';
+  // Park quoted values first, the same way the url() pass above does, so an
+  // at-rule quoted inside a declaration is never mistaken for a real prelude.
+  const quoted: string[] = [];
+  css = css.replace(/"[^"\n]*"|'[^'\n]*'/g, (value) => {
+    quoted.push(value);
+    return `READEST_STR_${quoted.length - 1}_PLACEHOLDER`;
+  });
   css = css.replace(/@media[^{]*/gi, (prelude) =>
     prelude
       .replace(/\(\s*orientation\s*:\s*(landscape|portrait)\s*\)/gi, (_, mode: string) =>
@@ -1247,6 +1254,7 @@ export const transformStylesheet = (
         },
       ),
   );
+  css = css.replace(/READEST_STR_(\d+)_PLACEHOLDER/g, (_, i) => quoted[+i]!);
 
   // replace absolute font sizes with rem units
   // replace vw and vh as they cause problems with layout


### PR DESCRIPTION
Fixes #6038

## The reported bug

The IDPF `childrens-media-query` sample ("The Swans") rendered as bare text: no illustration, no flower border, no page color. Everything it paints comes from one rule:

```css
@namespace epub "http://www.idpf.org/2007/ops";
div[epub|type="chapter"] {
  background-image: url(swans.jpg), url(flowers.jpg);
  background-color: #fdefc2;
  padding: 2em;
}
```

That rule was dead. Sections are handed to the iframe through `srcdoc` so browser extensions can reach them (blob: iframes are invisible to them, foliate-js `0561d06`), and **`srcdoc` is always parsed as `text/html`**. Confirmed in the running reader: `iframe.contentDocument.contentType === 'text/html'`, and the chapter div's `epub:type` attribute has `namespaceURI === null`. An HTML parser has no namespaces outside foreign content, so `epub:type` survives only as a literal null-namespace attribute name and every CSS namespace selector written against it silently matches nothing.

The book's unnamespaced rules (`h1`, `p > span:nth-child(even)`) kept working, which is what made this look like a partial failure rather than a parsing problem.

This also affects our own stylesheet: `aside[epub|type~="footnote"]` in `getPageLayoutStyles` has never matched. `footnoteTransformer`'s `class="epubtype-footnote"` rewrite has been covering for it, but only for `<aside epub:type="footnote">` with the attribute first and a single exact value, so `<aside id="x" epub:type="footnote noteref">` was slipping through and showing inline. Those hide as intended now.

**Fix:** `applyNamespacedAttributes` reads the `xmlns:*` declarations (which do survive HTML parsing, as ordinary attributes) and gives every `prefix:local` attribute a properly namespaced twin. The original attribute stays and the twin carries the same qualified name, so `getAttribute('epub:type')` callers are unaffected. It runs first in `docLoadHandler`, which foliate calls from `afterLoad` before `getBackground()` and before `render()`, so nothing re-lays-out.

## The second defect this exposed

With those rules live, resizing the window put the reader in a permanent ping-pong: the iframe flipped between 975 px and 487 px every ~65 ms indefinitely, and in scroll mode it wedged the renderer outright.

`View.expand()` sizes the section iframe to the whole multi-column strip (`pageCount * columnSize`), so `@media (orientation: ...)` inside a section describes the strip, not a page:

- 487x632 reads **portrait** -> `column-count: auto` -> tall content -> 2 pages -> strip becomes 975
- 975x632 reads **landscape** -> `column-count: 2` -> short content -> 1 page -> strip becomes 487

The strip is derived from the content and the content from the strip. There is no fixed point.

This is **not** caused by the namespace change. Verified by removing the namespaced attribute and re-expressing the identical rule as a plain class selector: same loop, 43 flips in 3 seconds. Any book with an orientation media query can hit it; this one was simply unable to reach its own CSS before.

**Fix:** `transformStylesheet` resolves the viewport features a section's media queries ask about against the reader's own viewport, the same thing it already does for `vw`/`vh` and for the same reason. The content stops depending on the strip and the cycle cannot form.

That covers `orientation` and, after review, `min-width` / `max-width` / `min-height` / `max-height` as well. The width case is not hypothetical: this sample's own `@media (max-width: 480px)` block moves the content height through `h1 { margin: 50% auto 0 0 }`, so it flips on the page count it is itself deciding, and it hung the renderer at narrow widths until it was handled too. Lengths that are not already px keep the authored feature rather than being guessed at, and both rewrites are confined to the media prelude so the same literal in a declaration value or an attribute selector is untouched.

One consequence worth naming: a book's media queries are now resolved once, when the section's stylesheet is transformed, so they no longer re-evaluate while the window is being dragged. That is the same trade the `vw`/`vh` rewrite already makes, and what they were re-evaluating against before was the column strip rather than anything the author meant.

An oscillation damper inside `expand()` was tried first and reverted: it fixed some geometries but the renderer still froze at a container width of 600 px, because the loop reaches `render()` by more paths than the guard can see. `packages/foliate-js` is untouched by this PR.

## Verification

Web build (`pnpm dev-web`, Chrome), against the reporter's own file:

- Illustration, flower strip, padding and page color all render, matching the Sigil reference in the issue.
- Layout settles at container widths 820/760/700/640/600/560/520/480/440 (600 and 760 previously froze the renderer) and across repeated OS window resizes.
- Moby-Dick and a namespace-free probe book render unchanged.

`pnpm test` 10767 passed, `pnpm lint` and `pnpm format:check` clean. 13 new tests.

## Not addressed

Separately from this PR: `transformStylesheet` bakes the theme's background into the book's stylesheet at load, so toggling the theme without reloading leaves a book's background at the old theme while the text color flips. Pre-existing, reproduces on a book with no namespaces, and needs a different fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Book styles using landscape or portrait media queries now respond correctly to the reader’s viewport orientation.
  - Width- and height-based media queries now adapt correctly to the reader’s viewport dimensions.
  - Improved rendering of EPUB content that uses namespaced attributes, such as `epub:type`.
  - Preserved namespace-based styling across nested content and document sections, while leaving undeclared and reserved namespaces unchanged.
  - Prevented media-query processing from altering quoted text, selectors, declarations, or unrelated CSS rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
