### PR TITLE
fix(bookdrop): recover the iOS service after suspension and keep peer presence honest

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2260,13 +2260,6 @@
   "Transfer failed": "فشل النقل",
   "No supported book files from {{alias}}": "لا توجد ملفات كتب مدعومة من {{alias}}",
   "Receiving from {{alias}}": "جارٍ الاستلام من {{alias}}",
-  "{{alias}} wants to send you books": "يريد {{alias}} إرسال كتب إليك",
-  "{{count}} book(s), {{size}}_zero": "لا كتب، {{size}}",
-  "{{count}} book(s), {{size}}_one": "كتاب واحد، {{size}}",
-  "{{count}} book(s), {{size}}_two": "كتابان، {{size}}",
-  "{{count}} book(s), {{size}}_few": "{{count}} كتب، {{size}}",
-  "{{count}} book(s), {{size}}_many": "{{count}} كتابًا، {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} كتاب، {{size}}",
   "Accept": "قبول",
   "and {{count}} more_zero": "ولا مزيد",
   "and {{count}} more_one": "وواحد آخر",
@@ -2548,5 +2541,11 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ملف نسخة احتياطية من ReadEra (.bak)",
   "BookOrbit Sync": "مزامنة BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "احفظ مكتبتك وتقدم القراءة والتمييزات في حساب Readest الخاص بك. يمكنك تغيير ذلك في أي وقت من الإعدادات."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "احفظ مكتبتك وتقدم القراءة والتمييزات في حساب Readest الخاص بك. يمكنك تغيير ذلك في أي وقت من الإعدادات.",
+  "{{alias}} wants to send you {{count}} book(s)_zero": "يريد {{alias}} إرسال {{count}} كتاب إليك",
+  "{{alias}} wants to send you {{count}} book(s)_one": "يريد {{alias}} إرسال كتاب واحد إليك",
+  "{{alias}} wants to send you {{count}} book(s)_two": "يريد {{alias}} إرسال كتابين إليك",
+  "{{alias}} wants to send you {{count}} book(s)_few": "يريد {{alias}} إرسال {{count}} كتب إليك",
+  "{{alias}} wants to send you {{count}} book(s)_many": "يريد {{alias}} إرسال {{count}} كتابًا إليك",
+  "{{alias}} wants to send you {{count}} book(s)_other": "يريد {{alias}} إرسال {{count}} كتاب إليك"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2060,9 +2060,6 @@
   "Transfer failed": "স্থানান্তর ব্যর্থ হয়েছে",
   "No supported book files from {{alias}}": "{{alias}} থেকে কোনো সমর্থিত বইয়ের ফাইল নেই",
   "Receiving from {{alias}}": "{{alias}} থেকে গ্রহণ করা হচ্ছে",
-  "{{alias}} wants to send you books": "{{alias}} আপনাকে বই পাঠাতে চায়",
-  "{{count}} book(s), {{size}}_one": "{{count}}টি বই, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}}টি বই, {{size}}",
   "Accept": "গ্রহণ করুন",
   "and {{count}} more_one": "এবং আরও {{count}}টি",
   "and {{count}} more_other": "এবং আরও {{count}}টি",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra ব্যাকআপ ফাইল (.bak)",
   "BookOrbit Sync": "BookOrbit সিঙ্ক",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "আপনার লাইব্রেরি, পড়ার অগ্রগতি এবং হাইলাইটগুলি আপনার Readest অ্যাকাউন্টে সংরক্ষণ করুন। আপনি যেকোনো সময় সেটিংসে এটি পরিবর্তন করতে পারেন।"
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "আপনার লাইব্রেরি, পড়ার অগ্রগতি এবং হাইলাইটগুলি আপনার Readest অ্যাকাউন্টে সংরক্ষণ করুন। আপনি যেকোনো সময় সেটিংসে এটি পরিবর্তন করতে পারেন।",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} আপনাকে {{count}}টি বই পাঠাতে চায়",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} আপনাকে {{count}}টি বই পাঠাতে চায়"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2010,8 +2010,6 @@
   "Transfer failed": "བརྒྱུད་སྐུར་ཕམ་སོང་།",
   "No supported book files from {{alias}}": "{{alias}} ནས་རྒྱབ་སྐྱོར་ཡོད་པའི་དེབ་ཡིག་ཆ་མེད།",
   "Receiving from {{alias}}": "{{alias}} ནས་ལེན་བཞིན་པ།",
-  "{{alias}} wants to send you books": "{{alias}} ཡིས་ཁྱེད་ལ་དེབ་སྐུར་འདོད་ཡོད།",
-  "{{count}} book(s), {{size}}_other": "དེབ་ {{count}}, {{size}}",
   "Accept": "དང་ལེན།",
   "and {{count}} more_other": "དང་གཞན་ {{count}}",
   "{{count}} unsupported file(s) will be skipped_other": "རྒྱབ་སྐྱོར་མེད་པའི་ཡིག་ཆ་ {{count}} མཆོང་རྒྱུ།",
@@ -2248,5 +2246,6 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra གྲབས་ཉར་ཡིག་ཆ (.bak)",
   "BookOrbit Sync": "BookOrbit ཟླ་སྒྲིག",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "ཁྱེད་ཀྱི་དཔེ་མཛོད་དང་། ཀློག་པའི་ཡར་འཕེལ། གཙོ་གནད་བཅས་ཁྱེད་ཀྱི་ Readest རྩིས་ཐོའི་ནང་ཉར་ཚགས་བྱེད། འདི་ནི་དུས་ནམ་ཡིན་ཡང་སྒྲིག་སྟངས་ནང་བསྒྱུར་བཅོས་བྱེད་ཐུབ།"
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "ཁྱེད་ཀྱི་དཔེ་མཛོད་དང་། ཀློག་པའི་ཡར་འཕེལ། གཙོ་གནད་བཅས་ཁྱེད་ཀྱི་ Readest རྩིས་ཐོའི་ནང་ཉར་ཚགས་བྱེད། འདི་ནི་དུས་ནམ་ཡིན་ཡང་སྒྲིག་སྟངས་ནང་བསྒྱུར་བཅོས་བྱེད་ཐུབ།",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} ཡིས་ཁྱེད་ལ་དེབ་ {{count}} སྐུར་འདོད་ཡོད།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2060,9 +2060,6 @@
   "Transfer failed": "Übertragung fehlgeschlagen",
   "No supported book files from {{alias}}": "Keine unterstützten Buchdateien von {{alias}}",
   "Receiving from {{alias}}": "Empfangen von {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} möchte Ihnen Bücher senden",
-  "{{count}} book(s), {{size}}_one": "{{count}} Buch, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} Bücher, {{size}}",
   "Accept": "Annehmen",
   "and {{count}} more_one": "und {{count}} weiteres",
   "and {{count}} more_other": "und {{count}} weitere",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra-Sicherungsdatei (.bak)",
   "BookOrbit Sync": "BookOrbit-Synchronisierung",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Speichern Sie Ihre Bibliothek, Ihren Lesefortschritt und Ihre Markierungen in Ihrem Readest-Konto. Sie können dies jederzeit in den Einstellungen ändern."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Speichern Sie Ihre Bibliothek, Ihren Lesefortschritt und Ihre Markierungen in Ihrem Readest-Konto. Sie können dies jederzeit in den Einstellungen ändern.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} möchte Ihnen {{count}} Buch senden",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} möchte Ihnen {{count}} Bücher senden"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2060,9 +2060,6 @@
   "Transfer failed": "Η μεταφορά απέτυχε",
   "No supported book files from {{alias}}": "Δεν υπάρχουν υποστηριζόμενα αρχεία βιβλίων από {{alias}}",
   "Receiving from {{alias}}": "Λήψη από {{alias}}",
-  "{{alias}} wants to send you books": "Ο/Η {{alias}} θέλει να σας στείλει βιβλία",
-  "{{count}} book(s), {{size}}_one": "{{count}} βιβλίο, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} βιβλία, {{size}}",
   "Accept": "Αποδοχή",
   "and {{count}} more_one": "και {{count}} ακόμη",
   "and {{count}} more_other": "και {{count}} ακόμη",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Αρχείο αντιγράφου ασφαλείας ReadEra (.bak)",
   "BookOrbit Sync": "Συγχρονισμός BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Αποθηκεύστε τη βιβλιοθήκη, την πρόοδο ανάγνωσης και τις επισημάνσεις σας στον λογαριασμό σας Readest. Μπορείτε να το αλλάξετε ανά πάσα στιγμή στις Ρυθμίσεις."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Αποθηκεύστε τη βιβλιοθήκη, την πρόοδο ανάγνωσης και τις επισημάνσεις σας στον λογαριασμό σας Readest. Μπορείτε να το αλλάξετε ανά πάσα στιγμή στις Ρυθμίσεις.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "Ο/Η {{alias}} θέλει να σας στείλει {{count}} βιβλίο",
+  "{{alias}} wants to send you {{count}} book(s)_other": "Ο/Η {{alias}} θέλει να σας στείλει {{count}} βιβλία"
 }

--- a/apps/readest-app/public/locales/en/translation.json
+++ b/apps/readest-app/public/locales/en/translation.json
@@ -111,5 +111,9 @@
   "{{count}} server_one": "{{count}} server",
   "{{count}} server_other": "{{count}} servers",
   "Includes {{count}} orphaned book file(s) not in your library_one": "Includes {{count}} orphaned book file not in your library",
-  "Includes {{count}} orphaned book file(s) not in your library_other": "Includes {{count}} orphaned book files not in your library"
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Includes {{count}} orphaned book files not in your library",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} wants to send you {{count}} book",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} wants to send you {{count}} books",
+  "{{count}} unsupported file(s) will be skipped_one": "{{count}} unsupported file will be skipped",
+  "{{count}} unsupported file(s) will be skipped_other": "{{count}} unsupported files will be skipped"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2110,10 +2110,6 @@
   "Transfer failed": "Error en la transferencia",
   "No supported book files from {{alias}}": "No hay archivos de libros compatibles de {{alias}}",
   "Receiving from {{alias}}": "Recibiendo de {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} quiere enviarte libros",
-  "{{count}} book(s), {{size}}_one": "{{count}} libro, {{size}}",
-  "{{count}} book(s), {{size}}_many": "{{count}} libros, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} libros, {{size}}",
   "Accept": "Aceptar",
   "and {{count}} more_one": "y {{count}} más",
   "and {{count}} more_many": "y {{count}} más",
@@ -2368,5 +2364,8 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Archivo de copia de seguridad de ReadEra (.bak)",
   "BookOrbit Sync": "Sincronización de BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Guarda tu biblioteca, progreso de lectura y resaltados en tu cuenta de Readest. Puedes cambiar esto en cualquier momento en Configuraciones."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Guarda tu biblioteca, progreso de lectura y resaltados en tu cuenta de Readest. Puedes cambiar esto en cualquier momento en Configuraciones.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} quiere enviarte {{count}} libro",
+  "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} quiere enviarte {{count}} libros",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} quiere enviarte {{count}} libros"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2060,9 +2060,6 @@
   "Transfer failed": "انتقال ناموفق بود",
   "No supported book files from {{alias}}": "هیچ فایل کتاب پشتیبانی‌شده‌ای از {{alias}} وجود ندارد",
   "Receiving from {{alias}}": "در حال دریافت از {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} می‌خواهد برای شما کتاب بفرستد",
-  "{{count}} book(s), {{size}}_one": "{{count}} کتاب، {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} کتاب، {{size}}",
   "Accept": "پذیرفتن",
   "and {{count}} more_one": "و {{count}} مورد دیگر",
   "and {{count}} more_other": "و {{count}} مورد دیگر",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "فایل پشتیبان ReadEra ‏(.bak)",
   "BookOrbit Sync": "همگام‌سازی BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "کتابخانه، وضعیت مطالعه و هایلایت‌های خود را در حساب Readest خود ذخیره کنید. می‌توانید این را هر زمان در تنظیمات تغییر دهید."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "کتابخانه، وضعیت مطالعه و هایلایت‌های خود را در حساب Readest خود ذخیره کنید. می‌توانید این را هر زمان در تنظیمات تغییر دهید.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} می‌خواهد {{count}} کتاب برای شما بفرستد",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} می‌خواهد {{count}} کتاب برای شما بفرستد"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2110,10 +2110,6 @@
   "Transfer failed": "Échec du transfert",
   "No supported book files from {{alias}}": "Aucun fichier de livre pris en charge de {{alias}}",
   "Receiving from {{alias}}": "Réception depuis {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} souhaite vous envoyer des livres",
-  "{{count}} book(s), {{size}}_one": "{{count}} livre, {{size}}",
-  "{{count}} book(s), {{size}}_many": "{{count}} livres, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} livres, {{size}}",
   "Accept": "Accepter",
   "and {{count}} more_one": "et {{count}} de plus",
   "and {{count}} more_many": "et {{count}} de plus",
@@ -2368,5 +2364,8 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Fichier de sauvegarde ReadEra (.bak)",
   "BookOrbit Sync": "Synchronisation BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Stockez votre bibliothèque, votre progression de lecture et vos surlignages dans votre compte Readest. Vous pouvez modifier ce choix à tout moment dans les Paramètres."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Stockez votre bibliothèque, votre progression de lecture et vos surlignages dans votre compte Readest. Vous pouvez modifier ce choix à tout moment dans les Paramètres.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} souhaite vous envoyer {{count}} livre",
