### PR TITLE
feat(sync): choose Readest Cloud before sign-in starts syncing

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2547,5 +2547,6 @@
   "This book was not found in the ReadEra backup.": "لم يتم العثور على هذا الكتاب في النسخة الاحتياطية من ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ملف نسخة احتياطية من ReadEra (.bak)",
-  "BookOrbit Sync": "مزامنة BookOrbit"
+  "BookOrbit Sync": "مزامنة BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "احفظ مكتبتك وتقدم القراءة والتمييزات في حساب Readest الخاص بك. يمكنك تغيير ذلك في أي وقت من الإعدادات."
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "এই বইটি ReadEra ব্যাকআপে পাওয়া যায়নি।",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra ব্যাকআপ ফাইল (.bak)",
-  "BookOrbit Sync": "BookOrbit সিঙ্ক"
+  "BookOrbit Sync": "BookOrbit সিঙ্ক",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "আপনার লাইব্রেরি, পড়ার অগ্রগতি এবং হাইলাইটগুলি আপনার Readest অ্যাকাউন্টে সংরক্ষণ করুন। আপনি যেকোনো সময় সেটিংসে এটি পরিবর্তন করতে পারেন।"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2247,5 +2247,6 @@
   "This book was not found in the ReadEra backup.": "དཔེ་དེབ་འདི་ ReadEra གྲབས་ཉར་ནང་མ་རྙེད།",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra གྲབས་ཉར་ཡིག་ཆ (.bak)",
-  "BookOrbit Sync": "BookOrbit ཟླ་སྒྲིག"
+  "BookOrbit Sync": "BookOrbit ཟླ་སྒྲིག",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "ཁྱེད་ཀྱི་དཔེ་མཛོད་དང་། ཀློག་པའི་ཡར་འཕེལ། གཙོ་གནད་བཅས་ཁྱེད་ཀྱི་ Readest རྩིས་ཐོའི་ནང་ཉར་ཚགས་བྱེད། འདི་ནི་དུས་ནམ་ཡིན་ཡང་སྒྲིག་སྟངས་ནང་བསྒྱུར་བཅོས་བྱེད་ཐུབ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "Dieses Buch wurde in der ReadEra-Sicherung nicht gefunden.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra-Sicherungsdatei (.bak)",
-  "BookOrbit Sync": "BookOrbit-Synchronisierung"
+  "BookOrbit Sync": "BookOrbit-Synchronisierung",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Speichern Sie Ihre Bibliothek, Ihren Lesefortschritt und Ihre Markierungen in Ihrem Readest-Konto. Sie können dies jederzeit in den Einstellungen ändern."
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "Αυτό το βιβλίο δεν βρέθηκε στο αντίγραφο ασφαλείας ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Αρχείο αντιγράφου ασφαλείας ReadEra (.bak)",
-  "BookOrbit Sync": "Συγχρονισμός BookOrbit"
+  "BookOrbit Sync": "Συγχρονισμός BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Αποθηκεύστε τη βιβλιοθήκη, την πρόοδο ανάγνωσης και τις επισημάνσεις σας στον λογαριασμό σας Readest. Μπορείτε να το αλλάξετε ανά πάσα στιγμή στις Ρυθμίσεις."
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2367,5 +2367,6 @@
   "This book was not found in the ReadEra backup.": "Este libro no se encontró en la copia de seguridad de ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Archivo de copia de seguridad de ReadEra (.bak)",
-  "BookOrbit Sync": "Sincronización de BookOrbit"
+  "BookOrbit Sync": "Sincronización de BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Guarda tu biblioteca, progreso de lectura y resaltados en tu cuenta de Readest. Puedes cambiar esto en cualquier momento en Configuraciones."
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "این کتاب در پشتیبان ReadEra پیدا نشد.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "فایل پشتیبان ReadEra ‏(.bak)",
-  "BookOrbit Sync": "همگام‌سازی BookOrbit"
+  "BookOrbit Sync": "همگام‌سازی BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "کتابخانه، وضعیت مطالعه و هایلایت‌های خود را در حساب Readest خود ذخیره کنید. می‌توانید این را هر زمان در تنظیمات تغییر دهید."
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2367,5 +2367,6 @@
   "This book was not found in the ReadEra backup.": "Ce livre n'a pas été trouvé dans la sauvegarde ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Fichier de sauvegarde ReadEra (.bak)",
-  "BookOrbit Sync": "Synchronisation BookOrbit"
+  "BookOrbit Sync": "Synchronisation BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Stockez votre bibliothèque, votre progression de lecture et vos surlignages dans votre compte Readest. Vous pouvez modifier ce choix à tout moment dans les Paramètres."
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2367,5 +2367,6 @@
   "This book was not found in the ReadEra backup.": "הספר הזה לא נמצא בגיבוי של ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "קובץ גיבוי של ReadEra ‏(.bak)",
-  "BookOrbit Sync": "סנכרון BookOrbit"
+  "BookOrbit Sync": "סנכרון BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "אחסן את הספרייה, התקדמות הקריאה וההדגשות שלך בחשבון Readest שלך. תוכל לשנות זאת בכל עת בהגדרות."
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "यह पुस्तक ReadEra बैकअप में नहीं मिली।",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra बैकअप फ़ाइल (.bak)",
-  "BookOrbit Sync": "BookOrbit सिंक"
+  "BookOrbit Sync": "BookOrbit सिंक",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "अपनी लाइब्रेरी, पढ़ने की प्रगति और हाइलाइट्स को अपने Readest खाते में संग्रहीत करें। आप इसे कभी भी सेटिंग्स में बदल सकते हैं।"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "Ez a könyv nem található a ReadEra biztonsági mentésben.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra biztonsági mentés fájlja (.bak)",
-  "BookOrbit Sync": "BookOrbit szinkronizálás"
+  "BookOrbit Sync": "BookOrbit szinkronizálás",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Tárolja könyvtárát, olvasási haladását és kiemeléseit a Readest-fiókjában. Ezt bármikor megváltoztathatja a Beállításokban."
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2247,5 +2247,6 @@
   "This book was not found in the ReadEra backup.": "Buku ini tidak ditemukan dalam cadangan ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "File cadangan ReadEra (.bak)",
-  "BookOrbit Sync": "Sinkronisasi BookOrbit"
+  "BookOrbit Sync": "Sinkronisasi BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Simpan perpustakaan, progres membaca, dan sorotan Anda di akun Readest Anda. Anda dapat mengubahnya kapan saja di Pengaturan."
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2367,5 +2367,6 @@
   "This book was not found in the ReadEra backup.": "Questo libro non è stato trovato nel backup di ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "File di backup di ReadEra (.bak)",
-  "BookOrbit Sync": "Sincronizzazione BookOrbit"
+  "BookOrbit Sync": "Sincronizzazione BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Archivia la tua biblioteca, il progresso di lettura e le evidenziazioni nel tuo account Readest. Puoi modificarlo in qualsiasi momento nelle Impostazioni."
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2247,5 +2247,6 @@
   "This book was not found in the ReadEra backup.": "この本は ReadEra のバックアップに見つかりませんでした。",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra のバックアップファイル (.bak)",
