### PR TITLE
fix(reader): stop the default font from overriding a book's embedded fonts

### DIFF
--- a/apps/readest-app/src/__tests__/utils/code-font-override.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/code-font-override.browser.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, afterEach } from 'vitest';
+
+import { getStyles, ThemeCode } from '@/utils/style';
+import { ViewSettings } from '@/types/book';
+import {
+  DEFAULT_BOOK_FONT,
+  DEFAULT_BOOK_LAYOUT,
+  DEFAULT_BOOK_LANGUAGE,
+  DEFAULT_BOOK_STYLE,
+  DEFAULT_VIEW_CONFIG,
+  DEFAULT_TTS_CONFIG,
+  DEFAULT_TRANSLATOR_CONFIG,
+  DEFAULT_ANNOTATOR_CONFIG,
+  DEFAULT_SCREEN_CONFIG,
+} from '@/services/constants';
+
+// The monospace fallback is the only rule that applies the app's code font:
+// the revert pass deliberately excludes pre/code/kbd, so nothing else covers
+// them. Both directions of "Override Book Font" therefore ride on this one
+// rule's place in the cascade, and specificity is what decides it - !important
+// does not exempt a declaration from the specificity tie-break, it only sorts
+// it above the non-important ones. These assert the resolved value in a real
+// engine rather than the emitted selector text.
+function makeViewSettings(overrides: Partial<ViewSettings> = {}): ViewSettings {
+  return {
+    ...DEFAULT_BOOK_FONT,
+    ...DEFAULT_BOOK_LAYOUT,
+    ...DEFAULT_BOOK_LANGUAGE,
+    ...DEFAULT_BOOK_STYLE,
+    ...DEFAULT_VIEW_CONFIG,
+    ...DEFAULT_TTS_CONFIG,
+    ...DEFAULT_TRANSLATOR_CONFIG,
+    ...DEFAULT_ANNOTATOR_CONFIG,
+    ...DEFAULT_SCREEN_CONFIG,
+    ...overrides,
+  } as ViewSettings;
+}
+
+const themeCode: ThemeCode = {
+  bg: '#ffffff',
+  fg: '#000000',
+  primary: '#3366cc',
+  isDarkMode: false,
+  palette: {
+    'base-100': '#ffffff',
+    'base-200': '#f0f0f0',
+    'base-300': '#e0e0e0',
+    'base-content': '#000000',
+    neutral: '#808080',
+    'neutral-content': '#ffffff',
+    primary: '#3366cc',
+    secondary: '#6699cc',
+    accent: '#33cc99',
+  },
+} as ThemeCode;
+
+const iframes: HTMLIFrameElement[] = [];
+
+// Mirrors the paginator's injection order: the book's author CSS is already in
+// <head> and the reader's generated stylesheet is appended at the end of it.
+const renderSection = (bookCss: string, bodyHtml: string, settings: Partial<ViewSettings>) => {
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+  iframes.push(iframe);
+  const doc = iframe.contentDocument!;
+  const bookStyle = doc.createElement('style');
+  bookStyle.textContent = bookCss;
+  doc.head.appendChild(bookStyle);
+  const readerStyle = doc.createElement('style');
+  readerStyle.textContent = getStyles(makeViewSettings(settings), themeCode);
+  doc.head.appendChild(readerStyle);
+  doc.body.innerHTML = bodyHtml;
+  return { doc, win: iframe.contentWindow! };
+};
+
+const codeFontOf = (bookCss: string, settings: Partial<ViewSettings>) => {
+  const { doc, win } = renderSection(bookCss, `<pre class="code">const x = 1;</pre>`, settings);
+  const pre = doc.querySelector('.code') as HTMLElement;
+  return win.getComputedStyle(pre).fontFamily;
+};
+
+afterEach(() => {
+  while (iframes.length) iframes.pop()!.remove();
+});
+
+describe('code font vs Override Book Font', () => {
+  test('lets the book keep its code font when the override is off', () => {
+    const font = codeFontOf(`pre { font-family: "BookCode"; }`, { overrideFont: false });
+    expect(font).toContain('BookCode');
+  });
+
+  test('forces the app monospace over a book code font when the override is on', () => {
+    const font = codeFontOf(`pre { font-family: "BookCode"; }`, { overrideFont: true });
+    expect(font).toContain('Consolas');
+    expect(font).not.toContain('BookCode');
+  });
+
+  test('forces the app monospace over an authored !important code font', () => {
+    const font = codeFontOf(`pre { font-family: "BookCode" !important; }`, { overrideFont: true });
+    expect(font).toContain('Consolas');
+    expect(font).not.toContain('BookCode');
+  });
+
+  test('forces the app monospace over a more specific authored !important rule', () => {
+    const font = codeFontOf(`body pre { font-family: "BookCode" !important; }`, {
+      overrideFont: true,
+    });
+    expect(font).toContain('Consolas');
+    expect(font).not.toContain('BookCode');
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
@@ -125,6 +125,19 @@ describe('getFontStyles branches (via getStyles)', () => {
     expect(css).toMatch(/:where\(html\)\s*\{\s*font-family: var\(--serif\)/);
   });
 
+  // The monospace injection is zero-specificity too, so a book's own code font
+  // wins when Override Book Font is off. With the toggle ON it must still be
+  // forced, which zero specificity alone cannot do - it needs !important.
+  it('forces the monospace fallback only when overrideFont is on', () => {
+    const off = getStyles(makeViewSettings({ overrideFont: false }), theme);
+    expect(off).toMatch(/:where\(pre, code, kbd\)\s*\{\s*font-family: var\(--monospace\)\s*;/);
+
+    const on = getStyles(makeViewSettings({ overrideFont: true }), theme);
+    expect(on).toMatch(
+      /:where\(pre, code, kbd\)\s*\{\s*font-family: var\(--monospace\) !important\s*;/,
+    );
+  });
+
   it('sets font-size according to defaultFontSize', () => {
     const vs = makeViewSettings({ defaultFontSize: 20 });
     const css = getStyles(vs, theme);

--- a/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
@@ -126,16 +126,19 @@ describe('getFontStyles branches (via getStyles)', () => {
   });
 
   // The monospace injection is zero-specificity too, so a book's own code font
-  // wins when Override Book Font is off. With the toggle ON it must still be
-  // forced, which zero specificity alone cannot do - it needs !important.
-  it('forces the monospace fallback only when overrideFont is on', () => {
+  // wins when Override Book Font is off. With the toggle ON the rule has to
+  // swap sides and outrank the book, which !important alone cannot do:
+  // specificity still breaks ties between important author declarations.
+  // The resolved cascade is asserted in code-font-override.browser.test.ts.
+  it('swaps the monospace rule above the book only when overrideFont is on', () => {
     const off = getStyles(makeViewSettings({ overrideFont: false }), theme);
     expect(off).toMatch(/:where\(pre, code, kbd\)\s*\{\s*font-family: var\(--monospace\)\s*;/);
 
     const on = getStyles(makeViewSettings({ overrideFont: true }), theme);
     expect(on).toMatch(
-      /:where\(pre, code, kbd\)\s*\{\s*font-family: var\(--monospace\) !important\s*;/,
+      /html body :is\(pre, code, kbd\)\s*\{\s*font-family: var\(--monospace\) !important\s*;/,
     );
+    expect(on).not.toContain(':where(pre, code, kbd)');
   });
 
   it('sets font-size according to defaultFontSize', () => {

--- a/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
@@ -112,6 +112,19 @@ describe('getFontStyles branches (via getStyles)', () => {
     expect(css).not.toContain('font-family: revert !important');
   });
 
+  // Regression: the app default font used to be injected as a plain `html`
+  // rule, tying on specificity with ebook CSS that also declares its font on
+  // the html element (Pandoc-style EPUBs) and winning purely by injection
+  // order — the book's embedded font silently never applied with "Override
+  // Book Font" off. :where() drops the rule's specificity to zero so any book
+  // declaration beats it.
+  it('injects the default font at zero specificity via :where(html)', () => {
+    const vs = makeViewSettings({ overrideFont: false, defaultFont: 'Serif' });
+    const css = getStyles(vs, theme);
+    expect(css).toContain(':where(html)');
+    expect(css).toMatch(/:where\(html\)\s*\{\s*font-family: var\(--serif\)/);
+  });
+
   it('sets font-size according to defaultFontSize', () => {
     const vs = makeViewSettings({ defaultFontSize: 20 });
     const css = getStyles(vs, theme);

--- a/apps/readest-app/src/__tests__/utils/style.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style.test.ts
@@ -163,44 +163,51 @@ describe('transformStylesheet', () => {
     });
   });
 
-  describe('font-family replacements', () => {
-    it('replaces serif with var(--serif, serif)', () => {
-      const css = '.text { font-family: serif; }';
+  describe('font-family passthrough', () => {
+    // Regression tests for the embedded-font corruption: the generic-family
+    // rewriting used to match the words serif/sans-serif/monospace INSIDE the
+    // book's font names, which embedded a real var() into the declaration,
+    // dropped the @font-face rule and detached the book's embedded font.
+    it('leaves an unquoted font name containing "Serif" untouched', () => {
+      const css =
+        '@font-face { font-family: Source Han Serif CN; src: url("f.ttf"); }\n' +
+        'body { font-family: Source Han Serif CN, serif; }';
       const result = transformStylesheet(css, VW, VH, VERTICAL);
-      expect(result).toContain('var(--serif, serif)');
+      expect(result).toContain('Source Han Serif CN');
+      expect(result).not.toContain('var(--serif');
     });
 
-    it('replaces sans-serif with var(--sans-serif, sans-serif)', () => {
-      const css = '.text { font-family: sans-serif; }';
+    it('leaves a quoted font name containing "Serif" untouched', () => {
+      const css = 'body { font-family: "Comic Serif Face", serif; }';
       const result = transformStylesheet(css, VW, VH, VERTICAL);
-      expect(result).toContain('var(--sans-serif, sans-serif)');
+      expect(result).toContain('"Comic Serif Face"');
+      expect(result).not.toContain('var(--serif');
     });
 
-    it('replaces monospace with var(--monospace, monospace)', () => {
-      const css = '.code { font-family: monospace; }';
+    it('leaves font names containing sans-serif/monospace words untouched', () => {
+      const css = '@font-face { font-family: "Ovo Sans-Serif Mono"; src: url(f.woff); }';
       const result = transformStylesheet(css, VW, VH, VERTICAL);
-      expect(result).toContain('var(--monospace, monospace)');
+      expect(result).toContain('"Ovo Sans-Serif Mono"');
+      expect(result).not.toContain('var(--sans-serif');
+      expect(result).not.toContain('var(--monospace');
     });
 
-    // Regression test for #5277: a stylesheet can be handed to this transform
-    // more than once. Rewriting the generic families again turned them into
     // `var(--var(--serif, serif), serif)`, which the CSS parser drops - the
     // book's font-family declarations vanished and the reader's own font
     // showed through instead.
     describe('idempotence', () => {
       const cases = [
-        ['.text { font-family: serif; }', 'var(--serif, serif)'],
-        ['.text { font-family: sans-serif; }', 'var(--sans-serif, sans-serif)'],
-        ['.code { font-family: monospace; }', 'var(--monospace, monospace)'],
-        ['.text { font-family: "FZSongTi", serif; }', 'var(--serif, serif)'],
-        ['.text { font-family: Helvetica, sans-serif; }', 'var(--sans-serif, sans-serif)'],
+        '.text { font-family: serif; }',
+        '.text { font-family: sans-serif; }',
+        '.code { font-family: monospace; }',
+        '.text { font-family: "FZSongTi", serif; }',
+        '.text { font-family: Helvetica, sans-serif; }',
       ] as const;
 
-      cases.forEach(([css, expected]) => {
+      cases.forEach((css) => {
         it(`keeps ${css} stable across repeated transforms`, () => {
           const once = transformStylesheet(css, VW, VH, VERTICAL);
           const twice = transformStylesheet(once, VW, VH, VERTICAL);
-          expect(once).toContain(expected);
           expect(twice).toBe(once);
           expect(twice).not.toContain('var(--var(');
         });

--- a/apps/readest-app/src/__tests__/utils/style.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style.test.ts
@@ -163,25 +163,59 @@ describe('transformStylesheet', () => {
     });
   });
 
-  describe('font-family passthrough', () => {
-    // Regression tests for the embedded-font corruption: the generic-family
-    // rewriting used to match the words serif/sans-serif/monospace INSIDE the
-    // book's font names, which embedded a real var() into the declaration,
-    // dropped the @font-face rule and detached the book's embedded font.
+  describe('font-family generic replacements', () => {
+    it('replaces serif with var(--serif, serif)', () => {
+      const css = '.text { font-family: serif; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('var(--serif, serif)');
+    });
+
+    it('replaces sans-serif with var(--sans-serif, sans-serif)', () => {
+      const css = '.text { font-family: sans-serif; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('var(--sans-serif, sans-serif)');
+    });
+
+    it('replaces monospace with var(--monospace, monospace)', () => {
+      const css = '.code { font-family: monospace; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('var(--monospace, monospace)');
+    });
+
+    it('keeps a trailing !important on the declaration', () => {
+      const css = '.text { font-family: serif !important; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('font-family: var(--serif, serif) !important');
+    });
+
+    it('replaces every generic in a list, not just the first', () => {
+      const css = '.text { font-family: Helvetica, sans-serif, monospace; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain(
+        'font-family: Helvetica, var(--sans-serif, sans-serif), var(--monospace, monospace)',
+      );
+    });
+
+    // Regression (#6047): the rewriting used to match the words
+    // serif/sans-serif/monospace ANYWHERE in the declaration, including inside
+    // the book's own family names. The injected var() is a real function in an
+    // unquoted name, and since CSS descriptors cannot contain var() every
+    // engine drops the whole @font-face rule - the book's embedded font was
+    // detached and never applied. Only a list item that IS the bare keyword may
+    // be replaced.
     it('leaves an unquoted font name containing "Serif" untouched', () => {
       const css =
         '@font-face { font-family: Source Han Serif CN; src: url("f.ttf"); }\n' +
         'body { font-family: Source Han Serif CN, serif; }';
       const result = transformStylesheet(css, VW, VH, VERTICAL);
-      expect(result).toContain('Source Han Serif CN');
-      expect(result).not.toContain('var(--serif');
+      expect(result).toContain('@font-face { font-family: Source Han Serif CN;');
+      expect(result).toContain('font-family: Source Han Serif CN, var(--serif, serif)');
     });
 
     it('leaves a quoted font name containing "Serif" untouched', () => {
-      const css = 'body { font-family: "Comic Serif Face", serif; }';
+      const css = 'p { font-family: "Comic Serif Face", serif; }';
       const result = transformStylesheet(css, VW, VH, VERTICAL);
-      expect(result).toContain('"Comic Serif Face"');
-      expect(result).not.toContain('var(--serif');
+      expect(result).toContain('font-family: "Comic Serif Face", var(--serif, serif)');
     });
 
     it('leaves font names containing sans-serif/monospace words untouched', () => {
@@ -192,22 +226,33 @@ describe('transformStylesheet', () => {
       expect(result).not.toContain('var(--monospace');
     });
 
+    it('leaves an unquoted family that is only a generic-looking word alone', () => {
+      const css = 'p { font-family: Serifa, Monospaced; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('font-family: Serifa, Monospaced');
+      expect(result).not.toContain('var(--');
+    });
+
+    // Regression test for #5277: a stylesheet can be handed to this transform
+    // more than once. Rewriting the generic families again turned them into
     // `var(--var(--serif, serif), serif)`, which the CSS parser drops - the
     // book's font-family declarations vanished and the reader's own font
-    // showed through instead.
+    // showed through instead. The var() fallback parks the keyword inside
+    // parentheses, so a second pass no longer sees a bare generic.
     describe('idempotence', () => {
       const cases = [
-        '.text { font-family: serif; }',
-        '.text { font-family: sans-serif; }',
-        '.code { font-family: monospace; }',
-        '.text { font-family: "FZSongTi", serif; }',
-        '.text { font-family: Helvetica, sans-serif; }',
+        ['.text { font-family: serif; }', 'var(--serif, serif)'],
+        ['.text { font-family: sans-serif; }', 'var(--sans-serif, sans-serif)'],
+        ['.code { font-family: monospace; }', 'var(--monospace, monospace)'],
+        ['.text { font-family: "FZSongTi", serif; }', 'var(--serif, serif)'],
+        ['.text { font-family: Helvetica, sans-serif; }', 'var(--sans-serif, sans-serif)'],
       ] as const;
 
-      cases.forEach((css) => {
+      cases.forEach(([css, expected]) => {
         it(`keeps ${css} stable across repeated transforms`, () => {
           const once = transformStylesheet(css, VW, VH, VERTICAL);
           const twice = transformStylesheet(once, VW, VH, VERTICAL);
+          expect(once).toContain(expected);
           expect(twice).toBe(once);
           expect(twice).not.toContain('var(--var(');
         });

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -117,8 +117,14 @@ const getFontStyles = (
       -webkit-text-size-adjust: none;
       text-size-adjust: none;
     }
-    /* lower specificity than ebook built-in font styles */
-    html {
+    /* Zero specificity (:where) so ANY ebook font-family declaration — even
+       one on the html element itself, at equal (0,0,1) specificity — wins the
+       cascade regardless of injection order. Books like Pandoc-generated
+       EPUBs declare their font on the html element; a plain html rule here
+       ties on specificity and wins only by being appended later, silently
+       overriding the book's embedded font with the app's default font
+       (mobile especially, whose default font is sans-serif). */
+    :where(html) {
       font-family: var(${defaultFontFamily}) ${overrideFont ? '!important' : ''};
     }
     /* higher specificity than ebook built-in font styles */
@@ -150,7 +156,7 @@ const getFontStyles = (
     [style*="font-size: 16px"], [style*="font-size:16px"] {
       font-size: 1rem !important;
     }
-    pre, code, kbd {
+    :where(pre, code, kbd) {
       font-family: var(--monospace);
       font-variant-ligatures: none;
     }

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1240,17 +1240,17 @@ export const transformStylesheet = (
     .replace(/([\s;])-ms-user-select\s*:\s*none/gi, '$1-ms-user-select: unset')
     .replace(/([\s;])-o-user-select\s*:\s*none/gi, '$1-o-user-select: unset')
     .replace(/([\s;])user-select\s*:\s*none/gi, '$1user-select: unset')
-    // Park the `var(--x, x)` chunks an earlier pass already produced: their
-    // inner keywords would otherwise be rewritten again into
-    // `var(--var(--serif, serif), serif)`, which is invalid, so the CSS parser
-    // drops the whole declaration and the book loses its fonts (readest#5277).
-    // The placeholders are underscore-wrapped so `\b` never matches inside them.
-    .replace(/var\(\s*--(sans-serif|serif|monospace)\s*,\s*\1\s*\)/gi, 'READEST_GF_$1_PLACEHOLDER')
-    .replace(/(font-family\s*:[^;]*?)\bsans-serif\b/gi, '$1READEST_SS_PLACEHOLDER')
-    .replace(/(font-family\s*:[^;]*?)\bserif\b(?!-)/gi, '$1var(--serif, serif)')
-    .replace(/READEST_SS_PLACEHOLDER/g, 'var(--sans-serif, sans-serif)')
-    .replace(/(font-family\s*:[^;]*?)\bmonospace\b/gi, '$1var(--monospace, monospace)')
-    .replace(/READEST_GF_(sans-serif|serif|monospace)_PLACEHOLDER/gi, 'var(--$1, $1)')
+    // Do NOT rewrite generic families (serif/sans-serif/monospace) inside the
+    // book's font-family declarations. That rewriting made the user's per-
+    // category font choice apply to books that declare e.g.
+    // `font-family: Source Han Serif CN`, but the keyword regexes also matched
+    // the word "Serif"/"Sans-Serif" inside the font NAME itself: the rewritten
+    // name embedded a real `var()` into the declaration, which drops the whole
+    // `@font-face` rule (descriptors cannot contain var()) and detaches the
+    // book's only reference to its embedded font — so with "Override Book
+    // Font" off, the embedded font silently never applied. Cascade-based
+    // fallbacks below (html font-family + the body generic-unset pass) already
+    // cover books that rely on generic families, without touching names.
     .replace(/([\s;])font-weight\s*:\s*normal/gi, '$1font-weight: var(--font-weight)')
     .replace(/([\s;])color\s*:\s*black/gi, '$1color: var(--theme-fg-color)')
     .replace(/([\s;])color\s*:\s*#000000/gi, '$1color: var(--theme-fg-color)')

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -156,11 +156,12 @@ const getFontStyles = (
     [style*="font-size: 16px"], [style*="font-size:16px"] {
       font-size: 1rem !important;
     }
-    /* Zero specificity so a book's own code font wins when Override Book Font
-       is off. The rule below deliberately excludes pre/code/kbd from the
-       revert pass, so this is the only place that forces the app monospace:
-       it needs !important to keep working once specificity is gone. */
-    :where(pre, code, kbd) {
+    /* The revert pass below deliberately excludes pre/code/kbd, so this is the
+       only rule that applies the app's code font and it has to swap sides with
+       the toggle. Off: zero specificity, so a book's own code font wins. On:
+       above the book, and !important is not enough on its own because
+       specificity still breaks ties between important author declarations. */
+    ${overrideFont ? 'html body :is(pre, code, kbd)' : ':where(pre, code, kbd)'} {
       font-family: var(--monospace) ${overrideFont ? '!important' : ''};
       font-variant-ligatures: none;
     }

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -156,8 +156,12 @@ const getFontStyles = (
     [style*="font-size: 16px"], [style*="font-size:16px"] {
       font-size: 1rem !important;
     }
+    /* Zero specificity so a book's own code font wins when Override Book Font
+       is off. The rule below deliberately excludes pre/code/kbd from the
+       revert pass, so this is the only place that forces the app monospace:
+       it needs !important to keep working once specificity is gone. */
     :where(pre, code, kbd) {
-      font-family: var(--monospace);
+      font-family: var(--monospace) ${overrideFont ? '!important' : ''};
       font-variant-ligatures: none;
     }
     body *:not(pre, code, kbd, .code):not(pre *, code *, kbd *, .code *) {
@@ -1246,17 +1250,35 @@ export const transformStylesheet = (
     .replace(/([\s;])-ms-user-select\s*:\s*none/gi, '$1-ms-user-select: unset')
     .replace(/([\s;])-o-user-select\s*:\s*none/gi, '$1-o-user-select: unset')
     .replace(/([\s;])user-select\s*:\s*none/gi, '$1user-select: unset')
-    // Do NOT rewrite generic families (serif/sans-serif/monospace) inside the
-    // book's font-family declarations. That rewriting made the user's per-
-    // category font choice apply to books that declare e.g.
-    // `font-family: Source Han Serif CN`, but the keyword regexes also matched
-    // the word "Serif"/"Sans-Serif" inside the font NAME itself: the rewritten
-    // name embedded a real `var()` into the declaration, which drops the whole
-    // `@font-face` rule (descriptors cannot contain var()) and detaches the
-    // book's only reference to its embedded font — so with "Override Book
-    // Font" off, the embedded font silently never applied. Cascade-based
-    // fallbacks below (html font-family + the body generic-unset pass) already
-    // cover books that rely on generic families, without touching names.
+    // Point the generic families at the user's per-category font choice, so a
+    // book that asks for `serif` gets the configured serif chain (which also
+    // carries the CJK font) instead of the platform default.
+    //
+    // Only a list item that IS the bare keyword may be rewritten. Matching the
+    // word anywhere in the declaration also hit the book's own family names:
+    // `font-family: Source Han Serif CN` became `Source Han var(--serif, serif) CN`,
+    // and since CSS descriptors cannot contain var() the engine dropped the
+    // whole @font-face rule, detaching the book's only reference to its
+    // embedded font (readest#6047).
+    //
+    // Parking the keyword inside the var() fallback also makes this idempotent:
+    // a stylesheet can be handed to this transform more than once, and a second
+    // pass no longer sees a bare generic to rewrite into
+    // `var(--var(--serif, serif), serif)` (readest#5277).
+    .replace(/(font-family\s*:\s*)([^;{}]*)/gi, (_match: string, prefix: string, value: string) => {
+      const important = /\s*!\s*important\s*$/i.exec(value);
+      const families = important ? value.slice(0, important.index) : value;
+      const rewritten = families
+        .split(',')
+        .map((family: string) => {
+          const generic = /^(serif|sans-serif|monospace)$/i.exec(family.trim());
+          if (!generic) return family;
+          const name = generic[1]!.toLowerCase();
+          return family.replace(generic[1]!, `var(--${name}, ${name})`);
+        })
+        .join(',');
+      return prefix + rewritten + (important ? important[0] : '');
+    })
     .replace(/([\s;])font-weight\s*:\s*normal/gi, '$1font-weight: var(--font-weight)')
     .replace(/([\s;])color\s*:\s*black/gi, '$1color: var(--theme-fg-color)')
     .replace(/([\s;])color\s*:\s*#000000/gi, '$1color: var(--theme-fg-color)')


### PR DESCRIPTION
## Summary

With **Override Book Font** off, a book's embedded fonts could silently fail to apply — especially on mobile, where the default font is sans-serif. Two independent mechanisms were responsible; this PR fixes both.

### 1. Generic-family rewriting corrupted the book's font names

`transformStylesheet` rewrote the generic keywords `serif` / `sans-serif` / `monospace` inside book CSS so the user's per-category font choice applies as a fallback. The regexes matched those words *anywhere* in a `font-family` declaration, including inside the book's own family names:

```css
/* book CSS */
@font-face { font-family: Source Han Serif CN; src: url(...); }
body { font-family: Source Han Serif CN, serif; }

/* after rewriting */
@font-face { font-family: Source Han var(--serif, serif) CN; ... }
body { font-family: Source Han var(--serif, serif) CN, serif; }
```

For an unquoted name the injected `var()` is a real function, and since CSS descriptors cannot contain `var()` every engine drops the whole `@font-face` rule; the reference in turn expands to the app font chain. The embedded font never loads. (Quoted names were corrupted too but stayed self-consistent — `var()` inside quotes is literal text — which made this easy to miss.)

Books that only reference generic families are still covered by the cascade fallbacks (the injected `html` font-family plus the body generic-unset pass), so the rewriting is simply removed.

### 2. The injected default font tied with book CSS declared on `html` and won by order

Pandoc-style EPUBs declare their font on the html element itself:

```css
html { font-family: '方正博雅刊宋_GBK', serif; }
```

The injected default (`html { font-family: var(--sans-serif) }`) has the same specificity (0,0,1) and is appended after the book's stylesheet, so it won on order alone. Body text inherited the app font while headings (which carry their own declarations) kept the book font — which made the bug read as "the toggle doesn't do anything".

The injection now uses `:where(html)` (and `:where(pre, code, kbd)` for the monospace fallback) so its specificity is zero: any book declaration wins regardless of order, while books that declare nothing still inherit the app default.

## Behavior after this PR

| Scenario | Before | After |
|---|---|---|
| Book declares fonts anywhere (incl. on `html`) | silently overridden by the app font | book fonts win when Override is off |
| Book font named `… Serif …` (unquoted) | `@font-face` dropped, font lost | preserved |
| Book declares no font at all | app default font | unchanged (app default font) |
| Override Book Font ON | app font forced | unchanged (app font forced) |

## Testing

- Unit tests updated; new regressions cover unquoted/quoted `Serif`-named families surviving the transform and the zero-specificity injection (220 style tests green).
- End-to-end on an Android emulator build with a Pandoc-style EPUB whose fonts are declared on `html`: body text `computed font-family` switches from the app chain (`Roboto, "LXGW WenKai GB Screen", …, sans-serif`) to the book's embedded font, and `document.fonts` reports the faces as `loaded`.
- Probe pages in Chromium 146 and WebKit (Safari 26.4) confirmed the removed rewriting dropped unquoted-name `@font-face` rules in both engines.

## Notes

- `:where()` is supported by every WebView this app targets (Chrome 88+ / Safari 14+).
- Should also fix #4985 (body text ignoring the book font regardless of the toggle on iOS) and likely covers the embedded-font reports in #2070.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ebook font handling so book-specified fonts take precedence when reader font override is disabled.
  - Reader font override now correctly applies to monospace content, including styles marked `!important`.
  - Generic font families are mapped to configured reader fonts while preserving `!important` declarations.
  - Font names containing terms such as “serif,” “sans-serif,” or “monospace” remain unchanged.

- **Tests**
  - Added coverage for font precedence, monospace overrides, generic family replacement, declaration preservation, and repeated stylesheet processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->