+  "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} souhaite vous envoyer {{count}} livres",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} souhaite vous envoyer {{count}} livres"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2110,10 +2110,6 @@
   "Transfer failed": "ההעברה נכשלה",
   "No supported book files from {{alias}}": "אין קובצי ספרים נתמכים מ-{{alias}}",
   "Receiving from {{alias}}": "מקבל מ-{{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} רוצה לשלוח לכם ספרים",
-  "{{count}} book(s), {{size}}_one": "ספר אחד, {{size}}",
-  "{{count}} book(s), {{size}}_two": "{{count}} ספרים, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} ספרים, {{size}}",
   "Accept": "אישור",
   "and {{count}} more_one": "ועוד אחד",
   "and {{count}} more_two": "ועוד {{count}}",
@@ -2368,5 +2364,8 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "קובץ גיבוי של ReadEra ‏(.bak)",
   "BookOrbit Sync": "סנכרון BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "אחסן את הספרייה, התקדמות הקריאה וההדגשות שלך בחשבון Readest שלך. תוכל לשנות זאת בכל עת בהגדרות."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "אחסן את הספרייה, התקדמות הקריאה וההדגשות שלך בחשבון Readest שלך. תוכל לשנות זאת בכל עת בהגדרות.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} רוצה לשלוח לכם ספר אחד",
+  "{{alias}} wants to send you {{count}} book(s)_two": "{{alias}} רוצה לשלוח לכם {{count}} ספרים",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} רוצה לשלוח לכם {{count}} ספרים"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2060,9 +2060,6 @@
   "Transfer failed": "स्थानांतरण विफल रहा",
   "No supported book files from {{alias}}": "{{alias}} से कोई समर्थित पुस्तक फ़ाइल नहीं",
   "Receiving from {{alias}}": "{{alias}} से प्राप्त हो रहा है",
-  "{{alias}} wants to send you books": "{{alias}} आपको पुस्तकें भेजना चाहता है",
-  "{{count}} book(s), {{size}}_one": "{{count}} पुस्तक, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} पुस्तकें, {{size}}",
   "Accept": "स्वीकार करें",
   "and {{count}} more_one": "और {{count}} अन्य",
   "and {{count}} more_other": "और {{count}} अन्य",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra बैकअप फ़ाइल (.bak)",
   "BookOrbit Sync": "BookOrbit सिंक",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "अपनी लाइब्रेरी, पढ़ने की प्रगति और हाइलाइट्स को अपने Readest खाते में संग्रहीत करें। आप इसे कभी भी सेटिंग्स में बदल सकते हैं।"
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "अपनी लाइब्रेरी, पढ़ने की प्रगति और हाइलाइट्स को अपने Readest खाते में संग्रहीत करें। आप इसे कभी भी सेटिंग्स में बदल सकते हैं।",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} आपको {{count}} पुस्तक भेजना चाहता है",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} आपको {{count}} पुस्तकें भेजना चाहता है"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2060,9 +2060,6 @@
   "Transfer failed": "Az átvitel sikertelen",
   "No supported book files from {{alias}}": "Nincs támogatott könyvfájl tőle: {{alias}}",
   "Receiving from {{alias}}": "Fogadás tőle: {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} könyveket szeretne küldeni Önnek",
-  "{{count}} book(s), {{size}}_one": "{{count}} könyv, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} könyv, {{size}}",
   "Accept": "Elfogadás",
   "and {{count}} more_one": "és még {{count}}",
   "and {{count}} more_other": "és még {{count}}",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra biztonsági mentés fájlja (.bak)",
   "BookOrbit Sync": "BookOrbit szinkronizálás",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Tárolja könyvtárát, olvasási haladását és kiemeléseit a Readest-fiókjában. Ezt bármikor megváltoztathatja a Beállításokban."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Tárolja könyvtárát, olvasási haladását és kiemeléseit a Readest-fiókjában. Ezt bármikor megváltoztathatja a Beállításokban.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} {{count}} könyvet szeretne küldeni Önnek",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} {{count}} könyvet szeretne küldeni Önnek"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2010,8 +2010,6 @@
   "Transfer failed": "Transfer gagal",
   "No supported book files from {{alias}}": "Tidak ada berkas buku yang didukung dari {{alias}}",
   "Receiving from {{alias}}": "Menerima dari {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} ingin mengirimi Anda buku",
-  "{{count}} book(s), {{size}}_other": "{{count}} buku, {{size}}",
   "Accept": "Terima",
   "and {{count}} more_other": "dan {{count}} lainnya",
   "{{count}} unsupported file(s) will be skipped_other": "{{count}} berkas yang tidak didukung akan dilewati",
@@ -2248,5 +2246,6 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "File cadangan ReadEra (.bak)",
   "BookOrbit Sync": "Sinkronisasi BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Simpan perpustakaan, progres membaca, dan sorotan Anda di akun Readest Anda. Anda dapat mengubahnya kapan saja di Pengaturan."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Simpan perpustakaan, progres membaca, dan sorotan Anda di akun Readest Anda. Anda dapat mengubahnya kapan saja di Pengaturan.",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} ingin mengirimi Anda {{count}} buku"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2110,10 +2110,6 @@
   "Transfer failed": "Trasferimento non riuscito",
   "No supported book files from {{alias}}": "Nessun file di libro supportato da {{alias}}",
   "Receiving from {{alias}}": "Ricezione da {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} vuole inviarti dei libri",
-  "{{count}} book(s), {{size}}_one": "{{count}} libro, {{size}}",
-  "{{count}} book(s), {{size}}_many": "{{count}} libri, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} libri, {{size}}",
   "Accept": "Accetta",
   "and {{count}} more_one": "e {{count}} altro",
   "and {{count}} more_many": "e altri {{count}}",
@@ -2368,5 +2364,8 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "File di backup di ReadEra (.bak)",
   "BookOrbit Sync": "Sincronizzazione BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Archivia la tua biblioteca, il progresso di lettura e le evidenziazioni nel tuo account Readest. Puoi modificarlo in qualsiasi momento nelle Impostazioni."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Archivia la tua biblioteca, il progresso di lettura e le evidenziazioni nel tuo account Readest. Puoi modificarlo in qualsiasi momento nelle Impostazioni.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} vuole inviarti {{count}} libro",
+  "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} vuole inviarti {{count}} libri",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} vuole inviarti {{count}} libri"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2010,8 +2010,6 @@
   "Transfer failed": "転送に失敗しました",
   "No supported book files from {{alias}}": "{{alias}}からの対応している本のファイルがありません",
   "Receiving from {{alias}}": "{{alias}}から受信中",
-  "{{alias}} wants to send you books": "{{alias}}が本を送信しようとしています",
-  "{{count}} book(s), {{size}}_other": "{{count}}冊、{{size}}",
   "Accept": "受け入れる",
   "and {{count}} more_other": "ほか{{count}}件",
   "{{count}} unsupported file(s) will be skipped_other": "対応していない{{count}}件のファイルはスキップされます",
@@ -2248,5 +2246,6 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra のバックアップファイル (.bak)",
   "BookOrbit Sync": "BookOrbit同期",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "ライブラリ、読書進捗、ハイライトを Readest アカウントに保存します。設定でいつでも変更できます。"
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "ライブラリ、読書進捗、ハイライトを Readest アカウントに保存します。設定でいつでも変更できます。",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}}が{{count}}冊の本を送信しようとしています"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -1249,9 +1249,6 @@
   "Transfer failed": "გადაცემა ვერ შესრულდა",
   "No supported book files from {{alias}}": "{{alias}}-იდან მხარდაჭერილი წიგნის ფაილები არ არის",
   "Receiving from {{alias}}": "მიღება {{alias}}-იდან",
-  "{{alias}} wants to send you books": "{{alias}}-ს სურს გამოგიგზავნოთ წიგნები",
-  "{{count}} book(s), {{size}}_one": "{{count}} წიგნი, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} წიგნი, {{size}}",
   "Accept": "მიღება",
   "and {{count}} more_one": "და კიდევ {{count}}",
   "and {{count}} more_other": "და კიდევ {{count}}",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra-ს სარეზერვო ასლის ფაილი (.bak)",
   "BookOrbit Sync": "BookOrbit სინქრონიზაცია",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "შეინახეთ თქვენი ბიბლიოთეკა, კითხვის პროგრესი და მარკირებები თქვენს Readest ანგარიშში. ამის შეცვლა ნებისმიერ დროს შეგიძლიათ პარამეტრებში."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "შეინახეთ თქვენი ბიბლიოთეკა, კითხვის პროგრესი და მარკირებები თქვენს Readest ანგარიშში. ამის შეცვლა ნებისმიერ დროს შეგიძლიათ პარამეტრებში.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}}-ს სურს გამოგიგზავნოთ {{count}} წიგნი",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}}-ს სურს გამოგიგზავნოთ {{count}} წიგნი"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2010,8 +2010,6 @@
   "Transfer failed": "전송에 실패했습니다",
   "No supported book files from {{alias}}": "{{alias}}에서 지원되는 책 파일이 없습니다",
   "Receiving from {{alias}}": "{{alias}}에서 받는 중",
-  "{{alias}} wants to send you books": "{{alias}}이(가) 책을 보내려고 합니다",
-  "{{count}} book(s), {{size}}_other": "책 {{count}}권, {{size}}",
   "Accept": "수락",
   "and {{count}} more_other": "외 {{count}}개",
   "{{count}} unsupported file(s) will be skipped_other": "지원되지 않는 파일 {{count}}개는 건너뜁니다",
@@ -2248,5 +2246,6 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra 백업 파일 (.bak)",
   "BookOrbit Sync": "BookOrbit 동기화",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "라이브러리, 읽기 진행 상황, 하이라이트를 Readest 계정에 저장합니다. 설정에서 언제든지 변경할 수 있습니다."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "라이브러리, 읽기 진행 상황, 하이라이트를 Readest 계정에 저장합니다. 설정에서 언제든지 변경할 수 있습니다.",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}}이(가) 책 {{count}}권을 보내려고 합니다"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2010,8 +2010,6 @@
   "Transfer failed": "Pemindahan gagal",
   "No supported book files from {{alias}}": "Tiada fail buku yang disokong daripada {{alias}}",
   "Receiving from {{alias}}": "Menerima daripada {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} mahu menghantar buku kepada anda",
-  "{{count}} book(s), {{size}}_other": "{{count}} buku, {{size}}",
   "Accept": "Terima",
   "and {{count}} more_other": "dan {{count}} lagi",
   "{{count}} unsupported file(s) will be skipped_other": "{{count}} fail yang tidak disokong akan dilangkau",
@@ -2248,5 +2246,6 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Fail sandaran ReadEra (.bak)",
   "BookOrbit Sync": "Penyegerakan BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Simpan perpustakaan, kemajuan bacaan dan penonjolan anda dalam akaun Readest anda. Anda boleh mengubahnya pada bila-bila masa dalam Tetapan."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Simpan perpustakaan, kemajuan bacaan dan penonjolan anda dalam akaun Readest anda. Anda boleh mengubahnya pada bila-bila masa dalam Tetapan.",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} mahu menghantar {{count}} buku kepada anda"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2060,9 +2060,6 @@
   "Transfer failed": "Overdracht mislukt",
   "No supported book files from {{alias}}": "Geen ondersteunde boekbestanden van {{alias}}",
   "Receiving from {{alias}}": "Ontvangen van {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} wil u boeken sturen",
-  "{{count}} book(s), {{size}}_one": "{{count}} boek, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} boeken, {{size}}",
   "Accept": "Accepteren",
   "and {{count}} more_one": "en {{count}} meer",
   "and {{count}} more_other": "en {{count}} meer",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra-back-upbestand (.bak)",
   "BookOrbit Sync": "BookOrbit-synchronisatie",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Sla je bibliotheek, leesvoortgang en markeringen op in je Readest-account. Je kunt dit altijd wijzigen in Instellingen."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Sla je bibliotheek, leesvoortgang en markeringen op in je Readest-account. Je kunt dit altijd wijzigen in Instellingen.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} wil u {{count}} boek sturen",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} wil u {{count}} boeken sturen"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2160,11 +2160,6 @@
   "Transfer failed": "Przesyłanie nie powiodło się",
   "No supported book files from {{alias}}": "Brak obsługiwanych plików książek od {{alias}}",
   "Receiving from {{alias}}": "Odbieranie od {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} chce wysłać Ci książki",
-  "{{count}} book(s), {{size}}_one": "{{count}} książka, {{size}}",
-  "{{count}} book(s), {{size}}_few": "{{count}} książki, {{size}}",
-  "{{count}} book(s), {{size}}_many": "{{count}} książek, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} książki, {{size}}",
   "Accept": "Akceptuj",
   "and {{count}} more_one": "i jeszcze {{count}}",
   "and {{count}} more_few": "i jeszcze {{count}}",
@@ -2428,5 +2423,9 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Plik kopii zapasowej ReadEra (.bak)",
   "BookOrbit Sync": "Synchronizacja BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Przechowuj bibliotekę, postęp czytania i zaznaczenia na swoim koncie Readest. Możesz to zmienić w dowolnej chwili w Ustawieniach."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Przechowuj bibliotekę, postęp czytania i zaznaczenia na swoim koncie Readest. Możesz to zmienić w dowolnej chwili w Ustawieniach.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} chce wysłać Ci {{count}} książkę",