-  "BookOrbit Sync": "BookOrbit同期"
+  "BookOrbit Sync": "BookOrbit同期",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "ライブラリ、読書進捗、ハイライトを Readest アカウントに保存します。設定でいつでも変更できます。"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "ეს წიგნი ვერ მოიძებნა ReadEra-ს სარეზერვო ასლში.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra-ს სარეზერვო ასლის ფაილი (.bak)",
-  "BookOrbit Sync": "BookOrbit სინქრონიზაცია"
+  "BookOrbit Sync": "BookOrbit სინქრონიზაცია",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "შეინახეთ თქვენი ბიბლიოთეკა, კითხვის პროგრესი და მარკირებები თქვენს Readest ანგარიშში. ამის შეცვლა ნებისმიერ დროს შეგიძლიათ პარამეტრებში."
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2247,5 +2247,6 @@
   "This book was not found in the ReadEra backup.": "이 책을 ReadEra 백업에서 찾을 수 없습니다.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra 백업 파일 (.bak)",
-  "BookOrbit Sync": "BookOrbit 동기화"
+  "BookOrbit Sync": "BookOrbit 동기화",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "라이브러리, 읽기 진행 상황, 하이라이트를 Readest 계정에 저장합니다. 설정에서 언제든지 변경할 수 있습니다."
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2247,5 +2247,6 @@
   "This book was not found in the ReadEra backup.": "Buku ini tidak ditemui dalam sandaran ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Fail sandaran ReadEra (.bak)",
-  "BookOrbit Sync": "Penyegerakan BookOrbit"
+  "BookOrbit Sync": "Penyegerakan BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Simpan perpustakaan, kemajuan bacaan dan penonjolan anda dalam akaun Readest anda. Anda boleh mengubahnya pada bila-bila masa dalam Tetapan."
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "Dit boek is niet gevonden in de ReadEra-back-up.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra-back-upbestand (.bak)",
-  "BookOrbit Sync": "BookOrbit-synchronisatie"
+  "BookOrbit Sync": "BookOrbit-synchronisatie",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Sla je bibliotheek, leesvoortgang en markeringen op in je Readest-account. Je kunt dit altijd wijzigen in Instellingen."
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2427,5 +2427,6 @@
   "This book was not found in the ReadEra backup.": "Nie znaleziono tej książki w kopii zapasowej ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Plik kopii zapasowej ReadEra (.bak)",
-  "BookOrbit Sync": "Synchronizacja BookOrbit"
+  "BookOrbit Sync": "Synchronizacja BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Przechowuj bibliotekę, postęp czytania i zaznaczenia na swoim koncie Readest. Możesz to zmienić w dowolnej chwili w Ustawieniach."
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2367,5 +2367,6 @@
   "This book was not found in the ReadEra backup.": "Este livro não foi encontrado no backup do ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Arquivo de backup do ReadEra (.bak)",
-  "BookOrbit Sync": "Sincronização do BookOrbit"
+  "BookOrbit Sync": "Sincronização do BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Armazene sua biblioteca, progresso de leitura e destaques na sua conta Readest. Você pode alterar isso a qualquer momento nas Configurações."
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2367,5 +2367,6 @@
   "This book was not found in the ReadEra backup.": "Este livro não foi encontrado no backup do ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Ficheiro de backup do ReadEra (.bak)",
-  "BookOrbit Sync": "Sincronização do BookOrbit"
+  "BookOrbit Sync": "Sincronização do BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Guarde a sua biblioteca, o progresso de leitura e os destaques na sua conta Readest. Pode alterar isto a qualquer momento nas Configurações."
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2367,5 +2367,6 @@
   "This book was not found in the ReadEra backup.": "Această carte nu a fost găsită în backupul ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Fișier de backup ReadEra (.bak)",
-  "BookOrbit Sync": "Sincronizare BookOrbit"
+  "BookOrbit Sync": "Sincronizare BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Stochează-ți biblioteca, progresul citirii și evidențierile în contul tău Readest. Poți schimba această opțiune oricând în Setări."
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2427,5 +2427,6 @@
   "This book was not found in the ReadEra backup.": "Эта книга не найдена в резервной копии ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Файл резервной копии ReadEra (.bak)",
-  "BookOrbit Sync": "Синхронизация BookOrbit"
+  "BookOrbit Sync": "Синхронизация BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Храните свою библиотеку, прогресс чтения и выделения в своей учётной записи Readest. Это можно изменить в любой момент в Настройках."
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "මෙම පොත ReadEra උපස්ථයේ හමු නොවීය.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra උපස්ථ ගොනුව (.bak)",
-  "BookOrbit Sync": "BookOrbit සමමුහුර්තකරණය"
+  "BookOrbit Sync": "BookOrbit සමමුහුර්තකරණය",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "ඔබේ පුස්තකාලය, කියවීමේ ප්‍රගතිය සහ ඉස්මතු කිරීම් ඔබේ Readest ගිණුමේ ගබඩා කරන්න. ඔබට ඕනෑම වේලාවක සැකසුම් තුළ මෙය වෙනස් කළ හැකිය."
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2427,5 +2427,6 @@
   "This book was not found in the ReadEra backup.": "Te knjige ni v varnostni kopiji ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Datoteka varnostne kopije ReadEra (.bak)",
-  "BookOrbit Sync": "Sinhronizacija BookOrbit"
+  "BookOrbit Sync": "Sinhronizacija BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Shranite knjižnico, napredek branja in označbe v svoj račun Readest. To lahko kadar koli spremenite v Nastavitvah."
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "Den här boken hittades inte i ReadEra-säkerhetskopian.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra-säkerhetskopia (.bak)",
-  "BookOrbit Sync": "BookOrbit-synkronisering"
+  "BookOrbit Sync": "BookOrbit-synkronisering",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Lagra ditt bibliotek, dina läsframsteg och markeringar i ditt Readest-konto. Du kan ändra detta när som helst i Inställningar."
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "இந்தப் புத்தகம் ReadEra காப்புப்பிரதியில் காணப்படவில்லை.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra காப்புப்பிரதி கோப்பு (.bak)",
-  "BookOrbit Sync": "BookOrbit ஒத்திசைவு"
+  "BookOrbit Sync": "BookOrbit ஒத்திசைவு",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "உங்கள் நூலகம், வாசிப்பு முன்னேற்றம் மற்றும் சிறப்பம்சங்களை உங்கள் Readest கணக்கில் சேமிக்கவும். இதை எப்போது வேண்டுமானாலும் அமைப்புகளில் மாற்றலாம்."
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2247,5 +2247,6 @@
   "This book was not found in the ReadEra backup.": "ไม่พบหนังสือเล่มนี้ในข้อมูลสำรองของ ReadEra",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ไฟล์สำรองข้อมูลของ ReadEra (.bak)",
-  "BookOrbit Sync": "การซิงค์ BookOrbit"
+  "BookOrbit Sync": "การซิงค์ BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "จัดเก็บคลังหนังสือ ความคืบหน้าการอ่าน และไฮไลต์ของคุณไว้ในบัญชี Readest ของคุณ คุณสามารถเปลี่ยนได้ทุกเมื่อในการตั้งค่า"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "Bu kitap ReadEra yedeğinde bulunamadı.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra yedek dosyası (.bak)",
-  "BookOrbit Sync": "BookOrbit Senkronizasyonu"
+  "BookOrbit Sync": "BookOrbit Senkronizasyonu",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Kütüphanenizi, okuma ilerlemenizi ve vurgularınızı Readest hesabınızda saklayın. Bunu istediğiniz zaman Ayarlar'dan değiştirebilirsiniz."
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2427,5 +2427,6 @@
   "This book was not found in the ReadEra backup.": "Цю книгу не знайдено в резервній копії ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Файл резервної копії ReadEra (.bak)",
