### PR TITLE
fix(ui): preserve mobile toast gutters

### DIFF
--- a/apps/readest-app/src/__tests__/components/toast-layout.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/toast-layout.browser.test.tsx
@@ -28,6 +28,7 @@ await import('@/styles/globals.css');
 // 1rem `.toast` padding daisyUI 4 drew between that offset and the alert.
 const TOP_BAR = 44;
 const TOAST_GAP = 16;
+const TOAST_MAX_WIDTH = 640;
 
 beforeAll(async () => {
   await page.viewport(1024, 768);
@@ -84,5 +85,29 @@ describe('Toast layout', () => {
     expect(screen.getByText('Something went wrong').getBoundingClientRect().width).toBeGreaterThan(
       0,
     );
+  });
+
+  it('keeps a long error toast inside the mobile viewport gutters', async () => {
+    await page.viewport(390, 844);
+    const toast = await showToast({
+      type: 'error',
+      message:
+        'The connection could not be completed because the remote server returned an unexpected response.',
+    });
+    const alert = toast.querySelector('.alert') as HTMLElement;
+    const box = alert.getBoundingClientRect();
+
+    expect(box.left).toBeGreaterThanOrEqual(TOAST_GAP);
+    expect(box.right).toBeLessThanOrEqual(window.innerWidth - TOAST_GAP);
+  });
+
+  it('keeps a long info toast within the desktop width cap', async () => {
+    await page.viewport(1024, 768);
+    const toast = await showToast({
+      type: 'info',
+      message: 'A'.repeat(200),
+    });
+
+    expect(toast.getBoundingClientRect().width).toBeLessThanOrEqual(TOAST_MAX_WIDTH);
   });
 });

--- a/apps/readest-app/src/components/Toast.tsx
+++ b/apps/readest-app/src/components/Toast.tsx
@@ -124,11 +124,10 @@ export const Toast = () => {
     toastMessage && (
       <div
         data-capture-invalidating-overlay='true'
-        // No width utility here: daisyUI 5 sizes the toast with
-        // `width: max-content`, and `width: auto` on a box pinned to
-        // `inset-inline: 50%` (toast-center) resolves to zero.
+        // Keep daisyUI's content-sized width, but retain the desktop cap
+        // without allowing it to override the mobile viewport gutters.
         className={clsx(
-          'toast z-[130] max-w-(--breakpoint-sm) transition-all duration-300',
+          'toast z-[130] max-w-[min(var(--breakpoint-sm),calc(100vw-2rem))] transition-all duration-300',
           toastClassMap[toastType],
           isVisible ? 'scale-100 opacity-100' : 'scale-95 opacity-0',
         )}


### PR DESCRIPTION
## Summary

- Keep long error toasts inside 16px mobile viewport gutters while preserving the existing 640px desktop cap.
- Add real-browser regression coverage for both mobile error spacing and long desktop info-toast sizing.

## Test Coverage

```text
CODE PATHS                                             USER FLOWS
[+] src/components/Toast.tsx                           [+] Long failure toast on mobile
  └── Toast render sizing                               └── [★★★ TESTED] 390x844 viewport keeps
      ├── [★★★ TESTED] mobile viewport gutters              both 16px gutters
      ├── [★★★ TESTED] desktop 640px width cap
      ├── [★★★ TESTED] short info content sizing
      ├── [★★★ TESTED] viewport centering
      └── [★★★ TESTED] top-bar offset

COVERAGE: 5/5 paths tested (100%) | GAPS: 0
Tests: 968 -> 968 (+0 files, +2 browser regression cases)
```

## Pre-Landing Review

No issues found.

## Design Review

Design Review (lite): no issues found. The change restores the intended responsive gutter without changing toast styling or e-ink behavior.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN. The diff contains only the toast sizing fix and its browser regression tests.

## Plan Completion

No plan file detected.

## Verification Results

Plan verification skipped because no plan file was detected. Direct regression and project verification completed below.

## Test plan

- [x] Unit tests: 10,780 passed, 16 skipped
- [x] Browser tests: 431 passed, 1 skipped
- [x] TypeScript and Biome lint
- [x] Production Next.js build

🤖 Generated with OpenAI Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved toast notification sizing to keep long messages within mobile screen gutters.
  * Added a maximum width for toast notifications on larger screens, improving readability and preventing excessive stretching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->