+  "{{alias}} wants to send you {{count}} book(s)_few": "{{alias}} chce wysłać Ci {{count}} książki",
+  "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} chce wysłać Ci {{count}} książek",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} chce wysłać Ci {{count}} książki"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2110,10 +2110,6 @@
   "Transfer failed": "Falha na transferência",
   "No supported book files from {{alias}}": "Nenhum arquivo de livro compatível de {{alias}}",
   "Receiving from {{alias}}": "Recebendo de {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} quer enviar livros para você",
-  "{{count}} book(s), {{size}}_one": "{{count}} livro, {{size}}",
-  "{{count}} book(s), {{size}}_many": "{{count}} livros, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} livros, {{size}}",
   "Accept": "Aceitar",
   "and {{count}} more_one": "e mais {{count}}",
   "and {{count}} more_many": "e mais {{count}}",
@@ -2368,5 +2364,8 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Arquivo de backup do ReadEra (.bak)",
   "BookOrbit Sync": "Sincronização do BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Armazene sua biblioteca, progresso de leitura e destaques na sua conta Readest. Você pode alterar isso a qualquer momento nas Configurações."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Armazene sua biblioteca, progresso de leitura e destaques na sua conta Readest. Você pode alterar isso a qualquer momento nas Configurações.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} quer enviar {{count}} livro para você",
+  "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} quer enviar {{count}} livros para você",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} quer enviar {{count}} livros para você"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2110,10 +2110,6 @@
   "Transfer failed": "Falha na transferência",
   "No supported book files from {{alias}}": "Nenhum ficheiro de livro suportado de {{alias}}",
   "Receiving from {{alias}}": "A receber de {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} quer enviar-lhe livros",
-  "{{count}} book(s), {{size}}_one": "{{count}} livro, {{size}}",
-  "{{count}} book(s), {{size}}_many": "{{count}} livros, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} livros, {{size}}",
   "Accept": "Aceitar",
   "and {{count}} more_one": "e mais {{count}}",
   "and {{count}} more_many": "e mais {{count}}",
@@ -2368,5 +2364,8 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Ficheiro de backup do ReadEra (.bak)",
   "BookOrbit Sync": "Sincronização do BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Guarde a sua biblioteca, o progresso de leitura e os destaques na sua conta Readest. Pode alterar isto a qualquer momento nas Configurações."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Guarde a sua biblioteca, o progresso de leitura e os destaques na sua conta Readest. Pode alterar isto a qualquer momento nas Configurações.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} quer enviar-lhe {{count}} livro",
+  "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} quer enviar-lhe {{count}} livros",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} quer enviar-lhe {{count}} livros"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2110,10 +2110,6 @@
   "Transfer failed": "Transferul a eșuat",
   "No supported book files from {{alias}}": "Niciun fișier de carte acceptat de la {{alias}}",
   "Receiving from {{alias}}": "Se primește de la {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} vrea să vă trimită cărți",
-  "{{count}} book(s), {{size}}_one": "{{count}} carte, {{size}}",
-  "{{count}} book(s), {{size}}_few": "{{count}} cărți, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} de cărți, {{size}}",
   "Accept": "Acceptă",
   "and {{count}} more_one": "și încă {{count}}",
   "and {{count}} more_few": "și încă {{count}}",
@@ -2368,5 +2364,8 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Fișier de backup ReadEra (.bak)",
   "BookOrbit Sync": "Sincronizare BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Stochează-ți biblioteca, progresul citirii și evidențierile în contul tău Readest. Poți schimba această opțiune oricând în Setări."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Stochează-ți biblioteca, progresul citirii și evidențierile în contul tău Readest. Poți schimba această opțiune oricând în Setări.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} vrea să vă trimită {{count}} carte",
+  "{{alias}} wants to send you {{count}} book(s)_few": "{{alias}} vrea să vă trimită {{count}} cărți",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} vrea să vă trimită {{count}} de cărți"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2160,11 +2160,6 @@
   "Transfer failed": "Ошибка передачи",
   "No supported book files from {{alias}}": "Нет поддерживаемых файлов книг от {{alias}}",
   "Receiving from {{alias}}": "Приём от {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} хочет отправить вам книги",
-  "{{count}} book(s), {{size}}_one": "{{count}} книга, {{size}}",
-  "{{count}} book(s), {{size}}_few": "{{count}} книги, {{size}}",
-  "{{count}} book(s), {{size}}_many": "{{count}} книг, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} книги, {{size}}",
   "Accept": "Принять",
   "and {{count}} more_one": "и ещё {{count}}",
   "and {{count}} more_few": "и ещё {{count}}",
@@ -2428,5 +2423,9 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Файл резервной копии ReadEra (.bak)",
   "BookOrbit Sync": "Синхронизация BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Храните свою библиотеку, прогресс чтения и выделения в своей учётной записи Readest. Это можно изменить в любой момент в Настройках."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Храните свою библиотеку, прогресс чтения и выделения в своей учётной записи Readest. Это можно изменить в любой момент в Настройках.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} хочет отправить вам {{count}} книгу",
+  "{{alias}} wants to send you {{count}} book(s)_few": "{{alias}} хочет отправить вам {{count}} книги",
+  "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} хочет отправить вам {{count}} книг",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} хочет отправить вам {{count}} книги"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2060,9 +2060,6 @@
   "Transfer failed": "හුවමාරුව අසාර්ථක විය",
   "No supported book files from {{alias}}": "{{alias}} වෙතින් සහාය දක්වන පොත් ගොනු නැත",
   "Receiving from {{alias}}": "{{alias}} වෙතින් ලැබෙමින්",
-  "{{alias}} wants to send you books": "{{alias}} ඔබට පොත් යැවීමට කැමතියි",
-  "{{count}} book(s), {{size}}_one": "පොත් {{count}}ක්, {{size}}",
-  "{{count}} book(s), {{size}}_other": "පොත් {{count}}ක්, {{size}}",
   "Accept": "පිළිගන්න",
   "and {{count}} more_one": "තවත් {{count}}ක්",
   "and {{count}} more_other": "තවත් {{count}}ක්",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra උපස්ථ ගොනුව (.bak)",
   "BookOrbit Sync": "BookOrbit සමමුහුර්තකරණය",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "ඔබේ පුස්තකාලය, කියවීමේ ප්‍රගතිය සහ ඉස්මතු කිරීම් ඔබේ Readest ගිණුමේ ගබඩා කරන්න. ඔබට ඕනෑම වේලාවක සැකසුම් තුළ මෙය වෙනස් කළ හැකිය."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "ඔබේ පුස්තකාලය, කියවීමේ ප්‍රගතිය සහ ඉස්මතු කිරීම් ඔබේ Readest ගිණුමේ ගබඩා කරන්න. ඔබට ඕනෑම වේලාවක සැකසුම් තුළ මෙය වෙනස් කළ හැකිය.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} ඔබට පොත් {{count}}ක් යැවීමට කැමතියි",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} ඔබට පොත් {{count}}ක් යැවීමට කැමතියි"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2160,11 +2160,6 @@
   "Transfer failed": "Prenos ni uspel",
   "No supported book files from {{alias}}": "Ni podprtih datotek knjig od {{alias}}",
   "Receiving from {{alias}}": "Prejemanje od {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} vam želi poslati knjige",
-  "{{count}} book(s), {{size}}_one": "{{count}} knjiga, {{size}}",
-  "{{count}} book(s), {{size}}_two": "{{count}} knjigi, {{size}}",
-  "{{count}} book(s), {{size}}_few": "{{count}} knjige, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} knjig, {{size}}",
   "Accept": "Sprejmi",
   "and {{count}} more_one": "in še {{count}}",
   "and {{count}} more_two": "in še {{count}}",
@@ -2428,5 +2423,9 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Datoteka varnostne kopije ReadEra (.bak)",
   "BookOrbit Sync": "Sinhronizacija BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Shranite knjižnico, napredek branja in označbe v svoj račun Readest. To lahko kadar koli spremenite v Nastavitvah."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Shranite knjižnico, napredek branja in označbe v svoj račun Readest. To lahko kadar koli spremenite v Nastavitvah.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} vam želi poslati {{count}} knjigo",
+  "{{alias}} wants to send you {{count}} book(s)_two": "{{alias}} vam želi poslati {{count}} knjigi",
+  "{{alias}} wants to send you {{count}} book(s)_few": "{{alias}} vam želi poslati {{count}} knjige",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} vam želi poslati {{count}} knjig"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2060,9 +2060,6 @@
   "Transfer failed": "Överföringen misslyckades",
   "No supported book files from {{alias}}": "Inga bokfiler som stöds från {{alias}}",
   "Receiving from {{alias}}": "Tar emot från {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} vill skicka böcker till dig",
-  "{{count}} book(s), {{size}}_one": "{{count}} bok, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} böcker, {{size}}",
   "Accept": "Acceptera",
   "and {{count}} more_one": "och {{count}} till",
   "and {{count}} more_other": "och {{count}} till",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra-säkerhetskopia (.bak)",
   "BookOrbit Sync": "BookOrbit-synkronisering",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Lagra ditt bibliotek, dina läsframsteg och markeringar i ditt Readest-konto. Du kan ändra detta när som helst i Inställningar."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Lagra ditt bibliotek, dina läsframsteg och markeringar i ditt Readest-konto. Du kan ändra detta när som helst i Inställningar.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} vill skicka {{count}} bok till dig",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} vill skicka {{count}} böcker till dig"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2060,9 +2060,6 @@
   "Transfer failed": "பரிமாற்றம் தோல்வியடைந்தது",
   "No supported book files from {{alias}}": "{{alias}}-இடமிருந்து ஆதரிக்கப்படும் புத்தகக் கோப்புகள் இல்லை",
   "Receiving from {{alias}}": "{{alias}}-இடமிருந்து பெறப்படுகிறது",
-  "{{alias}} wants to send you books": "{{alias}} உங்களுக்குப் புத்தகங்களை அனுப்ப விரும்புகிறார்",
-  "{{count}} book(s), {{size}}_one": "{{count}} புத்தகம், {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} புத்தகங்கள், {{size}}",
   "Accept": "ஏற்றுக்கொள்",
   "and {{count}} more_one": "மேலும் {{count}}",
   "and {{count}} more_other": "மேலும் {{count}}",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra காப்புப்பிரதி கோப்பு (.bak)",
   "BookOrbit Sync": "BookOrbit ஒத்திசைவு",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "உங்கள் நூலகம், வாசிப்பு முன்னேற்றம் மற்றும் சிறப்பம்சங்களை உங்கள் Readest கணக்கில் சேமிக்கவும். இதை எப்போது வேண்டுமானாலும் அமைப்புகளில் மாற்றலாம்."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "உங்கள் நூலகம், வாசிப்பு முன்னேற்றம் மற்றும் சிறப்பம்சங்களை உங்கள் Readest கணக்கில் சேமிக்கவும். இதை எப்போது வேண்டுமானாலும் அமைப்புகளில் மாற்றலாம்.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} உங்களுக்கு {{count}} புத்தகத்தை அனுப்ப விரும்புகிறார்",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} உங்களுக்கு {{count}} புத்தகங்களை அனுப்ப விரும்புகிறார்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2010,8 +2010,6 @@
   "Transfer failed": "การถ่ายโอนล้มเหลว",
   "No supported book files from {{alias}}": "ไม่มีไฟล์หนังสือที่รองรับจาก {{alias}}",
   "Receiving from {{alias}}": "กำลังรับจาก {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} ต้องการส่งหนังสือให้คุณ",
-  "{{count}} book(s), {{size}}_other": "หนังสือ {{count}} เล่ม, {{size}}",
   "Accept": "ยอมรับ",
   "and {{count}} more_other": "และอีก {{count}} รายการ",
   "{{count}} unsupported file(s) will be skipped_other": "จะข้ามไฟล์ที่ไม่รองรับ {{count}} ไฟล์",
@@ -2248,5 +2246,6 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ไฟล์สำรองข้อมูลของ ReadEra (.bak)",
   "BookOrbit Sync": "การซิงค์ BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "จัดเก็บคลังหนังสือ ความคืบหน้าการอ่าน และไฮไลต์ของคุณไว้ในบัญชี Readest ของคุณ คุณสามารถเปลี่ยนได้ทุกเมื่อในการตั้งค่า"
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "จัดเก็บคลังหนังสือ ความคืบหน้าการอ่าน และไฮไลต์ของคุณไว้ในบัญชี Readest ของคุณ คุณสามารถเปลี่ยนได้ทุกเมื่อในการตั้งค่า",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} ต้องการส่งหนังสือ {{count}} เล่มให้คุณ"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2060,9 +2060,6 @@
   "Transfer failed": "Aktarım başarısız oldu",
   "No supported book files from {{alias}}": "{{alias}} cihazından desteklenen kitap dosyası yok",
   "Receiving from {{alias}}": "{{alias}} cihazından alınıyor",
-  "{{alias}} wants to send you books": "{{alias}} size kitap göndermek istiyor",
-  "{{count}} book(s), {{size}}_one": "{{count}} kitap, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} kitap, {{size}}",
   "Accept": "Kabul et",
   "and {{count}} more_one": "ve {{count}} tane daha",
   "and {{count}} more_other": "ve {{count}} tane daha",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra yedek dosyası (.bak)",
   "BookOrbit Sync": "BookOrbit Senkronizasyonu",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Kütüphanenizi, okuma ilerlemenizi ve vurgularınızı Readest hesabınızda saklayın. Bunu istediğiniz zaman Ayarlar'dan değiştirebilirsiniz."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Kütüphanenizi, okuma ilerlemenizi ve vurgularınızı Readest hesabınızda saklayın. Bunu istediğiniz zaman Ayarlar'dan değiştirebilirsiniz.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} size {{count}} kitap göndermek istiyor",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} size {{count}} kitap göndermek istiyor"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2160,11 +2160,6 @@
   "Transfer failed": "Помилка передавання",
   "No supported book files from {{alias}}": "Немає підтримуваних файлів книг від {{alias}}",
   "Receiving from {{alias}}": "Отримання від {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} хоче надіслати вам книги",