-  "BookOrbit Sync": "Синхронізація BookOrbit"
+  "BookOrbit Sync": "Синхронізація BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Зберігайте свою бібліотеку, проґрес читання та виділення у своєму обліковому записі Readest. Це можна змінити будь-коли в Налаштуваннях."
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2307,5 +2307,6 @@
   "This book was not found in the ReadEra backup.": "Bu kitob ReadEra zaxira nusxasida topilmadi.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra zaxira nusxa fayli (.bak)",
-  "BookOrbit Sync": "BookOrbit sinxronlash"
+  "BookOrbit Sync": "BookOrbit sinxronlash",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Kutubxonangiz, oʻqish jarayoni va belgilashlaringizni Readest hisobingizda saqlang. Buni istalgan vaqtda Sozlamalarda oʻzgartirishingiz mumkin."
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2247,5 +2247,6 @@
   "This book was not found in the ReadEra backup.": "Không tìm thấy cuốn sách này trong bản sao lưu ReadEra.",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Tệp sao lưu ReadEra (.bak)",
-  "BookOrbit Sync": "Đồng bộ BookOrbit"
+  "BookOrbit Sync": "Đồng bộ BookOrbit",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Lưu trữ thư viện, tiến trình đọc và điểm nổi bật của bạn trong tài khoản Readest của bạn. Bạn có thể thay đổi tùy chọn này bất cứ lúc nào trong Cài đặt."
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2247,5 +2247,6 @@
   "This book was not found in the ReadEra backup.": "未在 ReadEra 备份中找到本书。",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra 备份文件 (.bak)",
-  "BookOrbit Sync": "BookOrbit 同步"
+  "BookOrbit Sync": "BookOrbit 同步",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "将您的书库、阅读进度和高亮存储在您的 Readest 账户中。您可以随时在设置中更改。"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2247,5 +2247,6 @@
   "This book was not found in the ReadEra backup.": "未在 ReadEra 備份中找到本書。",
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra 備份檔案 (.bak)",
-  "BookOrbit Sync": "BookOrbit 同步"
+  "BookOrbit Sync": "BookOrbit 同步",
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "將您的書庫、閱讀進度和高亮儲存在您的 Readest 帳戶中。您可以隨時在設定中變更。"
 }

--- a/apps/readest-app/src/__tests__/components/SyncCategoriesSection.test.tsx
+++ b/apps/readest-app/src/__tests__/components/SyncCategoriesSection.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { SystemSettings } from '@/types/settings';
+import { useSettingsStore } from '@/store/settingsStore';
+
+/**
+ * The Manage Sync panel reads every row from the settings store, so it must
+ * not render before that store is hydrated: a cold /user load would show each
+ * category's default instead of the user's real choice, and flipping a row
+ * would write the empty object back over their settings.
+ */
+
+const saveSettings = vi.fn(async () => {});
+// useEnsureSettingsLoaded reads through this when the store is unhydrated.
+const loadSettings = vi.fn(async () => useSettingsStore.getState().settings);
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({
+    envConfig: { getAppService: async () => ({ saveSettings, loadSettings }) },
+    appService: null,
+  }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/utils/settingsSync', () => ({
+  broadcastGlobalSettings: vi.fn(),
+}));
+
+import { SyncCategoriesSection } from '@/app/user/components/SyncCategoriesSection';
+
+const base = {
+  version: 1,
+  webdav: { enabled: false },
+  googleDrive: { enabled: false },
+  s3: { enabled: false },
+  onedrive: { enabled: false },
+  icloud: { enabled: false },
+  syncCategories: {},
+} as unknown as SystemSettings;
+
+const row = (label: string) => screen.getByLabelText(label) as HTMLInputElement;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('SyncCategoriesSection', () => {
+  test('renders nothing until the settings store is hydrated', () => {
+    // A refreshed /user renders cold: every category would read its default,
+    // misreporting the user's choices, and toggling a row would persist that
+    // empty object over them.
+    useSettingsStore.setState({ settings: {} as SystemSettings } as never);
+    render(<SyncCategoriesSection />);
+    expect(screen.queryByLabelText('Books')).toBeNull();
+  });
+
+  test('renders the categories once hydrated', () => {
+    useSettingsStore.setState({ settings: base } as never);
+    render(<SyncCategoriesSection />);
+    expect(row('Books').checked).toBe(true);
+    expect(row('App settings').checked).toBe(true);
+  });
+});