-  "{{count}} book(s), {{size}}_one": "{{count}} книга, {{size}}",
-  "{{count}} book(s), {{size}}_few": "{{count}} книги, {{size}}",
-  "{{count}} book(s), {{size}}_many": "{{count}} книг, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} книги, {{size}}",
   "Accept": "Прийняти",
   "and {{count}} more_one": "і ще {{count}}",
   "and {{count}} more_few": "і ще {{count}}",
@@ -2428,5 +2423,9 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Файл резервної копії ReadEra (.bak)",
   "BookOrbit Sync": "Синхронізація BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Зберігайте свою бібліотеку, проґрес читання та виділення у своєму обліковому записі Readest. Це можна змінити будь-коли в Налаштуваннях."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Зберігайте свою бібліотеку, проґрес читання та виділення у своєму обліковому записі Readest. Це можна змінити будь-коли в Налаштуваннях.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} хоче надіслати вам {{count}} книгу",
+  "{{alias}} wants to send you {{count}} book(s)_few": "{{alias}} хоче надіслати вам {{count}} книги",
+  "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} хоче надіслати вам {{count}} книг",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} хоче надіслати вам {{count}} книги"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2060,9 +2060,6 @@
   "Transfer failed": "Uzatish muvaffaqiyatsiz tugadi",
   "No supported book files from {{alias}}": "{{alias}}dan qo‘llab-quvvatlanadigan kitob fayllari yo‘q",
   "Receiving from {{alias}}": "{{alias}}dan qabul qilinmoqda",
-  "{{alias}} wants to send you books": "{{alias}} sizga kitob yubormoqchi",
-  "{{count}} book(s), {{size}}_one": "{{count}} ta kitob, {{size}}",
-  "{{count}} book(s), {{size}}_other": "{{count}} ta kitob, {{size}}",
   "Accept": "Qabul qilish",
   "and {{count}} more_one": "va yana {{count}} ta",
   "and {{count}} more_other": "va yana {{count}} ta",
@@ -2308,5 +2305,7 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra zaxira nusxa fayli (.bak)",
   "BookOrbit Sync": "BookOrbit sinxronlash",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Kutubxonangiz, oʻqish jarayoni va belgilashlaringizni Readest hisobingizda saqlang. Buni istalgan vaqtda Sozlamalarda oʻzgartirishingiz mumkin."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Kutubxonangiz, oʻqish jarayoni va belgilashlaringizni Readest hisobingizda saqlang. Buni istalgan vaqtda Sozlamalarda oʻzgartirishingiz mumkin.",
+  "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} sizga {{count}} ta kitob yubormoqchi",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} sizga {{count}} ta kitob yubormoqchi"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2010,8 +2010,6 @@
   "Transfer failed": "Truyền tệp thất bại",
   "No supported book files from {{alias}}": "Không có tệp sách được hỗ trợ từ {{alias}}",
   "Receiving from {{alias}}": "Đang nhận từ {{alias}}",
-  "{{alias}} wants to send you books": "{{alias}} muốn gửi sách cho bạn",
-  "{{count}} book(s), {{size}}_other": "{{count}} cuốn sách, {{size}}",
   "Accept": "Chấp nhận",
   "and {{count}} more_other": "và {{count}} mục khác",
   "{{count}} unsupported file(s) will be skipped_other": "{{count}} tệp không được hỗ trợ sẽ bị bỏ qua",
@@ -2248,5 +2246,6 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "Tệp sao lưu ReadEra (.bak)",
   "BookOrbit Sync": "Đồng bộ BookOrbit",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Lưu trữ thư viện, tiến trình đọc và điểm nổi bật của bạn trong tài khoản Readest của bạn. Bạn có thể thay đổi tùy chọn này bất cứ lúc nào trong Cài đặt."
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Lưu trữ thư viện, tiến trình đọc và điểm nổi bật của bạn trong tài khoản Readest của bạn. Bạn có thể thay đổi tùy chọn này bất cứ lúc nào trong Cài đặt.",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} muốn gửi cho bạn {{count}} cuốn sách"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2025,8 +2025,6 @@
   "Transfer failed": "传输失败",
   "No supported book files from {{alias}}": "{{alias}} 发送的文件中没有支持的图书文件",
   "Receiving from {{alias}}": "正在从 {{alias}} 接收",
-  "{{alias}} wants to send you books": "{{alias}} 想要向您发送图书",
-  "{{count}} book(s), {{size}}_other": "{{count}} 本书，{{size}}",
   "Accept": "接受",
   "and {{count}} more_other": "及另外 {{count}} 个",
   "{{count}} unsupported file(s) will be skipped_other": "将跳过 {{count}} 个不支持的文件",
@@ -2248,5 +2246,6 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra 备份文件 (.bak)",
   "BookOrbit Sync": "BookOrbit 同步",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "将您的书库、阅读进度和高亮存储在您的 Readest 账户中。您可以随时在设置中更改。"
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "将您的书库、阅读进度和高亮存储在您的 Readest 账户中。您可以随时在设置中更改。",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} 想要向您发送 {{count}} 本书"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2025,8 +2025,6 @@
   "Transfer failed": "傳輸失敗",
   "No supported book files from {{alias}}": "{{alias}} 傳送的檔案中沒有支援的書籍檔案",
   "Receiving from {{alias}}": "正在從 {{alias}} 接收",
-  "{{alias}} wants to send you books": "{{alias}} 想要傳送書籍給您",
-  "{{count}} book(s), {{size}}_other": "{{count}} 本書，{{size}}",
   "Accept": "接受",
   "and {{count}} more_other": "及另外 {{count}} 個",
   "{{count}} unsupported file(s) will be skipped_other": "將略過 {{count}} 個不支援的檔案",
@@ -2248,5 +2246,6 @@
   "ReadEra": "ReadEra",
   "ReadEra backup file (.bak)": "ReadEra 備份檔案 (.bak)",
   "BookOrbit Sync": "BookOrbit 同步",
-  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "將您的書庫、閱讀進度和高亮儲存在您的 Readest 帳戶中。您可以隨時在設定中變更。"
+  "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "將您的書庫、閱讀進度和高亮儲存在您的 Readest 帳戶中。您可以隨時在設定中變更。",
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} 想要傳送 {{count}} 本書給您"
 }