--- a/apps/readest-app/src/__tests__/components/auth/AuthPanelCloudChoiceRace.test.tsx
+++ b/apps/readest-app/src/__tests__/components/auth/AuthPanelCloudChoiceRace.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { SystemSettings } from '@/types/settings';
+import { useSettingsStore } from '@/store/settingsStore';
+
+/**
+ * The Readest Cloud opt-in persists asynchronously, and web OAuth leaves the
+ * page with a full redirect (`signInWithOAuth` without `skipBrowserRedirect`).
+ * Unchecking the box and immediately hitting a provider button could therefore
+ * tear down the page mid-write and lose the opt-out — silently reinstating the
+ * upload this whole change exists to prevent.
+ */
+
+let releaseSave: () => void;
+const savePending = () => new Promise<void>((resolve) => (releaseSave = resolve));
+const saveSettings = vi.fn(savePending);
+const loadSettings = vi.fn(async () => useSettingsStore.getState().settings);
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({
+    envConfig: { getAppService: async () => ({ saveSettings, loadSettings }) },
+    appService: null,
+  }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  // Interpolate so the four provider buttons are distinguishable.
+  useTranslation: () => (key: string, opts?: Record<string, string>) =>
+    opts ? key.replace(/\{\{(\w+)\}\}/g, (_m, name) => opts[name] ?? _m) : key,
+}));
+
+vi.mock('@/utils/settingsSync', () => ({
+  broadcastGlobalSettings: vi.fn(),
+}));
+
+import AuthPanel from '@/app/auth/components/AuthPanel';
+
+const freshInstall = {
+  version: 1,
+  webdav: { enabled: false },
+  googleDrive: { enabled: false },
+} as unknown as SystemSettings;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useSettingsStore.setState({ settings: freshInstall } as never);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AuthPanel cloud choice vs OAuth redirect', () => {
+  test('holds provider sign-in until the opt-out has been written', async () => {
+    const onProviderSignIn = vi.fn(async () => {});
+    render(
+      <AuthPanel
+        supabaseClient={{} as never}
+        onProviderSignIn={onProviderSignIn}
+        magicLink={true}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: /Sign in with Google/ }));
+
+    // The save has not resolved, so nothing may navigate away yet.
+    await Promise.resolve();
+    expect(onProviderSignIn).not.toHaveBeenCalled();
+
+    releaseSave();
+
+    await waitFor(() => expect(onProviderSignIn).toHaveBeenCalledTimes(1));
+    expect(useSettingsStore.getState().settings.readestCloud?.enabled).toBe(false);
+  });
+
+  test('does not delay sign-in when the box was never touched', async () => {
+    const onProviderSignIn = vi.fn(async () => {});
+    render(
+      <AuthPanel
+        supabaseClient={{} as never}
+        onProviderSignIn={onProviderSignIn}
+        magicLink={true}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Sign in with Google/ }));
+
+    await waitFor(() => expect(onProviderSignIn).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/readest-app/src/__tests__/components/auth/ReadestCloudOptIn.test.tsx
+++ b/apps/readest-app/src/__tests__/components/auth/ReadestCloudOptIn.test.tsx
@@ -1,0 +1,139 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { SystemSettings } from '@/types/settings';
+import { useSettingsStore } from '@/store/settingsStore';
+
+/**
+ * #6010: signing in used to start a Readest Cloud upload before the user had
+ * seen a single sync option. Third-party backends need premium, premium needs
+ * an account, so at the moment of sign-in there is by construction no
+ * third-party provider — `isReadestCloudEnabled` derives ON and
+ * `useBooksSync`'s `user` effect fires. This opt-in puts the decision on the
+ * sign-in page itself.
+ *
+ * It writes through the moment it is toggled rather than on submit: the choice
+ * has to survive an OAuth redirect and a magic-link round-trip, and it has to
+ * be on disk before /library mounts.
+ */
+
+const saveSettings = vi.fn(async () => {});
+// useEnsureSettingsLoaded reads through this when the store is unhydrated.
+const loadSettings = vi.fn(async () => useSettingsStore.getState().settings);
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({
+    envConfig: { getAppService: async () => ({ saveSettings, loadSettings }) },
+    appService: null,
+  }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/utils/settingsSync', () => ({
+  broadcastGlobalSettings: vi.fn(),
+}));
+
+import ReadestCloudOptIn from '@/app/auth/components/ReadestCloudOptIn';
+
+/** A fresh install: no explicit flag, no third-party backend. */
+const freshInstall = {
+  version: 1,
+  webdav: { enabled: false },
+  googleDrive: { enabled: false },
+} as unknown as SystemSettings;
+
+const withWebDAV = {
+  version: 1,
+  webdav: { enabled: true, serverUrl: 'https://dav.example.com', username: 'alice' },
+  googleDrive: { enabled: false },
+} as unknown as SystemSettings;
+
+const box = () => screen.getByRole('checkbox') as HTMLInputElement;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ReadestCloudOptIn', () => {
+  test('renders nothing until the settings store is hydrated', () => {
+    // A cold /auth load leaves the store empty, and isReadestCloudEnabled
+    // derives ON from `{}` — showing a checked box over a stored opt-out.
+    useSettingsStore.setState({ settings: {} as SystemSettings } as never);
+    render(<ReadestCloudOptIn />);
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+
+  test('reflects a stored opt-out rather than the empty-object default', () => {
+    useSettingsStore.setState({
+      settings: {
+        ...freshInstall,
+        readestCloud: { enabled: false, disabledAt: 1_700_000_000_000 },
+      } as unknown as SystemSettings,
+    } as never);
+    render(<ReadestCloudOptIn />);
+    expect(box().checked).toBe(false);
+  });
+
+  test('starts checked on a fresh install, matching the derived default', () => {
+    useSettingsStore.setState({ settings: freshInstall } as never);
+    render(<ReadestCloudOptIn />);
+    expect(box().checked).toBe(true);
+  });
+
+  test('unchecking writes the same explicit opt-out the Integrations checkbox does', async () => {
+    useSettingsStore.setState({ settings: freshInstall } as never);
+    render(<ReadestCloudOptIn />);
+
+    fireEvent.click(box());
+
+    await waitFor(() => {
+      expect(useSettingsStore.getState().settings.readestCloud?.enabled).toBe(false);
+    });
+    expect(useSettingsStore.getState().settings.readestCloud?.disabledAt).toBeTruthy();
+    expect(saveSettings).toHaveBeenCalled();
+    expect(box().checked).toBe(false);
+  });
+
+  test('re-checking clears the flag instead of pinning it to true', async () => {
+    useSettingsStore.setState({ settings: freshInstall } as never);
+    render(<ReadestCloudOptIn />);
+
+    fireEvent.click(box());
+    await waitFor(() => {
+      expect(useSettingsStore.getState().settings.readestCloud?.enabled).toBe(false);
+    });
+    fireEvent.click(box());
+
+    // An explicit `true` here would retire the `?? !hasAnyThirdPartyEnabled`
+    // fallback, so enabling WebDAV later would leave Readest Cloud on and the
+    // library would upload to both.
+    await waitFor(() => {
+      expect(useSettingsStore.getState().settings.readestCloud?.enabled).toBeUndefined();
+    });
+    expect(useSettingsStore.getState().settings.readestCloud?.disabledAt).toBeUndefined();
+    expect(box().checked).toBe(true);
+  });
+
+  test('shows the derived off state when a third-party backend already syncs, and pins true when checked', async () => {
+    useSettingsStore.setState({ settings: withWebDAV } as never);
+    render(<ReadestCloudOptIn />);
+
+    // Derivation says off while WebDAV owns the library channels.
+    expect(box().checked).toBe(false);
+
+    fireEvent.click(box());
+
+    // Clearing the flag would derive back to off, so this one has to be explicit.
+    await waitFor(() => {
+      expect(useSettingsStore.getState().settings.readestCloud?.enabled).toBe(true);
+    });
+    expect(box().checked).toBe(true);
+  });
+});

--- a/apps/readest-app/src/__tests__/components/settings/cloudSync.test.ts
+++ b/apps/readest-app/src/__tests__/components/settings/cloudSync.test.ts
@@ -6,6 +6,7 @@ vi.mock('@/utils/settingsSync', () => ({
 
 import {
   persistCloudProviderEnabled,
+  persistReadestCloudChoice,
   withCloudProviderEnabled,
 } from '@/services/sync/cloudSyncActivation';
 import { useSettingsStore } from '@/store/settingsStore';
@@ -71,6 +72,30 @@ describe('withCloudProviderEnabled', () => {
     } as SystemSettings;
     const again = withCloudProviderEnabled(optedOut, 'gdrive', true);
     expect(again.googleDrive.syncBooks).toBe(false);
+  });
+
+  test('reconnecting a provider selected here before keeps its syncBooks opt-out', () => {
+    // #6010: Disconnect only writes `enabled: false`, so `providerSelectedAt`
+    // and the sub-toggles survive it. The reconnect's off -> on edge must not
+    // resurrect the "mirror my library here" default over a deliberate opt-out
+    // — buildWebDAVConnectSettings preserves syncBooks precisely so that a
+    // reconnect is not a reset.
+    const reconnecting = {
+      ...both,
+      googleDrive: {
+        enabled: false,
+        accountLabel: 'a@b.com',
+        syncBooks: false,
+        providerSelectedAt: 1_700_000_000_000,
+      },
+    } as unknown as SystemSettings;
+
+    const next = withCloudProviderEnabled(reconnecting, 'gdrive', true);
+
+    expect(next.googleDrive.enabled).toBe(true);
+    expect(next.googleDrive.syncBooks).toBe(false);
+    // The stamp still tracks the most recent selection on this device.
+    expect(next.googleDrive.providerSelectedAt).toBeGreaterThan(1_700_000_000_000);
   });
 
   test('disabling a provider keeps its config so reconnecting is one click', () => {
@@ -189,6 +214,68 @@ describe('persistCloudProviderEnabled', () => {
     expect(next.webdav.enabled).toBe(true);
     expect(next.webdav.syncBooks).toBe(true);
     expect(next.webdav.providerSelectedAt).toBeTruthy();
+  });
+});
+
+/**
+ * The Readest Cloud opt-in on the sign-in page (#6010) needs a third state
+ * that `persistCloudProviderEnabled` cannot express: clearing the flag back to
+ * `undefined`. That `undefined` is load-bearing — `isReadestCloudEnabled`
+ * derives from it, which is what makes enabling WebDAV later switch Readest
+ * Cloud off instead of uploading the library to both.
+ */
+describe('persistReadestCloudChoice', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ settings: {} as SystemSettings });
+    mockBroadcastGlobalSettings.mockClear();
+  });
+
+  const makeEnvConfig = (
+    saveSettings: (settings: SystemSettings) => Promise<void>,
+  ): EnvConfigType =>
+    ({
+      getAppService: vi.fn().mockResolvedValue({ saveSettings }),
+    }) as unknown as EnvConfigType;
+
+  test('false writes an explicit opt-out and stamps disabledAt', async () => {
+    const saveSettings = vi.fn().mockResolvedValue(undefined);
+    useSettingsStore.setState({ settings: { version: 1 } as unknown as SystemSettings });
+
+    const next = await persistReadestCloudChoice(makeEnvConfig(saveSettings), false);
+
+    expect(next.readestCloud?.enabled).toBe(false);
+    expect(next.readestCloud?.disabledAt).toBeTruthy();
+    expect(saveSettings).toHaveBeenCalledWith(next);
+    expect(mockBroadcastGlobalSettings).toHaveBeenCalledWith(next, {
+      includeCloudSyncProviders: true,
+    });
+  });
+
+  test('undefined clears the flag so the derived fallback applies again', async () => {
+    const saveSettings = vi.fn().mockResolvedValue(undefined);
+    const envConfig = makeEnvConfig(saveSettings);
+    useSettingsStore.setState({ settings: { version: 1 } as unknown as SystemSettings });
+
+    await persistReadestCloudChoice(envConfig, false);
+    const restored = await persistReadestCloudChoice(envConfig, undefined);
+
+    expect(restored.readestCloud?.enabled).toBeUndefined();
+    // disabledAt anchors the mixed-fleet probe for a device that stopped
+    // writing native rows; a device back on the derived default never did.
+    expect(restored.readestCloud?.disabledAt).toBeUndefined();
+    expect(useSettingsStore.getState().settings.readestCloud?.enabled).toBeUndefined();
+  });
+
+  test('true writes an explicit opt-in and clears disabledAt', async () => {
+    const saveSettings = vi.fn().mockResolvedValue(undefined);
+    const envConfig = makeEnvConfig(saveSettings);
+    useSettingsStore.setState({ settings: { version: 1 } as unknown as SystemSettings });
+
+    await persistReadestCloudChoice(envConfig, false);
+    const next = await persistReadestCloudChoice(envConfig, true);
+
+    expect(next.readestCloud?.enabled).toBe(true);
+    expect(next.readestCloud?.disabledAt).toBeUndefined();
   });
 });
 