--- a/apps/readest-app/src-tauri/build.rs
+++ b/apps/readest-app/src-tauri/build.rs
@@ -61,6 +61,7 @@ fn main() {
             "localsend_list_devices",
             "localsend_announce",
             "localsend_set_discoverable",
+            "localsend_is_alive",
             "localsend_respond",
             "localsend_cancel_receive",
             "localsend_send_files",

--- a/apps/readest-app/src-tauri/capabilities/default.json
+++ b/apps/readest-app/src-tauri/capabilities/default.json
@@ -246,6 +246,7 @@
     "allow-localsend-list-devices",
     "allow-localsend-announce",
     "allow-localsend-set-discoverable",
+    "allow-localsend-is-alive",
     "allow-localsend-respond",
     "allow-localsend-cancel-receive",
     "allow-localsend-send-files",

--- a/apps/readest-app/src-tauri/capabilities/webdriver-remote.json
+++ b/apps/readest-app/src-tauri/capabilities/webdriver-remote.json
@@ -41,6 +41,7 @@
     "allow-localsend-list-devices",
     "allow-localsend-announce",
     "allow-localsend-set-discoverable",
+    "allow-localsend-is-alive",
     "allow-localsend-respond",
     "allow-localsend-cancel-receive",
     "allow-localsend-send-files",

--- a/apps/readest-app/src-tauri/permissions/autogenerated/localsend_is_alive.toml
+++ b/apps/readest-app/src-tauri/permissions/autogenerated/localsend_is_alive.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-localsend-is-alive"
+description = "Enables the localsend_is_alive command without any pre-configured scope."
+commands.allow = ["localsend_is_alive"]
+
+[[permission]]
+identifier = "deny-localsend-is-alive"
+description = "Denies the localsend_is_alive command without any pre-configured scope."
+commands.deny = ["localsend_is_alive"]

--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -445,6 +445,7 @@ pub fn run() {
             localsend::commands::localsend_list_devices,
             localsend::commands::localsend_announce,
             localsend::commands::localsend_set_discoverable,
+            localsend::commands::localsend_is_alive,
             localsend::commands::localsend_respond,
             localsend::commands::localsend_cancel_receive,
             localsend::commands::localsend_send_files,

--- a/apps/readest-app/src-tauri/src/localsend/commands.rs
+++ b/apps/readest-app/src-tauri/src/localsend/commands.rs
@@ -4,18 +4,24 @@ use super::LocalSendState;
 use std::collections::{HashMap, HashSet};
 use tauri::{AppHandle, Emitter, Runtime, State};
 
+/// Whether an interface can carry LocalSend peers, i.e. whether its address is
+/// worth reporting as this device's "#<n>" tag.
+///
+/// VPN tunnels (tun0/utun4/ppp0/wg0) and the cellular link (pdp_ip0) carry
+/// addresses no peer on the LAN can reach, so a tag naming one is a number the
+/// user can never match against what a peer shows. An iPhone on Wi-Fi with
+/// cellular up reported three tags for this reason.
+fn is_lan_interface(name: &str) -> bool {
+    !["tun", "utun", "ppp", "wg", "pdp_ip"]
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+}
+
 fn local_ips() -> Vec<String> {
     if_addrs::get_if_addrs()
         .unwrap_or_default()
         .iter()
-        // VPN tunnels (tun0/utun4/ppp0/wg0) carry addresses peers on the LAN
-        // never see; including them would add misleading "#<n>" device tags.
-        .filter(|iface| {
-            let name = iface.name.as_str();
-            !["tun", "utun", "ppp", "wg"]
-                .iter()
-                .any(|prefix| name.starts_with(prefix))
-        })
+        .filter(|iface| is_lan_interface(iface.name.as_str()))
         .filter_map(|iface| match iface.ip() {
             std::net::IpAddr::V4(ip) if !ip.is_loopback() => Some(ip.to_string()),
             _ => None,
@@ -121,7 +127,7 @@ pub async fn localsend_list_devices(
     let guard = state.0.lock().await;
     Ok(guard
         .as_ref()
-        .map(|s| service::device_payloads(&s.discovery))
+        .map(|s| service::device_payloads(&s.discovery, &s.departed))
         .unwrap_or_default())
 }
 
@@ -167,6 +173,22 @@ pub async fn localsend_announce(
     Ok(())
 }
 
+/// Whether the running service can still be reached. The webview calls this
+/// when the app returns to the foreground: on iOS the listening socket does
+/// not survive suspension, and nothing reports that, so `running: true` alone
+/// is not proof the service works (see [`service::listener_is_alive`]).
+#[tauri::command]
+pub async fn localsend_is_alive(state: State<'_, LocalSendState>) -> Result<bool, String> {
+    let port = {
+        let guard = state.0.lock().await;
+        guard.as_ref().map(|service| service.port)
+    };
+    match port {
+        Some(port) => Ok(service::listener_is_alive(port).await),
+        None => Ok(false),
+    }
+}
+
 #[tauri::command]
 pub async fn localsend_set_discoverable(
     state: State<'_, LocalSendState>,
@@ -176,17 +198,31 @@ pub async fn localsend_set_discoverable(
     // app is backgrounded, it stops answering announcements, so peers age it
     // out of their pickers within a few seconds (AirDrop style). On return it
     // answers again and announces once, so open pickers re-list it at once.
-    let discovery = {
+    let (discovery, identity, port) = {
         let guard = state.0.lock().await;
         let Some(service) = guard.as_ref() else {
             return Ok(());
         };
-        service.discovery.clone()
+        (
+            service.discovery.clone(),
+            service.identity.clone(),
+            service.port,
+        )
     };
     discovery.set_answer_announcements(active);
     if active {
         discovery.announce().await;
     }
+    // Multicast never reaches an iOS peer (no multicast entitlement), and a
+    // device that just went dark keeps answering probes for its whole grace
+    // window, so peers would hold its tile for 10-15s. Tell them directly:
+    // the real port means "back", DEPARTURE_PORT means "going dark".
+    let notify_port = if active {
+        port
+    } else {
+        service::DEPARTURE_PORT
+    };
+    service::notify_peers(&identity, &discovery, notify_port).await;
     Ok(())
 }
 
@@ -367,6 +403,18 @@ pub async fn localsend_cancel_send(state: State<'_, LocalSendState>) -> Result<(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lan_interfaces_exclude_tunnels_and_cellular() {
+        for name in ["en0", "en8", "bridge100", "awdl0", "eth0"] {
+            assert!(is_lan_interface(name), "{name} can carry LAN peers");
+        }
+        // pdp_ip0 is the iPhone's cellular link: reachable by nobody on the
+        // LAN, so its last octet must never become this device's tag.
+        for name in ["tun0", "utun4", "ppp0", "wg0", "pdp_ip0", "pdp_ip1"] {
+            assert!(!is_lan_interface(name), "{name} carries no LAN peers");
+        }
+    }
 
     #[test]
     fn scan_covers_localsend_and_readest_ports() {

--- a/apps/readest-app/src-tauri/src/localsend/identity.rs
+++ b/apps/readest-app/src-tauri/src/localsend/identity.rs
@@ -5,6 +5,7 @@
 use anyhow::Context;
 use localsend::crypto::cert::fingerprint_from_cert_der;
 use localsend::discovery::DeviceIdentity;
+use localsend::http::dto::RegisterDto;
 use localsend::http::dto_v2::RegisterDtoV2;
 use localsend::http::server::TlsConfig;
 use localsend::http::state::ClientInfo;
@@ -135,6 +136,25 @@ impl Identity {
         }
     }
 
+    /// The register payload this device sends to a peer directly, as the
+    /// presence hello (its real port) or goodbye (`DEPARTURE_PORT`).
+    ///
+    /// Derived from the same identity as [`Self::register_dto`], because a
+    /// register replaces the peer's stored device: a field missing here is a
+    /// field the peer loses until its next probe re-confirms us.
+    pub fn client_register_dto(&self, port: u16) -> RegisterDto {
+        RegisterDto {
+            alias: self.alias.clone(),
+            version: PROTOCOL_VERSION_V2.to_string(),
+            device_model: Some(self.device_model.clone()),
+            device_type: Some(device_type()),
+            token: self.fingerprint.clone(),
+            port,
+            protocol: ProtocolType::Https,
+            has_web_interface: false,
+        }
+    }
+
     pub fn multicast_device(&self, port: u16) -> MulticastDevice {
         MulticastDevice {
             alias: self.alias.clone(),
@@ -163,6 +183,36 @@ mod tests {
         assert_eq!(a.fingerprint, b.fingerprint);
         assert!(!a.fingerprint.is_empty());
         assert!(a.cert_pem.contains("BEGIN CERTIFICATE"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn client_register_dto_carries_the_same_identity_as_the_announce() {
+        // A register REPLACES the peer's stored device, so any field this
+        // drops is a field peers lose. Dropping `device_type` made an iPhone
+        // draw as a computer for a beat after every unlock.
+        let dir = std::env::temp_dir().join(format!("ls-crd-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = std::fs::remove_file(dir.join("identity.pem"));
+        let id = Identity::load_or_generate(&dir, "Phone".into(), "iOS".into()).unwrap();
+
+        let announced = id.register_dto(53318);
+        let sent = id.client_register_dto(53318);
+
+        assert_eq!(sent.alias, announced.alias);
+        assert_eq!(sent.version, announced.version);
+        assert_eq!(sent.device_model, announced.device_model);
+        assert_eq!(sent.device_type, announced.device_type);
+        assert!(sent.device_type.is_some(), "peers key their icon off this");
+        assert_eq!(sent.token, announced.fingerprint);
+        assert_eq!(sent.port, announced.port);
+        assert_eq!(sent.protocol, announced.protocol);
+        assert_eq!(sent.has_web_interface, announced.download);
+
+        // The goodbye differs from the hello in the port and nothing else.
+        let bye = id.client_register_dto(0);
+        assert_eq!(bye.port, 0);
+        assert_eq!(bye.device_type, announced.device_type);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/apps/readest-app/src-tauri/src/localsend/service.rs
+++ b/apps/readest-app/src-tauri/src/localsend/service.rs
@@ -8,6 +8,7 @@ use localsend::discovery::{
     DeviceChannel, DiscoveredDevice, DiscoveryConfig, DiscoveryEvent, DiscoveryHandle, HttpChannel,
     StatefulDevice, DEFAULT_DISCOVERY_TIMEOUT,
 };
+use localsend::http::client::{LsHttpClient, LsHttpClientVersion};
 use localsend::http::dto_v2::RegisterDtoV2;
 use localsend::http::server::common::save::FileUploadTarget;
 use localsend::http::server::v2::{PrepareUploadDecisionV2, ServerEventV2, SessionEndReasonV2};
@@ -91,6 +92,8 @@ pub struct RunningService {
     pub pending: PendingMap,
     pub receiving: ReceivingMap,
     pub send_cancel: SendCancelSlot,
+    /// Peers that said goodbye, and when. See [`DEPARTURE_PORT`].
+    pub departed: DepartedPeers,
     pub multicast_error: Option<String>,
 }
 
@@ -191,6 +194,7 @@ pub async fn start<R: Runtime>(
         pending: Arc::new(StdMutex::new(HashMap::new())),
         receiving: Arc::new(StdMutex::new(HashMap::new())),
         send_cancel: Arc::new(StdMutex::new(None)),
+        departed: Arc::new(StdMutex::new(HashMap::new())),
         multicast_error,
     };
     spawn_event_pump(app, &service, server_rx, discovery_rx);
@@ -219,6 +223,7 @@ fn spawn_event_pump<R: Runtime>(
     let pending = service.pending.clone();
     let receiving = service.receiving.clone();
     let send_cancel = service.send_cancel.clone();
+    let departed = service.departed.clone();
     let self_fingerprint = service.identity.fingerprint.clone();
     tauri::async_runtime::spawn(async move {
         loop {
@@ -234,6 +239,19 @@ fn spawn_event_pump<R: Runtime>(
                             Some(scope_id) => format!("{}%{scope_id}", ip.ip),
                             None => ip.ip.to_string(),
                         };
+                        // A register advertising DEPARTURE_PORT is a goodbye,
+                        // not an arrival: the peer is about to go dark and
+                        // would otherwise keep answering probes (and so keep
+                        // its tile alive) for its whole grace window.
+                        if info.port == DEPARTURE_PORT {
+                            departed
+                                .lock()
+                                .unwrap()
+                                .insert(info.fingerprint.clone(), SystemTime::now());
+                            emit_devices(&app, &discovery, &departed);
+                            continue;
+                        }
+                        departed.lock().unwrap().remove(&info.fingerprint);
                         let discovery = discovery.clone();
                         let self_fingerprint = self_fingerprint.clone();
                         tauri::async_runtime::spawn(async move {
@@ -246,7 +264,7 @@ fn spawn_event_pump<R: Runtime>(
                     None => break,
                 },
                 event = discovery_rx.recv() => match event {
-                    Some(_) => emit_devices(&app, &discovery),
+                    Some(_) => emit_devices(&app, &discovery, &departed),
                     None => break,
                 },
             }
@@ -282,6 +300,73 @@ pub async fn register_peer(
     discovery.add_device(device).await;
 }
 
+/// Peers that told us they are going away, and when they said so.
+pub type DepartedPeers = Arc<StdMutex<HashMap<String, SystemTime>>>;
+
+/// The port a departing device advertises in its goodbye.
+///
+/// Presence is otherwise inferred from "does the peer still answer", which is
+/// too slow: iOS keeps a locked app running for its background grace window,
+/// so a phone whose screen just went off goes on answering re-probes for
+/// several seconds and only then ages out at [`PRESENCE_TTL`] - 10 to 15
+/// seconds in the list after the user pocketed it. So a device about to go
+/// dark says so, over the register route it already speaks, and its peers
+/// drop it on the next beat. Port zero means "not listening": no peer can
+/// dial it, so a LocalSend client that does not know about goodbyes just
+/// records an address it cannot send to until the hello corrects it.
+pub const DEPARTURE_PORT: u16 = 0;
+
+/// How long a goodbye keeps a peer out of the list without a matching hello.
+///
+/// It must outlast the sender's grace window, or the peer's own next answered
+/// probe would put it straight back. It is bounded so a hello lost on the way
+/// back cannot hide a device that is really there: past this, presence falls
+/// back to [`PRESENCE_TTL`], which by then has pruned a peer that truly left.
+pub const DEPARTURE_HOLD: Duration = Duration::from_secs(15);
+
+/// A goodbye is best-effort and races the OS suspending us, so it gets one
+/// short attempt per peer rather than a retry.
+const DEPARTURE_TIMEOUT: Duration = Duration::from_millis(700);
+
+/// Whether a peer that said goodbye at `departed_at` is still held out of the
+/// list.
+pub fn peer_has_departed(departed_at: Option<SystemTime>, now: SystemTime) -> bool {
+    departed_at.is_some_and(|at| {
+        now.duration_since(at)
+            .map(|age| age < DEPARTURE_HOLD)
+            .unwrap_or(true)
+    })
+}
+
+/// Tells every known peer that this device is going dark (`port`
+/// [`DEPARTURE_PORT`]) or is back (its real port), over the register route.
+///
+/// Best-effort: peers that have gone away themselves simply time out, and the
+/// presence TTL still covers every case where this never arrives at all - a
+/// crash, a force-quit, or walking out of range.
+pub async fn notify_peers(identity: &Identity, discovery: &DiscoveryHandle, port: u16) {
+    let channels = known_reprobe_channels(&discovery.devices());
+    if channels.is_empty() {
+        return;
+    }
+    // No pinned fingerprint: this is discovery traffic, and the payload says
+    // nothing a peer does not already know about us.
+    let Ok(client) = LsHttpClient::new(
+        &identity.key_pem,
+        &identity.cert_pem,
+        LsHttpClientVersion::V2,
+        None,
+        Some(DEPARTURE_TIMEOUT),
+    ) else {
+        return;
+    };
+    let dto = identity.client_register_dto(port);
+    let sends = channels
+        .iter()
+        .map(|channel| client.register(channel.protocol, &channel.host, channel.port, dto.clone()));
+    futures::future::join_all(sends).await;
+}
+
 /// A discovered peer is shown only while it keeps answering presence probes.
 /// Once its last confirmation is older than this, the picker drops it, so a
 /// device that locked its screen (and stopped answering) disappears within a
@@ -303,12 +388,21 @@ fn device_is_present(last_seen: Option<SystemTime>, now: SystemTime) -> bool {
     }
 }
 
-pub fn device_payloads(discovery: &DiscoveryHandle) -> Vec<DevicePayload> {
+pub fn device_payloads(
+    discovery: &DiscoveryHandle,
+    departed: &DepartedPeers,
+) -> Vec<DevicePayload> {
     let now = SystemTime::now();
+    let departed = departed.lock().unwrap().clone();
     discovery
         .devices()
         .into_iter()
         .filter_map(|stateful| {
+            // A peer that announced it is going dark leaves at once, instead of
+            // lingering on the TTL it goes on refreshing through its grace window.
+            if peer_has_departed(departed.get(&stateful.device.fingerprint).copied(), now) {
+                return None;
+            }
             // Prune peers that stopped answering (screen locked / app backgrounded).
             let last_seen = stateful.logs.last().map(|log| log.timestamp);
             if !device_is_present(last_seen, now) {
@@ -317,14 +411,19 @@ pub fn device_payloads(discovery: &DiscoveryHandle) -> Vec<DevicePayload> {
             let http = stateful.get_best_channel().and_then(|c| c.http())?;
             // The best channel may be IPv6; a multi-homed device usually also
             // has an IPv4 channel, whose last octet is the "#<n>" tag shown
-            // in the UI.
+            // in the UI. Channel ranking follows the most recent confirmation,
+            // so picking the first IPv4 there made the tag flicker between a
+            // peer's addresses (an iPhone answers on both Wi-Fi and the
+            // iPhone-USB link). The tag is an identity label, so choose it
+            // deterministically instead: the routable address over an
+            // autoconfigured link-local one, then the lowest address.
             let ipv4_host = stateful
                 .get_ranked_channels()
                 .into_iter()
                 .filter_map(|channel| channel.http())
-                .map(|http| http.host.as_str())
-                .find(|host| host.parse::<std::net::Ipv4Addr>().is_ok())
-                .map(str::to_string);
+                .filter_map(|http| http.host.parse::<std::net::Ipv4Addr>().ok())
+                .min_by_key(|ip| (ip.is_link_local(), *ip))
+                .map(|ip| ip.to_string());
             Some(DevicePayload {
                 alias: stateful.device.alias.clone(),
                 device_model: stateful.device.device_model.clone(),
@@ -338,6 +437,26 @@ pub fn device_payloads(discovery: &DiscoveryHandle) -> Vec<DevicePayload> {
         })
         .collect()
 }
+
+/// Whether the HTTP server bound to `port` still accepts connections.
+///
+/// iOS reclaims a suspended app's listening socket, and the accept loop is
+/// never woken to notice: `TcpListener::accept` stays pending forever, so
+/// [`ServerEventV2::ListenerFailed`] is never emitted and the service looks
+/// healthy while no peer can reach it (Nearby BookDrop then went silent until
+/// the user toggled the setting off and on). A loopback connect is the only
+/// thing that tells the two apart - the OS refuses it once the socket is gone.
+pub async fn listener_is_alive(port: u16) -> bool {
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    matches!(
+        tokio::time::timeout(LIVENESS_TIMEOUT, tokio::net::TcpStream::connect(addr)).await,
+        Ok(Ok(_))
+    )
+}
+
+/// A loopback connect either completes or is refused at once; anything longer
+/// than this is a wedged socket, which counts as dead.
+const LIVENESS_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// The HTTP channels of the currently known peers, for a unicast re-probe.
 ///
@@ -359,11 +478,15 @@ pub fn known_reprobe_channels(devices: &[StatefulDevice]) -> Vec<HttpChannel> {
         .collect()
 }
 
-fn emit_devices<R: Runtime>(app: &AppHandle<R>, discovery: &DiscoveryHandle) {
+fn emit_devices<R: Runtime>(
+    app: &AppHandle<R>,
+    discovery: &DiscoveryHandle,
+    departed: &DepartedPeers,
+) {
     let _ = app.emit(
         EV_DEVICES,
         DevicesPayload {
-            devices: device_payloads(discovery),
+            devices: device_payloads(discovery, departed),
         },
     );
 }
@@ -887,6 +1010,11 @@ pub async fn run_send<R: Runtime>(
 mod tests {
     use super::*;
 
+    /// No peer has said goodbye in these tests.
+    fn no_departures() -> DepartedPeers {
+        Arc::new(StdMutex::new(HashMap::new()))
+    }
+
     #[test]
     fn presence_ttl_keeps_recent_and_drops_stale() {
         let now = SystemTime::now();
@@ -1006,7 +1134,7 @@ mod tests {
             register_dto("peer-fp"),
         ));
 
-        let devices = device_payloads(&discovery);
+        let devices = device_payloads(&discovery, &no_departures());
         assert_eq!(devices.len(), 1);
         assert_eq!(devices[0].fingerprint, "peer-fp");
         assert_eq!(devices[0].host, "192.168.2.135");
@@ -1039,9 +1167,123 @@ mod tests {
             .await;
         });
 
-        let devices = device_payloads(&discovery);
+        let devices = device_payloads(&discovery, &no_departures());
         assert_eq!(devices.len(), 1);
         assert_eq!(devices[0].ipv4_host.as_deref(), Some("192.168.2.135"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn device_payload_keeps_the_ipv4_tag_stable_for_a_multi_homed_peer() {
+        // A phone on Wi-Fi and on the iPhone-USB link answers on both
+        // addresses in turn. The "#<n>" tag must not follow whichever
+        // confirmation landed last (it flickered between the two), and must
+        // name the routable address rather than the link-local one.
+        let dir = std::env::temp_dir().join(format!("ls-mh-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = std::fs::remove_file(dir.join("identity.pem"));
+        let identity = Identity::load_or_generate(&dir, "Readest".into(), "macOS".into()).unwrap();
+        let discovery = test_discovery(&identity);
+
+        let confirm = |host: &str| {
+            tauri::async_runtime::block_on(register_peer(
+                &discovery,
+                &identity.fingerprint,
+                host.into(),
+                register_dto("peer-fp"),
+            ));
+        };
+        let tag_host = || {
+            device_payloads(&discovery, &no_departures())[0]
+                .ipv4_host
+                .clone()
+        };
+
+        confirm("192.168.2.99");
+        assert_eq!(tag_host().as_deref(), Some("192.168.2.99"));
+        confirm("169.254.109.245");
+        assert_eq!(
+            tag_host().as_deref(),
+            Some("192.168.2.99"),
+            "a link-local confirmation must not take over the tag"
+        );
+        confirm("192.168.2.99");
+        assert_eq!(tag_host().as_deref(), Some("192.168.2.99"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn listener_is_alive_follows_the_bound_socket() {
+        tauri::async_runtime::block_on(async {
+            let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+                .await
+                .unwrap();
+            let port = listener.local_addr().unwrap().port();
+            assert!(
+                listener_is_alive(port).await,
+                "a bound listener must answer the probe"
+            );
+
+            // Dropping the listener is what the OS does to a suspended iOS
+            // app's socket: the port stops accepting while the service still
+            // believes it is running.
+            drop(listener);
+            assert!(
+                !listener_is_alive(port).await,
+                "a reclaimed socket must fail the probe"
+            );
+        });
+    }
+
+    #[test]
+    fn a_goodbye_hides_a_peer_that_is_still_answering() {
+        // iOS keeps a locked app running for a few seconds, so the phone goes
+        // on answering re-probes after it said goodbye. The hold is what stops
+        // the very next probe from putting it straight back in the list.
+        let now = SystemTime::now();
+        assert!(peer_has_departed(Some(now), now));
+        assert!(peer_has_departed(
+            Some(now - DEPARTURE_HOLD + Duration::from_secs(1)),
+            now
+        ));
+        // Bounded, so a lost hello cannot hide a live device for good.
+        assert!(!peer_has_departed(
+            Some(now - DEPARTURE_HOLD - Duration::from_secs(1)),
+            now
+        ));
+        assert!(!peer_has_departed(None, now));
+    }
+
+    #[test]
+    fn device_payloads_drop_a_peer_that_said_goodbye_until_it_says_hello() {
+        let dir = std::env::temp_dir().join(format!("ls-bye-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = std::fs::remove_file(dir.join("identity.pem"));
+        let identity = Identity::load_or_generate(&dir, "Readest".into(), "macOS".into()).unwrap();
+        let discovery = test_discovery(&identity);
+        let departed: DepartedPeers = Arc::new(StdMutex::new(HashMap::new()));
+
+        tauri::async_runtime::block_on(register_peer(
+            &discovery,
+            &identity.fingerprint,
+            "192.168.2.99".into(),
+            register_dto("peer-fp"),
+        ));
+        assert_eq!(device_payloads(&discovery, &departed).len(), 1);
+
+        departed
+            .lock()
+            .unwrap()
+            .insert("peer-fp".into(), SystemTime::now());
+        assert!(
+            device_payloads(&discovery, &departed).is_empty(),
+            "a peer that said goodbye must leave the list at once"
+        );
+
+        // The hello clears the hold, even though nothing about the peer's
+        // last-seen timestamp changed.
+        departed.lock().unwrap().remove("peer-fp");
+        assert_eq!(device_payloads(&discovery, &departed).len(), 1);
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -1060,7 +1302,7 @@ mod tests {
             register_dto(&identity.fingerprint.clone()),
         ));
 
-        assert!(device_payloads(&discovery).is_empty());
+        assert!(device_payloads(&discovery, &no_departures()).is_empty());
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/apps/readest-app/src/__tests__/components/localsend/LocalSendManagerPresence.test.tsx
+++ b/apps/readest-app/src/__tests__/components/localsend/LocalSendManagerPresence.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+
+/**
+ * Foreground recovery for Nearby BookDrop.
+ *
+ * iOS reclaims a suspended app's listening socket but never wakes the accept
+ * loop, so `ServerEventV2::ListenerFailed` is never emitted and the store keeps
+ * `running: true` on a service no peer can reach. The manager used to branch on
+ * that flag, so returning to the foreground only re-announced presence on a
+ * dead listener and the phone stayed invisible to every peer until the user
+ * toggled the setting off and on. It must probe liveness instead.
+ */
+
+vi.mock('@/hooks/useTranslation', () => ({ useTranslation: () => (s: string) => s }));
+vi.mock('@/services/environment', () => ({ isTauriAppPlatform: () => true }));
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({
+    envConfig: {},
+    appService: { osPlatform: 'ios', isIOSApp: true, isAndroidApp: false, hasHaptics: false },
+  }),
+}));
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ user: null }) }));
+vi.mock('@/hooks/useQuotaStats', () => ({
+  useQuotaStats: () => ({ userProfilePlan: 'free', customizationPurchased: false }),
+}));
+vi.mock('@/services/localsend/devicePrefs', () => ({
+  DEFAULT_ALIAS_NAMED_KEY: "{{name}}'s Readest",
+  getLocalSendAlias: () => 'Test Device',
+  isLocalSendEnabled: () => true,
+}));
+vi.mock('@/utils/bridge', () => ({ setMulticastLock: vi.fn(async () => {}) }));
+vi.mock('@/services/localsend/sounds', () => ({
+  playTransferCue: vi.fn(),
+  primeTransferCues: vi.fn(),
+}));
+vi.mock('@/services/ingestService', () => ({ ingestFile: vi.fn() }));
+vi.mock('@/services/localsend/bookFile', () => ({ resolveBookSendFile: vi.fn() }));
+vi.mock('@tauri-apps/plugin-haptics', () => ({ impactFeedback: vi.fn(async () => {}) }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+
+const startLocalSend = vi.fn(async (_alias: string, _deviceModel: string) => ({
+  running: true,
+  alias: 'Test Device',
+  port: 53318,
+  fingerprint: 'fp',
+  deviceModel: 'iOS',
+  localIps: ['192.168.2.99'],
+  multicastError: null,
+}));
+const stopLocalSend = vi.fn(async () => {});
+const setLocalSendDiscoverable = vi.fn(async (_active: boolean) => {});
+const isLocalSendAlive = vi.fn(async () => true);
+
+vi.mock('@/services/localsend/service', () => ({
+  startLocalSend: (alias: string, deviceModel: string) => startLocalSend(alias, deviceModel),
+  stopLocalSend: () => stopLocalSend(),
+  setLocalSendDiscoverable: (active: boolean) => setLocalSendDiscoverable(active),
+  isLocalSendAlive: () => isLocalSendAlive(),
+  respondLocalSend: vi.fn(async () => true),
+  cancelLocalSendReceive: vi.fn(async () => {}),
+}));
+
+import LocalSendManager from '@/components/localsend/LocalSendManager';
+
+const setVisibility = (state: 'visible' | 'hidden') => {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+};
+
+/** Fire `visibilitychange` and let the handler's awaits settle. */
+const changeVisibilityTo = async (state: 'visible' | 'hidden') => {
+  setVisibility(state);
+  await act(async () => {
+    document.dispatchEvent(new Event('visibilitychange'));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+const mountManager = async () => {
+  await act(async () => {
+    render(<LocalSendManager />);
+  });
+  // Ignore the service start the mount itself performs.
+  startLocalSend.mockClear();
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isLocalSendAlive.mockResolvedValue(true);
+  setVisibility('visible');
+});
+afterEach(() => cleanup());
+
+describe('LocalSendManager foreground presence', () => {
+  it('rebuilds the service when the listener did not survive suspension', async () => {
+    await mountManager();
+
+    // The status still says running - this is exactly the iOS zombie state.
+    isLocalSendAlive.mockResolvedValue(false);
+    await changeVisibilityTo('visible');
+
+    expect(stopLocalSend).toHaveBeenCalled();
+    expect(startLocalSend).toHaveBeenCalled();
+    expect(setLocalSendDiscoverable).not.toHaveBeenCalledWith(true);
+  });
+
+  it('only re-announces presence when the listener is still alive', async () => {
+    await mountManager();
+
+    isLocalSendAlive.mockResolvedValue(true);
+    await changeVisibilityTo('visible');
+
+    expect(setLocalSendDiscoverable).toHaveBeenCalledWith(true);
+    expect(stopLocalSend).not.toHaveBeenCalled();
+    expect(startLocalSend).not.toHaveBeenCalled();
+  });
+
+  it('goes quiet on the way out without probing', async () => {
+    await mountManager();
+
+    await changeVisibilityTo('hidden');
+
+    expect(setLocalSendDiscoverable).toHaveBeenCalledWith(false);
+    expect(isLocalSendAlive).not.toHaveBeenCalled();
+    expect(stopLocalSend).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/components/localsend/ReceiveRequestPairing.test.tsx
+++ b/apps/readest-app/src/__tests__/components/localsend/ReceiveRequestPairing.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/react';
+
+/**
+ * The pairing opt-in on an incoming Nearby BookDrop request.
+ *
+ * The locked (no entitlement) variant must stay legible: daisyUI drops a
+ * `disabled` box to `opacity: .2` on top of an already 20%-opacity border, so
+ * marking it disabled made the control indistinguishable from the dialog
+ * surface. The row itself is the control, so the box is decorative.
+ */
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string, o?: Record<string, unknown>) =>
+    s.replace(/\{\{(\w+)\}\}/g, (_m, k) => String(o?.[k] ?? '')),
+}));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: { osPlatform: 'macos' } }),
+}));
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ user: null }) }));
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({ safeAreaInsets: { top: 0, bottom: 0, left: 0, right: 0 } }),
+}));
+
+const quota = { userProfilePlan: 'free' as string | undefined, customizationPurchased: false };
+vi.mock('@/hooks/useQuotaStats', () => ({ useQuotaStats: () => quota }));
+
+import ReceiveRequestDialog from '@/components/localsend/ReceiveRequestDialog';
+import en from '../../../../public/locales/en/translation.json';
+
+const request = {
+  sessionId: 's1',
+  sender: {
+    alias: 'Readest',
+    deviceModel: 'macOS',
+    deviceType: 'desktop',
+    fingerprint: 'fp',
+    certVerified: true,
+  },
+  files: [
+    { id: 'f1', fileName: 'Moby-Dick.epub', size: 1_550_000, fileType: 'epub', preview: null },
+  ],
+};
+
+const renderDialog = () =>
+  render(
+    <ReceiveRequestDialog request={request as never} onAccept={vi.fn()} onDecline={vi.fn()} />,
+  );
+
+afterEach(() => {
+  cleanup();
+  quota.userProfilePlan = 'free';
+  quota.customizationPurchased = false;
+});
+
+describe('ReceiveRequestDialog pairing opt-in', () => {
+  it('offers a single opt-in, with no separate "accept once" choice', () => {
+    quota.customizationPurchased = true;
+    renderDialog();
+    expect(screen.getByText('Always accept from Readest')).toBeTruthy();
+    expect(screen.queryByText('Accept once')).toBeNull();
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+  });
+
+  it('keeps the locked box at full opacity rather than marking it disabled', () => {
+    renderDialog();
+    expect(screen.getByText('Premium')).toBeTruthy();
+    const box = document.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
+    expect(box).not.toBeNull();
+    // `disabled` is what triggers daisyUI's opacity:.2 washout.
+    expect(box!.disabled).toBe(false);
+    expect(box!.checked).toBe(false);
+    expect(box!.className).toContain('border-base-content/45');
+  });
+
+  it('passes the book count to the title so i18next can pluralise it', () => {
+    renderDialog();
+    // The mock translator only interpolates, so this proves `count` reaches
+    // the key; the plural forms themselves are asserted below.
+    expect(screen.getByText('Readest wants to send you 1 book(s)')).toBeTruthy();
+    // The total size used to be repeated here even though every row shows one.
+    expect(screen.queryByText(/1 book\(s\), /)).toBeNull();
+  });
+
+  it('ships English plural forms for the title, or it renders as "1 book(s)"', () => {
+    const key = '{{alias}} wants to send you {{count}} book(s)';
+    expect(en[`${key}_one` as keyof typeof en]).toBe('{{alias}} wants to send you {{count}} book');
+    expect(en[`${key}_other` as keyof typeof en]).toBe(
+      '{{alias}} wants to send you {{count}} books',
+    );
+  });
+});

--- a/apps/readest-app/src/__tests__/components/settings/Tips.test.tsx
+++ b/apps/readest-app/src/__tests__/components/settings/Tips.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/react';
+
+/**
+ * Callers write conditional bullets as `{cond && <li>...</li>}`, which hands
+ * Tips a literal `false` whenever the condition is off. `React.Children.map`
+ * keeps those slots, so Tips used to wrap each one in an `<li>` with a bullet
+ * dot and no text: Nearby BookDrop showed five bullets with the last two
+ * blank, and the S3 sub-page showed a stray one off the web platform.
+ */
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+import Tips from '@/components/settings/primitives/Tips';
+
+afterEach(() => cleanup());
+
+describe('Tips', () => {
+  it('renders one bullet per real child', () => {
+    render(
+      <Tips>
+        <li>First</li>
+        <li>Second</li>
+      </Tips>,
+    );
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    expect(items.map((li) => li.textContent)).toEqual(['First', 'Second']);
+  });
+
+  it('drops bullets whose condition is off instead of rendering them empty', () => {
+    const paired = 0;
+    const multicastError: string | null = null;
+    render(
+      <Tips>
+        <li>Always shown</li>
+        {paired > 0 && <li>Paired devices are accepted automatically.</li>}
+        {multicastError && <li>Discovery via multicast is unavailable.</li>}
+      </Tips>,
+    );
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+    expect(items[0]!.textContent).toBe('Always shown');
+  });
+
+  it('keeps a conditional bullet once its condition is met', () => {
+    render(
+      <Tips>
+        <li>Always shown</li>
+        {true && <li>Paired devices are accepted automatically.</li>}
+      </Tips>,
+    );
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/localsend/deviceModel.test.ts
+++ b/apps/readest-app/src/__tests__/services/localsend/deviceModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ipTag, localSendDeviceModel } from '@/services/localsend/deviceModel';
+import { ipTag, localSendDeviceModel, preferredIpTag } from '@/services/localsend/deviceModel';
 
 describe('localSendDeviceModel', () => {
   it('maps each OS to the name peers show as the device tag', () => {
@@ -33,5 +33,29 @@ describe('ipTag', () => {
     expect(ipTag('mac.local')).toBe(null);
     expect(ipTag('')).toBe(null);
     expect(ipTag('1.2.3.256')).toBe(null);
+  });
+});
+
+describe('preferredIpTag', () => {
+  it('names one address, not every interface the device happens to have', () => {
+    // An iPhone on Wi-Fi and plugged into a Mac: the settings row used to read
+    // "#100 #99 #245", none of which a peer could be matched against.
+    expect(preferredIpTag(['192.168.2.99', '169.254.109.245'])).toBe('#99');
+  });
+
+  it('prefers a routable address over an autoconfigured link-local one', () => {
+    expect(preferredIpTag(['169.254.109.245', '192.168.2.99'])).toBe('#99');
+    expect(preferredIpTag(['169.254.109.245'])).toBe('#245');
+  });
+
+  it('is order independent, so the tag never changes between reads', () => {
+    const hosts = ['192.168.2.99', '10.0.0.100', '169.254.109.245'];
+    expect(preferredIpTag(hosts)).toBe(preferredIpTag([...hosts].reverse()));
+  });
+
+  it('ignores anything that is not a dotted IPv4 address', () => {
+    expect(preferredIpTag(['fe80::1%3', 'mac.local', '192.168.2.99'])).toBe('#99');
+    expect(preferredIpTag(['fe80::1', ''])).toBe(null);
+    expect(preferredIpTag([])).toBe(null);
   });
 });

--- a/apps/readest-app/src/__tests__/services/localsend/devicePrefs.test.ts
+++ b/apps/readest-app/src/__tests__/services/localsend/devicePrefs.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  getLocalSendAlias,
+  isLocalSendEnabled,
+  setLocalSendAlias,
+  setLocalSendEnabled,
+} from '@/services/localsend/devicePrefs';
+
+const ENABLED_KEY = 'readest-localsend-enabled';
+
+describe('Nearby BookDrop enable preference', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('stays off until the user turns it on', () => {
+    // Load-bearing, not incidental: starting the service joins a multicast
+    // group and binds a LAN listener, which makes iOS raise its Local Network
+    // prompt at first launch. A decline there is sticky and would break the
+    // feature for good, so nothing starts before the user asks for it.
+    expect(isLocalSendEnabled()).toBe(false);
+  });
+
+  it('treats any value other than "true" as off', () => {
+    localStorage.setItem(ENABLED_KEY, 'false');
+    expect(isLocalSendEnabled()).toBe(false);
+    localStorage.setItem(ENABLED_KEY, '');
+    expect(isLocalSendEnabled()).toBe(false);
+  });
+
+  it('round-trips the toggle both ways', () => {
+    setLocalSendEnabled(true);
+    expect(localStorage.getItem(ENABLED_KEY)).toBe('true');
+    expect(isLocalSendEnabled()).toBe(true);
+    setLocalSendEnabled(false);
+    expect(isLocalSendEnabled()).toBe(false);
+  });
+
+  it('leaves the alias empty until the user names the device', () => {
+    expect(getLocalSendAlias()).toBe('');
+    setLocalSendAlias('Study Mac');
+    expect(getLocalSendAlias()).toBe('Study Mac');
+  });
+});

--- a/apps/readest-app/src/components/Alert.tsx
+++ b/apps/readest-app/src/components/Alert.tsx
@@ -5,7 +5,10 @@ import { useKeyDownActions } from '@/hooks/useKeyDownActions';
 
 const Alert: React.FC<{
   title: string;
-  message: string;
+  // Optional: a dialog whose children already carry the detail (e.g. the
+  // Nearby BookDrop request, which lists each file with its own size) reads
+  // cleaner with the title alone than with a redundant summary line.
+  message?: string;
   onCancel: () => void;
   onConfirm: () => void;
   // Optional content rendered between the title/message and the actions row
@@ -50,22 +53,28 @@ const Alert: React.FC<{
         )}
       >
         <div className='labels flex items-start gap-3'>
-          <svg
-            xmlns='http://www.w3.org/2000/svg'
-            fill='none'
-            viewBox='0 0 24 24'
-            className='stroke-info mt-0.5 h-6 w-6 shrink-0'
-          >
-            <path
-              strokeLinecap='round'
-              strokeLinejoin='round'
-              strokeWidth='2'
-              d='M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
-            ></path>
-          </svg>
+          {/* Centred on the title's line box (h-5 = text-sm's 1.25rem
+              line-height) rather than nudged down by a fixed margin, so the
+              icon reads as aligned with the heading whether or not a message
+              follows it and however the title wraps. */}
+          <span className='flex h-5 shrink-0 items-center'>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              fill='none'
+              viewBox='0 0 24 24'
+              className='stroke-info h-6 w-6 shrink-0'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                strokeWidth='2'
+                d='M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+              ></path>
+            </svg>
+          </span>
           <div className='flex min-w-0 flex-col gap-1'>
             <h3 className='text-start text-sm font-medium'>{title}</h3>
-            <div className='text-start text-sm'>{message}</div>
+            {message && <div className='text-start text-sm'>{message}</div>}
           </div>
         </div>
         {children}

--- a/apps/readest-app/src/components/localsend/LocalSendManager.tsx
+++ b/apps/readest-app/src/components/localsend/LocalSendManager.tsx
@@ -23,6 +23,7 @@ import {
 import { playTransferCue, primeTransferCues } from '@/services/localsend/sounds';
 import {
   cancelLocalSendReceive,
+  isLocalSendAlive,
   respondLocalSend,
   setLocalSendDiscoverable,
   startLocalSend,
@@ -173,20 +174,30 @@ const LocalSendManager: React.FC = () => {
   // This is presence only - the service keeps running, nothing disconnects.
   useEffect(() => {
     if (!isTauriAppPlatform()) return;
-    const sync = () => {
+    const sync = async () => {
       if (!isLocalSendEnabled()) return;
       const visible = document.visibilityState === 'visible';
-      // The OS can reclaim a backgrounded app's listening socket (iOS); the
-      // backend tears the dead service down and reports running:false. Bring it
-      // back on the next foreground before re-announcing presence.
-      if (visible && !useLocalSendStore.getState().status?.running) {
+      if (!visible) {
+        void setLocalSendDiscoverable(false).catch(() => {});
+        return;
+      }
+      // The OS can reclaim a backgrounded app's listening socket (iOS). When
+      // the core notices, it tears the dead service down and reports
+      // running:false - but iOS never wakes the accept loop to notice, so the
+      // status stays running:true on a service no peer can reach (the picker
+      // showed nothing until the user toggled the setting off and on). Trust a
+      // liveness probe, not the stored flag, and rebuild the service when it
+      // fails: `stop` first, or `start` would hand back the dead one.
+      if (!(await isLocalSendAlive().catch(() => false))) {
+        await stopLocalSend().catch(() => {});
         void syncServiceState();
         return;
       }
-      void setLocalSendDiscoverable(visible).catch(() => {});
+      void setLocalSendDiscoverable(true).catch(() => {});
     };
-    document.addEventListener('visibilitychange', sync);
-    return () => document.removeEventListener('visibilitychange', sync);
+    const onVisibilityChange = () => void sync();
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
   }, [syncServiceState]);
 
   // The alias change flow restarts the service (stop, then start with the new

--- a/apps/readest-app/src/components/localsend/ReceiveRequestDialog.tsx
+++ b/apps/readest-app/src/components/localsend/ReceiveRequestDialog.tsx
@@ -15,6 +15,14 @@ import clsx from 'clsx';
 
 const MAX_LISTED_FILES = 8;
 
+/** Row chassis for the pairing opt-in; `items-start` keeps the box and the
+ *  Premium badge on the first line when the label wraps. `pe-0` is load
+ *  bearing: the badge is `ms-auto`, so any end padding here would inset it
+ *  from the dialog's content edge and break its alignment with the Accept
+ *  button below. */
+const PAIR_ROW =
+  'flex cursor-pointer items-start gap-2 rounded-md ps-1 pe-0 py-2 text-start text-sm';
+
 interface ReceiveRequestDialogProps {
   request: ReceiveRequest;
   onAccept: (fileIds: string[], pairDevice: boolean) => void;
@@ -26,11 +34,11 @@ interface ReceiveRequestDialogProps {
  * import; other offered files are declined via protocol partial-accept, with
  * a note so the user knows the sender sees the split.
  *
- * Cert-verified senders can be paired ("Always accept from this device"):
- * future drops then skip this dialog. The checkbox is hidden entirely for
- * cert-less senders (their fingerprint is spoofable, so they can never be
- * trusted), and shows a Premium badge routing to the upgrade page for users
- * without the pairing entitlement.
+ * Cert-verified senders can be paired via "Always accept from <device>":
+ * ticking it makes future drops from that device skip this dialog. The opt-in
+ * is hidden entirely for cert-less senders (their fingerprint is spoofable, so
+ * they can never be trusted); users without the pairing entitlement see it
+ * inert behind a Premium badge that routes to the upgrade page.
  */
 const ReceiveRequestDialog: React.FC<ReceiveRequestDialogProps> = ({
   request,
@@ -49,12 +57,12 @@ const ReceiveRequestDialog: React.FC<ReceiveRequestDialogProps> = ({
 
   // Mirrors the TTS-cache paywall: badge only users who can't pair yet —
   // signed out (known at once), or a resolved plan without the feature.
-  // While a signed-in user's plan is still loading, show neither the
-  // checkbox nor the badge so nothing flashes.
+  // While a signed-in user's plan is still loading, show neither the scope
+  // choice nor the badge so nothing flashes.
   const { userProfilePlan, customizationPurchased } = useQuotaStats();
   const pairingEntitled = isNearbyPairingAllowed(userProfilePlan ?? 'free', customizationPurchased);
-  const showPairCheckbox = request.sender.certVerified && pairingEntitled;
-  const showPairLocked =
+  const canPair = request.sender.certVerified && pairingEntitled;
+  const pairLocked =
     request.sender.certVerified && !pairingEntitled && (!user || userProfilePlan !== undefined);
 
   const openUpgrade = () => {
@@ -64,8 +72,6 @@ const ReceiveRequestDialog: React.FC<ReceiveRequestDialogProps> = ({
       navigateToLogin(router);
     }
   };
-
-  const totalSize = supported.reduce((sum, file) => sum + file.size, 0);
 
   return (
     <div
@@ -77,10 +83,9 @@ const ReceiveRequestDialog: React.FC<ReceiveRequestDialogProps> = ({
       style={{ paddingBottom: `${(safeAreaInsets?.bottom || 0) + 16}px` }}
     >
       <Alert
-        title={_('{{alias}} wants to send you books', { alias: request.sender.alias })}
-        message={_('{{count}} book(s), {{size}}', {
+        title={_('{{alias}} wants to send you {{count}} book(s)', {
+          alias: request.sender.alias,
           count: supported.length,
-          size: formatBytes(totalSize),
         })}
         confirmLabel={_('Accept')}
         confirmButtonClassName='btn-contrast'
@@ -123,34 +128,40 @@ const ReceiveRequestDialog: React.FC<ReceiveRequestDialogProps> = ({
               {_('{{count}} unsupported file(s) will be skipped', { count: skipped.length })}
             </div>
           )}
-          {showPairCheckbox && (
-            <label className='mt-1 flex cursor-pointer items-center gap-2'>
+          {canPair && (
+            <label className={clsx(PAIR_ROW, 'mt-2')}>
               <input
                 type='checkbox'
-                className='checkbox checkbox-sm eink-bordered'
+                className='checkbox checkbox-sm eink-bordered mt-0.5 shrink-0'
                 checked={pairDevice}
                 onChange={(event) => setPairDevice(event.target.checked)}
               />
-              <span>{_('Always accept from {{alias}}', { alias: request.sender.alias })}</span>
-            </label>
-          )}
-          {showPairLocked && (
-            <button
-              type='button'
-              className='mt-1 flex items-center gap-2 text-start'
-              onClick={openUpgrade}
-            >
-              <input
-                type='checkbox'
-                className='checkbox checkbox-sm'
-                disabled
-                checked={false}
-                readOnly
-              />
-              <span className='text-base-content/70'>
+              <span className='select-none'>
                 {_('Always accept from {{alias}}', { alias: request.sender.alias })}
               </span>
-              <span className='badge badge-sm badge-ghost shrink-0'>{_('Premium')}</span>
+            </label>
+          )}
+          {pairLocked && (
+            <button type='button' className={clsx(PAIR_ROW, 'mt-2 w-full')} onClick={openUpgrade}>
+              {/* Decorative, never `disabled`: daisyUI drops a disabled box to
+                  `opacity: .2` on top of an already 20%-opacity border, which
+                  left the control indistinguishable from the surface. Keep it
+                  at full opacity with an explicit border and take it out of
+                  the tab order instead - the row itself is the control. */}
+              <input
+                type='checkbox'
+                className='checkbox checkbox-sm eink-bordered border-base-content/45 pointer-events-none mt-0.5 shrink-0'
+                checked={false}
+                readOnly
+                tabIndex={-1}
+                aria-hidden='true'
+              />
+              <span className='text-base-content/60 select-none'>
+                {_('Always accept from {{alias}}', { alias: request.sender.alias })}
+              </span>
+              <span className='badge badge-sm badge-ghost ms-auto mt-0.5 shrink-0'>
+                {_('Premium')}
+              </span>
             </button>
           )}
         </div>

--- a/apps/readest-app/src/components/settings/integrations/LocalSendForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/LocalSendForm.tsx
@@ -10,7 +10,7 @@ import {
 import { getPairedDevices, removePairedDevice } from '@/services/localsend/pairedDevices';
 import { isLocalSendSoundsEnabled, setLocalSendSoundsEnabled } from '@/services/localsend/sounds';
 import { getLocalSendStatus } from '@/services/localsend/service';
-import { ipTag } from '@/services/localsend/deviceModel';
+import { preferredIpTag } from '@/services/localsend/deviceModel';
 import type { LocalSendStatus } from '@/services/localsend/types';
 import { eventDispatcher } from '@/utils/event';
 import SubPageHeader from '../SubPageHeader';
@@ -24,14 +24,14 @@ import {
 } from '../primitives';
 
 /**
- * "#120 macOS"-style tag: the last octet of this host's IPv4 address plus
- * the announced OS name, so the user can tell peers which device to pick
- * when aliases collide.
+ * "#120 macOS"-style tag: the last octet of this host's IPv4 address plus the
+ * announced OS name, so the user can tell peers which device to pick when
+ * aliases collide. One tag, matching the single tag every peer shows for this
+ * device - listing each interface instead ("#100 #99 #245") gave the user
+ * three numbers and no way to tell which one a peer meant.
  */
-const deviceTag = (status: LocalSendStatus): string => {
-  const tags = status.localIps.map(ipTag).filter(Boolean);
-  return [...new Set(tags), status.deviceModel].filter(Boolean).join(' ');
-};
+const deviceTag = (status: LocalSendStatus): string =>
+  [preferredIpTag(status.localIps), status.deviceModel].filter(Boolean).join(' ');
 
 interface LocalSendFormProps {
   onBack: () => void;

--- a/apps/readest-app/src/components/settings/primitives/Tips.tsx
+++ b/apps/readest-app/src/components/settings/primitives/Tips.tsx
@@ -30,7 +30,10 @@ const Tips: React.FC<TipsProps> = ({ title, children, className }) => {
           {title ?? _('Tips')}
         </div>
         <ul className='space-y-0.5'>
-          {React.Children.map(children, (child, i) => {
+          {/* `toArray` (unlike `Children.map`) drops null/undefined/boolean
+              slots, so a caller's `{cond && <li>...</li>}` disappears when
+              `cond` is false instead of rendering a dot with no text. */}
+          {React.Children.toArray(children).map((child, i) => {
             const content =
               React.isValidElement(child) &&
               (child as React.ReactElement<{ children?: React.ReactNode }>).type === 'li'

--- a/apps/readest-app/src/services/localsend/deviceModel.ts
+++ b/apps/readest-app/src/services/localsend/deviceModel.ts
@@ -18,6 +18,35 @@ export function ipTag(host: string): string | null {
   return `#${Number(octets[3])}`;
 }
 
+/**
+ * The single "#<n>" tag for a device with several addresses.
+ *
+ * A device has one tag, so a user can read it out and match it against the one
+ * a peer shows. Multi-homed hosts break that if every address is listed: an
+ * iPhone on Wi-Fi and plugged into a Mac has a Wi-Fi address and an
+ * autoconfigured link-local one for the USB link, and used to advertise both.
+ * Pick the address a peer is most likely to have reached, deterministically:
+ * routable before link-local, then the lowest. The Rust side ranks a peer's
+ * confirmed channels by the same rule, so the two displays agree.
+ */
+export function preferredIpTag(hosts: string[]): string | null {
+  const ranked = hosts
+    .filter((host) => ipTag(host) !== null)
+    .map((host) => host.split('.').map(Number))
+    .sort((a, b) => {
+      const linkLocal = (o: number[]) => (o[0] === 169 && o[1] === 254 ? 1 : 0);
+      return (
+        linkLocal(a) - linkLocal(b) ||
+        a[0]! - b[0]! ||
+        a[1]! - b[1]! ||
+        a[2]! - b[2]! ||
+        a[3]! - b[3]!
+      );
+    });
+  const best = ranked[0];
+  return best ? `#${best[3]}` : null;
+}
+
 export function localSendDeviceModel(os: OsPlatform, isTablet: boolean): string {
   switch (os) {
     case 'android':

--- a/apps/readest-app/src/services/localsend/devicePrefs.ts
+++ b/apps/readest-app/src/services/localsend/devicePrefs.ts
@@ -12,7 +12,16 @@ const ALIAS_KEY = 'readest-localsend-alias';
 // the key for extraction (the scanner reads `_('...')` literals).
 export const DEFAULT_ALIAS_NAMED_KEY = _("{{name}}'s Readest");
 
-/** Whether this device runs the LocalSend service. Defaults to false (opt-in). */
+/**
+ * Whether this device runs the LocalSend service. Defaults to false (opt-in).
+ *
+ * Deliberately opt-in, not on-by-default: starting the service joins a
+ * multicast group and binds a LAN listener, which makes iOS raise its Local
+ * Network permission prompt (and macOS its firewall dialog) the first time the
+ * app runs. Spending that prompt at first launch, on a user who has never
+ * heard of Nearby BookDrop, risks a sticky decline that then breaks the
+ * feature for good. The service starts when the user turns it on.
+ */
 export function isLocalSendEnabled(): boolean {
   try {
     return localStorage.getItem(ENABLED_KEY) === 'true';

--- a/apps/readest-app/src/services/localsend/service.ts
+++ b/apps/readest-app/src/services/localsend/service.ts
@@ -22,6 +22,18 @@ export async function announceLocalSend(scan: boolean): Promise<void> {
 }
 
 /**
+ * Whether the running service can still accept connections.
+ *
+ * iOS reclaims a suspended app's listening socket without ever failing the
+ * accept loop, so the service keeps reporting `running: true` while no peer
+ * can reach it. Probe this on the way back to the foreground rather than
+ * trusting the stored status.
+ */
+export async function isLocalSendAlive(): Promise<boolean> {
+  return await invoke<boolean>('localsend_is_alive');
+}
+
+/**
  * Presence gate (not a connection): when this device's screen locks or the app
  * is backgrounded, `active = false` stops it answering announcements, so peers
  * age it out of their pickers within a few seconds. `active = true` makes it


### PR DESCRIPTION
Four defects found while verifying Nearby BookDrop on an iPhone for the first time, plus the receive prompt they surfaced.

## The service went permanently invisible after a screen lock

iOS reclaims a suspended app's listening socket but never wakes the accept loop, so `ServerEventV2::ListenerFailed` is never emitted, the core never tears the service down, and `status.running` stays `true` on a service no peer can reach. `LocalSendManager`'s foreground handler branched on that flag, so returning to the foreground only re-announced presence on a dead listener. Nothing short of toggling the setting off and on rebound the socket.

Confirmed on device rather than inferred: iPhone awake, Readest foreground-running, settings still reporting "Visible as ... Port 53318", and `nc` finding nothing listening on 53317-53327 on either of its addresses.

The foreground path now probes liveness (`localsend_is_alive`, a loopback connect) and rebuilds the service when it fails. A loopback connect is the only thing that separates a live listener from a reclaimed one, because the accept loop is stuck rather than ended.

## A locked device lingered for 10 to 15 seconds

Measured with a one-second poll: the phone keeps answering the unicast re-probe through the whole iOS background grace window, and only then does the 4.5s `PRESENCE_TTL` start. `set_answer_announcements` gates the multicast answer path alone, never the register route the re-probe actually hits.

A device about to go dark now says so over that same register route, advertising `DEPARTURE_PORT`, and its peers drop it on the next beat. `DEPARTURE_HOLD` must outlast the grace window or the peer's own next answered probe would put it straight back, and is bounded so a hello lost on the way back cannot hide a live device for good.

The service keeps running throughout, so in-flight transfers are unaffected. No crate fork was needed: `LsHttpClient::new` and `Client::register` are already public. `Client::cancel` was rejected as a carrier because the handler cancels a pending session from the sender's IP even with no matching session id, so a goodbye could abort a real transfer.

## Device tags were unstable and over-reported

`device_payloads` took a peer's `#<n>` tag from the first IPv4 in `get_ranked_channels()`, and the crate ranks by most recent confirmation, so the label followed whichever address answered last. An iPhone reachable over both Wi-Fi and the iPhone-USB link alternated between two tags. It is now chosen deterministically: routable before link-local, then lowest.

Separately, `local_ips()` excluded VPN tunnels but not the cellular link, so a phone on Wi-Fi with cellular up advertised three tags, none of which a user could match against the single tag a peer shows. Cellular is excluded now, and the settings row names one address using the same rule the peer side applies.

## The incoming transfer prompt

The title read "... wants to send you books" over "1 book(s), 73.94 kB", because English carried no plural forms for that key and i18next fell back to the raw key. The count moved into the title with proper plural forms across all 34 locales, and the summary line is gone since it repeated a total size every file row already shows.

The pairing opt-in's locked variant was invisible on light themes: daisyUI drops a `disabled` box to `opacity: .2` on top of an already 20%-opacity border. The box is decorative there, so it is no longer marked disabled and carries an explicit border.

## Tips rendered empty bullets

`Tips` wraps every child in its own bullet but used `React.Children.map`, which keeps boolean slots, so every `{cond && <li>}` with a false condition drew a dot with no text. Nearby BookDrop showed five bullets with the last two blank; the S3 sub-page showed a stray one off the web platform. Swept the codebase: `Dropdown` also uses `Children.map` but adds no per-child chrome, and `BoxedList` divides with CSS, so `Tips` was the only instance.

## Testing

`pnpm test` 10812 passed, `pnpm test:rust` 134 passed, lint / format:check / fmt:check / clippy:check clean.

Ten regression tests. The ones guarding real regressions were each verified to fail against the pre-fix code first, including the dropped `device_type` that briefly drew the iPhone as a computer (`left: None, right: Some(Desktop)`).

Not covered by tests: the layout changes are pure CSS, and the iOS behaviour needs a device build on both ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Nearby book-transfer requests now display the sender and number of books in plural-aware messages across supported languages.
  - LocalSend can detect whether its listener remains active and recover automatically when the app returns to the foreground.
  - Device announcements now update peers promptly when availability changes.

- **Bug Fixes**
  - Improved LocalSend device identification by selecting a consistent, routable network address.
  - Excluded cellular and tunnel interfaces from local device discovery.
  - Conditional tips no longer show empty bullet points.
  - Transfer dialogs no longer repeat total file-size information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->