--- a/apps/readest-app/src/app/auth/components/AuthPanel.tsx
+++ b/apps/readest-app/src/app/auth/components/AuthPanel.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import Image from 'next/image';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { FcGoogle } from 'react-icons/fc';
@@ -21,6 +22,14 @@ export default function AuthPanel({
   onProviderSignIn,
 }: AuthPanelProps) {
   const _ = useTranslation();
+  // `signInWithOAuth` redirects the whole page on web, which can cut off the
+  // opt-in's settings write. Hold sign-in until it has landed. Null until the
+  // user actually touches the checkbox, so the common path adds no delay.
+  const pendingCloudChoice = useRef<Promise<unknown> | null>(null);
+  const handleProviderSignIn = async (provider: OAuthProvider) => {
+    await pendingCloudChoice.current;
+    return onProviderSignIn(provider);
+  };
 
   return (
     <div className='flex w-full max-w-sm flex-col items-center gap-6'>
@@ -36,25 +45,25 @@ export default function AuthPanel({
       <div className='flex w-full flex-col gap-2.5'>
         <ProviderLogin
           provider='google'
-          handleSignIn={onProviderSignIn}
+          handleSignIn={handleProviderSignIn}
           Icon={FcGoogle}
           label={_('Sign in with {{provider}}', { provider: 'Google' })}
         />
         <ProviderLogin
           provider='apple'
-          handleSignIn={onProviderSignIn}
+          handleSignIn={handleProviderSignIn}
           Icon={FaApple}
           label={_('Sign in with {{provider}}', { provider: 'Apple' })}
         />
         <ProviderLogin
           provider='github'
-          handleSignIn={onProviderSignIn}
+          handleSignIn={handleProviderSignIn}
           Icon={FaGithub}
           label={_('Sign in with {{provider}}', { provider: 'GitHub' })}
         />
         <ProviderLogin
           provider='discord'
-          handleSignIn={onProviderSignIn}
+          handleSignIn={handleProviderSignIn}
           Icon={FaDiscord}
           label={_('Sign in with {{provider}}', { provider: 'Discord' })}
         />
@@ -69,7 +78,11 @@ export default function AuthPanel({
         redirectTo={redirectTo}
         magicLink={magicLink}
       />
-      <ReadestCloudOptIn />
+      <ReadestCloudOptIn
+        onPendingWrite={(write) => {
+          pendingCloudChoice.current = write;
+        }}
+      />
     </div>
   );
 }

--- a/apps/readest-app/src/app/auth/components/AuthPanel.tsx
+++ b/apps/readest-app/src/app/auth/components/AuthPanel.tsx
@@ -5,6 +5,7 @@ import { FaApple, FaGithub, FaDiscord } from 'react-icons/fa';
 import { useTranslation } from '@/hooks/useTranslation';
 import { ProviderLogin, type OAuthProvider } from './ProviderLogin';
 import EmailPasswordAuth from './EmailPasswordAuth';
+import ReadestCloudOptIn from './ReadestCloudOptIn';
 
 interface AuthPanelProps {
   supabaseClient: SupabaseClient;
@@ -68,6 +69,7 @@ export default function AuthPanel({
         redirectTo={redirectTo}
         magicLink={magicLink}
       />
+      <ReadestCloudOptIn />
     </div>
   );
 }

--- a/apps/readest-app/src/app/auth/components/ReadestCloudOptIn.tsx
+++ b/apps/readest-app/src/app/auth/components/ReadestCloudOptIn.tsx
@@ -1,0 +1,69 @@
+import { useEnv } from '@/context/EnvContext';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useSettingsStore } from '@/store/settingsStore';
+import { persistReadestCloudChoice } from '@/services/sync/cloudSyncActivation';
+import { hasAnyThirdPartyEnabled, isReadestCloudEnabled } from '@/services/sync/cloudSyncProvider';
+
+/**
+ * Readest Cloud opt-in, shown on the sign-in page (#6010).
+ *
+ * Signing in used to start a library upload before the user had seen a single
+ * sync option: a third-party backend needs premium and premium needs an
+ * account, so at the moment of sign-in there is by construction no third-party
+ * provider enabled, `isReadestCloudEnabled` derives ON, and `useBooksSync`'s
+ * `user` effect fires as soon as /library mounts. Someone signing in only to
+ * unlock WebDAV or S3 had no chance to say so first.
+ *
+ * The choice is written the moment the box is toggled, not on submit, so it
+ * survives an OAuth redirect and a magic-link round-trip and is already on
+ * disk before the library page can start syncing. It writes through the same
+ * settings the Integrations page reads, so unchecking here IS unchecking
+ * Readest Cloud there.
+ *
+ * Renders nothing until the settings store is hydrated. `isReadestCloudEnabled`
+ * derives ON from an empty object (no explicit flag, no third-party backend),
+ * so on a cold /auth load — a deep link, or an OAuth return — the box would
+ * show checked over a stored `enabled: false`, and `handleChange` would decide
+ * whether to pin or clear from the same empty object. The auth page hydrates
+ * on mount; this guard keeps the wrong state off the screen until it does.
+ */
+export default function ReadestCloudOptIn() {
+  const _ = useTranslation();
+  const { envConfig } = useEnv();
+  const settings = useSettingsStore((state) => state.settings);
+  const hydrated = !!settings?.version;
+  const checked = isReadestCloudEnabled(settings);
+
+  const handleChange = (next: boolean) => {
+    // Prefer clearing the flag to pinning it: an absent value keeps deriving,
+    // which is what lets a later WebDAV / Drive / S3 activation switch Readest
+    // Cloud off instead of mirroring the library to both. Pin only when the
+    // derivation would disagree with what the user just chose.
+    const derivesToChecked = !hasAnyThirdPartyEnabled(settings);
+    void persistReadestCloudChoice(envConfig, next && derivesToChecked ? undefined : next);
+  };
+
+  if (!hydrated) return null;
+
+  return (
+    <div className='flex w-full flex-col gap-4'>
+      <hr className='border-base-300 w-full border-t' />
+      <label className='flex cursor-pointer select-none items-start gap-3'>
+        <input
+          type='checkbox'
+          checked={checked}
+          onChange={(event) => handleChange(event.target.checked)}
+          className='checkbox checkbox-sm mt-0.5 shrink-0'
+        />
+        <span className='flex flex-col gap-1'>
+          <span className='text-sm'>{_('Sync with Readest Cloud')}</span>
+          <span className='text-base-content/60 text-xs leading-relaxed'>
+            {_(
+              'Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.',
+            )}
+          </span>
+        </span>
+      </label>
+    </div>
+  );
+}

--- a/apps/readest-app/src/app/auth/components/ReadestCloudOptIn.tsx
+++ b/apps/readest-app/src/app/auth/components/ReadestCloudOptIn.tsx
@@ -27,7 +27,17 @@ import { hasAnyThirdPartyEnabled, isReadestCloudEnabled } from '@/services/sync/
  * whether to pin or clear from the same empty object. The auth page hydrates
  * on mount; this guard keeps the wrong state off the screen until it does.
  */
-export default function ReadestCloudOptIn() {
+interface ReadestCloudOptInProps {
+  /**
+   * Reports the in-flight settings write. Web OAuth leaves the page with a full
+   * redirect, so the sign-in handlers await this before navigating: a torn-off
+   * write would silently drop the opt-out and start the very upload this
+   * control exists to prevent.
+   */
+  onPendingWrite?: (write: Promise<unknown>) => void;
+}
+
+export default function ReadestCloudOptIn({ onPendingWrite }: ReadestCloudOptInProps) {
   const _ = useTranslation();
   const { envConfig } = useEnv();
   const settings = useSettingsStore((state) => state.settings);
@@ -40,7 +50,15 @@ export default function ReadestCloudOptIn() {
     // Cloud off instead of mirroring the library to both. Pin only when the
     // derivation would disagree with what the user just chose.
     const derivesToChecked = !hasAnyThirdPartyEnabled(settings);
-    void persistReadestCloudChoice(envConfig, next && derivesToChecked ? undefined : next);
+    const write = persistReadestCloudChoice(
+      envConfig,
+      next && derivesToChecked ? undefined : next,
+    ).catch((error) => {
+      // Swallowed so awaiting this in AuthPanel can never reject the sign-in
+      // it is gating; the checkbox falls back to the stored value on re-render.
+      console.error('Failed to save the Readest Cloud choice:', error);
+    });
+    onPendingWrite?.(write);
   };
 
   if (!hydrated) return null;

--- a/apps/readest-app/src/app/auth/page.tsx
+++ b/apps/readest-app/src/app/auth/page.tsx
@@ -11,6 +11,7 @@ import { useEnv } from '@/context/EnvContext';
 import { useTheme } from '@/hooks/useTheme';
 import { useThemeStore } from '@/store/themeStore';
 import { useSettingsStore } from '@/store/settingsStore';
+import { useEnsureSettingsLoaded } from '@/hooks/useEnsureSettingsLoaded';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useTrafficLightStore } from '@/store/trafficLightStore';
 import { getBaseUrl, isTauriAppPlatform } from '@/services/environment';
@@ -51,6 +52,9 @@ export default function AuthPage() {
   const headerRef = useRef<HTMLDivElement>(null);
 
   useTheme({ systemUIVisible: false });
+  // The OAuth return and any deep link land here cold; hydrate before the
+  // Readest Cloud opt-in or handleGoBack's keepLogin write reads the store.
+  useEnsureSettingsLoaded();
 
   const getTauriRedirectTo = (isOAuth: boolean) => {
     // For custom OAuth mode, use a local server to handle the OAuth callback

--- a/apps/readest-app/src/app/auth/page.tsx
+++ b/apps/readest-app/src/app/auth/page.tsx
@@ -54,7 +54,7 @@ export default function AuthPage() {
   useTheme({ systemUIVisible: false });
   // The OAuth return and any deep link land here cold; hydrate before the
   // Readest Cloud opt-in or handleGoBack's keepLogin write reads the store.
-  useEnsureSettingsLoaded();
+  const settingsLoaded = useEnsureSettingsLoaded();
 
   const getTauriRedirectTo = (isOAuth: boolean) => {
     // For custom OAuth mode, use a local server to handle the OAuth callback
@@ -232,10 +232,22 @@ export default function AuthPage() {
   };
 
   const handleGoBack = () => {
-    // Keep login false to avoid infinite loop to redirect to the login page
-    settings.keepLogin = false;
-    setSettings(settings);
-    saveSettings(envConfig, settings);
+    // Keep login false to avoid infinite loop to redirect to the login page.
+    // On a cold load the store is still an empty object, so read through to
+    // disk first: persisting that would overwrite the real settings file with
+    // a lone `keepLogin`. Building a new object rather than mutating in place
+    // also keeps the settingsStore subscriber's identity check meaningful.
+    void (async () => {
+      try {
+        const appService = await envConfig.getAppService();
+        const current = settingsLoaded ? settings : await appService.loadSettings();
+        const next = { ...current, keepLogin: false };
+        setSettings(next);
+        await saveSettings(envConfig, next);
+      } catch (error) {
+        console.error('Failed to clear keepLogin:', error);
+      }
+    })();
     const redirectTo = new URLSearchParams(window.location.search).get('redirect');
     if (redirectTo) {
       router.push(redirectTo);

--- a/apps/readest-app/src/app/user/components/SyncCategoriesSection.tsx
+++ b/apps/readest-app/src/app/user/components/SyncCategoriesSection.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { useEnv } from '@/context/EnvContext';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useSettingsStore } from '@/store/settingsStore';
+import { useEnsureSettingsLoaded } from '@/hooks/useEnsureSettingsLoaded';
 import {
   isReadestCloudEnabled,
   getEnabledFileSyncBackends,
@@ -79,12 +80,16 @@ export function SyncCategoriesSection() {
   const _ = useTranslation();
   const { envConfig } = useEnv();
   const { settings, setSettings, saveSettings } = useSettingsStore();
+  const hydrated = useEnsureSettingsLoaded();
   const copy = useCategoryCopy();
   const readestEnabled = isReadestCloudEnabled(settings);
   const backends = getEnabledFileSyncBackends(settings);
   const cloudProviderName = cloudProvidersDisplayName(backends);
 
-  if (!settings) return null;
+  // A refreshed /user renders before the store is hydrated, where every
+  // category reads its default. Showing that would misreport the user's real
+  // choices, and toggling a row would persist the empty object over them.
+  if (!settings || !hydrated) return null;
 
   const enabled = (category: SyncCategory): boolean => {
     const value = settings.syncCategories?.[category];

--- a/apps/readest-app/src/hooks/useEnsureSettingsLoaded.ts
+++ b/apps/readest-app/src/hooks/useEnsureSettingsLoaded.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { useEnv } from '@/context/EnvContext';
+import { useSettingsStore } from '@/store/settingsStore';
+
+/**
+ * Hydrate the settings store on routes that can be entered cold.
+ *
+ * Most surfaces reach the store already populated, because the library page
+ * loads settings on the way in. A route opened directly — a refreshed /user,
+ * a deep link, the OAuth return to /auth — never does, and the store's initial
+ * value is an empty object. Anything reading it then reads defaults instead of
+ * the user's real settings: a sync toggle shows ON over a stored OFF, and
+ * writing that object back persists an almost-empty settings file over the
+ * real one.
+ *
+ * Returns whether the store is hydrated, so callers can hold off rendering
+ * settings-derived state rather than flashing a wrong value.
+ */
+export const useEnsureSettingsLoaded = (): boolean => {
+  const { envConfig } = useEnv();
+  const settings = useSettingsStore((state) => state.settings);
+  const setSettings = useSettingsStore((state) => state.setSettings);
+  const hydrated = !!settings?.version;
+
+  useEffect(() => {
+    if (hydrated) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const appService = await envConfig.getAppService();
+        const loaded = await appService.loadSettings();
+        if (!cancelled) setSettings(loaded);
+      } catch (error) {
+        // Leave the store unhydrated: callers keep their settings-derived UI
+        // hidden, which is the safe outcome. Rendering defaults over real
+        // values is what this hook exists to prevent.
+        console.error('Failed to load settings:', error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [envConfig, hydrated, setSettings]);
+
+  return hydrated;
+};

--- a/apps/readest-app/src/services/sync/cloudSyncActivation.ts
+++ b/apps/readest-app/src/services/sync/cloudSyncActivation.ts
@@ -6,6 +6,29 @@ import { useSettingsStore } from '@/store/settingsStore';
 import { broadcastGlobalSettings } from '@/utils/settingsSync';
 
 /**
+ * Write Readest Cloud's own switch, including the third state a plain boolean
+ * cannot express: `undefined`, which restores the derived fallback
+ * (`enabled ?? !hasAnyThirdPartyEnabled`, see `isReadestCloudEnabled`).
+ *
+ * Clearing rather than pinning `true` matters — a pinned `true` retires the
+ * derivation, so enabling WebDAV later would leave Readest Cloud on and the
+ * library would upload to both. `disabledAt` is stamped only for an explicit
+ * opt-out: it anchors the mixed-fleet probe ("when did this device stop
+ * writing native rows"), which a device back on the derived default never did.
+ */
+export const withReadestCloudChoice = (
+  settings: SystemSettings,
+  enabled: boolean | undefined,
+): SystemSettings => ({
+  ...settings,
+  readestCloud: {
+    ...settings.readestCloud,
+    enabled,
+    disabledAt: enabled === false ? Date.now() : undefined,
+  },
+});
+
+/**
  * Turn ONE cloud sync provider on or off, leaving every other provider exactly
  * as it was (#5062). Providers are an independent set: any subset may sync
  * the library at once.
@@ -14,10 +37,14 @@ import { broadcastGlobalSettings } from '@/utils/settingsSync';
  * left untouched when switching a provider off, so re-enabling it later needs
  * no re-entry; only an explicit Disconnect tears the config down.
  *
- * Switching a third-party provider ON (off -> on edge only) also turns its
- * `syncBooks` on and stamps `providerSelectedAt`: checking a provider means
- * "mirror my library here". An explicit `syncBooks` opt-out while the provider
- * stays on is respected — a redundant re-activation changes nothing.
+ * Switching a third-party provider ON (off -> on edge only) stamps
+ * `providerSelectedAt`, and on the FIRST activation on this device also turns
+ * its `syncBooks` on: checking a provider for the first time means "mirror my
+ * library here". A LATER reactivation leaves the sub-toggles alone. Disconnect
+ * writes only `enabled: false`, and `buildWebDAVConnectSettings` preserves the
+ * sub-toggles precisely so a reconnect is not a reset — force-flipping
+ * `syncBooks` back on here silently discarded a deliberate Upload Book Files
+ * opt-out every time a user reconnected (#6010).
  *
  * Switching Readest Cloud OFF stamps `readestCloud.disabledAt`, the anchor for
  * mixed-fleet detection ("when did this device stop writing native rows").
@@ -28,36 +55,52 @@ export const withCloudProviderEnabled = (
   enabled: boolean,
 ): SystemSettings => {
   if (kind === 'readest') {
-    return {
-      ...settings,
-      readestCloud: {
-        ...settings.readestCloud,
-        enabled,
-        disabledAt: enabled ? undefined : Date.now(),
-      },
-    };
+    return withReadestCloudChoice(settings, enabled);
   }
   const key = settingsKeyForBackend(kind);
   const slice = settings[key];
   const activating = enabled && !slice?.enabled;
+  // Read before the write below re-stamps it: the stamp is what tells a
+  // reconnect apart from a first-ever activation on this device.
+  const firstActivation = activating && !slice?.providerSelectedAt;
   return {
     ...settings,
     [key]: {
       ...slice,
       enabled,
-      ...(activating ? { syncBooks: true, providerSelectedAt: Date.now() } : {}),
+      ...(activating
+        ? { ...(firstActivation ? { syncBooks: true } : {}), providerSelectedAt: Date.now() }
+        : {}),
     },
   };
 };
 
 /**
+ * Load the live settings, apply `apply`, then hydrate the store, persist, and
+ * broadcast. Shared by the two writers below so a cloud-sync selection always
+ * (a) persists, (b) hydrates the settings store even on routes where it was
+ * never loaded (the OAuth callbacks), and (c) broadcasts to other windows — a
+ * stale reader window would otherwise clobber the change on its next
+ * whole-file save.
+ */
+const persistCloudSyncSelection = async (
+  envConfig: EnvConfigType,
+  apply: (settings: SystemSettings) => SystemSettings,
+): Promise<SystemSettings> => {
+  const store = useSettingsStore.getState();
+  const appService = await envConfig.getAppService();
+  const current = store.settings?.version ? store.settings : await appService.loadSettings();
+  const next = apply(current);
+  store.setSettings(next);
+  await appService.saveSettings(next);
+  void broadcastGlobalSettings(next, { includeCloudSyncProviders: true });
+  return next;
+};
+
+/**
  * The single write path for switching a cloud sync provider on or off. Every
  * surface (the Cloud Sync checkboxes, each provider's connect/disconnect flow,
- * the Drive and OneDrive OAuth callbacks) routes through here so the change
- * always (a) persists, (b) hydrates the settings store even on routes where it
- * was never loaded (the OAuth callbacks), and (c) broadcasts to other windows —
- * a stale reader window would otherwise clobber the change on its next
- * whole-file save.
+ * the Drive and OneDrive OAuth callbacks) routes through here.
  *
  * `mutate` runs BEFORE the toggle so connect flows can apply credentials or an
  * account label without pre-setting `enabled` (which would suppress the
@@ -68,13 +111,19 @@ export const persistCloudProviderEnabled = async (
   kind: CloudSyncProviderKind,
   enabled: boolean,
   mutate: (settings: SystemSettings) => SystemSettings = (s) => s,
-): Promise<SystemSettings> => {
-  const store = useSettingsStore.getState();
-  const appService = await envConfig.getAppService();
-  const current = store.settings?.version ? store.settings : await appService.loadSettings();
-  const next = withCloudProviderEnabled(mutate(current), kind, enabled);
-  store.setSettings(next);
-  await appService.saveSettings(next);
-  void broadcastGlobalSettings(next, { includeCloudSyncProviders: true });
-  return next;
-};
+): Promise<SystemSettings> =>
+  persistCloudSyncSelection(envConfig, (current) =>
+    withCloudProviderEnabled(mutate(current), kind, enabled),
+  );
+
+/**
+ * Readest Cloud's switch, for callers that need to clear it back to the
+ * derived default as well as set it. The sign-in page's opt-in (#6010) is the
+ * one such caller; the Integrations checkbox goes through
+ * `persistCloudProviderEnabled` like every other provider.
+ */
+export const persistReadestCloudChoice = async (
+  envConfig: EnvConfigType,
+  enabled: boolean | undefined,
+): Promise<SystemSettings> =>
+  persistCloudSyncSelection(envConfig, (current) => withReadestCloudChoice(current, enabled));


### PR DESCRIPTION
Closes #6010.

## The problem

Signing in starts a Readest Cloud upload before the user has seen a single sync option.

A third-party backend needs premium, and premium needs an account. So at the moment of sign-in there is *by construction* no third-party provider enabled, `isReadestCloudEnabled` falls through to its derived default:

```ts
settings?.readestCloud?.enabled ?? !hasAnyThirdPartyEnabled(settings)
```

…which is `true`, and `useBooksSync`'s `user` effect fires as soon as `/library` mounts. Someone signing in only to unlock WebDAV or S3 has no chance to say so first.

## The opt-in

A Readest Cloud checkbox on the sign-in page, at the bottom of `AuthPanel` so it visibly governs the four OAuth buttons as well as email sign-in. It writes through the same settings the Integrations page reads, so unchecking here *is* unchecking Readest Cloud there.

It persists **the moment it is toggled**, not on submit. That is what makes the choice survive an OAuth redirect and a magic-link round trip, and guarantees it is on disk before the library page can start syncing.

Checking the box prefers **clearing** the flag to pinning it:

```ts
const derivesToChecked = !hasAnyThirdPartyEnabled(settings);
persistReadestCloudChoice(envConfig, next && derivesToChecked ? undefined : next);
```

That `undefined` is load-bearing. Pinning `true` would retire the derivation, so enabling WebDAV later would leave Readest Cloud on and the library would upload to both, which is the cost the reporter is complaining about. Only a choice the derivation would disagree with gets pinned.

| state | `readestCloud.enabled` |
| --- | --- |
| fresh install, box left alone | `undefined` (keeps deriving) |
| unchecked | `false` + `disabledAt` |
| unchecked, then reconsidered | `undefined` |
| checked while WebDAV is already on | `true` (pinned, or it would not stick) |

## Reconnect no longer wipes Upload Book Files

The second half of #6010, and two helpers that contradicted each other. `buildWebDAVConnectSettings` says `syncBooks` "was earned by prior use and MUST be preserved across a disconnect/reconnect cycle", and preserves it. Then `withCloudProviderEnabled` ran on top, saw the off→on edge, and force-set `syncBooks: true` anyway.

Now the default applies on the **first** activation only, detected by an absent `providerSelectedAt` read before the write re-stamps it. Disconnect deliberately leaves that stamp in place, so it cleanly separates a reconnect from a first-ever activation on this device.

## Settings hydration

Routes entered cold never hydrate the settings store, and `isReadestCloudEnabled({})` derives `true`. The new checkbox made this visible by rendering checked over a stored `enabled: false`.

The same gap already affected **Manage Sync**: a refreshed `/user` rendered every category from an empty object, showing defaults regardless of the user's real values, and flipping any row called `handleToggle` on that empty object and persisted it, writing a near-empty settings file over the user's real settings.

`useEnsureSettingsLoaded` fixes both. Callers hold settings-derived state back until it resolves; a failed load leaves the store unhydrated and the UI hidden, which is the safe outcome.

## Testing

10 new unit tests; the reconnect one failed first with `expected true to be false`, reproducing the bug.

- `pnpm test` — 894 files, **10792 passed**, 16 skipped
- `pnpm lint` — clean
- `pnpm format:check` — clean
- i18n — one new key across all 34 locales, zero `__STRING_NOT_TRANSLATED__`

Verified in Chrome on the web build: placement, checked state, and the zh-CN copy. The signed-out sign-in page was not exercised in a browser (it needs a signed-out session); its behaviour is covered by unit tests driving the real component through the real store and persist path.

## Not in this PR

#5934 (pause syncing, and per-book do-not-sync) is deliberately out of scope. Also worth its own issue: `readestCloud.enabled` is named like a master switch but only gates the library channels (`book`, `progress`, `note`) — the account-level replicas ride the Readest account regardless. And the flag is device-local, so a three-device user has to uncheck it three times.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in checkbox for Readest Cloud sync during sign-in.
  * Added localized descriptions for BookOrbit Sync across supported languages.
  * Settings-dependent sync controls now wait for settings to load before appearing.

* **Bug Fixes**
  * Ensured cloud sync preferences are saved before sign-in navigation.
  * Preserved upload preferences when reconnecting third-party sync providers.
  * Improved handling of Readest Cloud opt-in, opt-out, and reset choices.
  * Prevented default sync states from appearing before settings hydration.

* **Tests**
  * Added coverage for hydration, cloud opt-in behavior, persistence, sign-in timing, and provider reconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->