### PR TITLE
fix(koplugin): honour BookDrop goodbyes and un-dangle the localsend pin

### DIFF
--- a/apps/readest.koplugin/native/localsend-bin/Cargo.lock
+++ b/apps/readest.koplugin/native/localsend-bin/Cargo.lock
@@ -179,16 +179,6 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -666,11 +656,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -898,7 +886,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 [[package]]
 name = "localsend"
 version = "0.1.0"
-source = "git+https://github.com/readest/localsend?rev=3cae1825670617244ad235ba4295114d53e5fd2b#3cae1825670617244ad235ba4295114d53e5fd2b"
+source = "git+https://github.com/readest/localsend?rev=1609ca7cd5689e10cc4703e7ce178513e5d95b11#1609ca7cd5689e10cc4703e7ce178513e5d95b11"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -910,6 +898,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "if-addrs",
+ "libc",
  "lru",
  "pem 4.0.0",
  "percent-encoding",
@@ -1463,7 +1452,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -1532,7 +1521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1790,27 +1779,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2256,35 +2224,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/apps/readest.koplugin/native/localsend-bin/Cargo.toml
+++ b/apps/readest.koplugin/native/localsend-bin/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1"
 bytes = "1"
 futures-util = "0.3"
 if-addrs = "0.15"
-localsend = { git = "https://github.com/readest/localsend", rev = "3cae1825670617244ad235ba4295114d53e5fd2b", default-features = false, features = ["discovery"] }
+localsend = { git = "https://github.com/readest/localsend", rev = "1609ca7cd5689e10cc4703e7ce178513e5d95b11", default-features = false, features = ["discovery"] }
 pem = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/readest.koplugin/native/localsend-bin/src/bin/helper.rs
+++ b/apps/readest.koplugin/native/localsend-bin/src/bin/helper.rs
@@ -216,7 +216,7 @@ fn dispatch(line: &str, svc: &service::Service) -> bool {
         }
         "list_devices" => {
             events::push(&Event::Devices {
-                devices: service::device_payloads(&svc.discovery),
+                devices: service::device_payloads(&svc.discovery, &svc.departed),
             });
         }
         "send" => {

--- a/apps/readest.koplugin/native/localsend-bin/src/service.rs
+++ b/apps/readest.koplugin/native/localsend-bin/src/service.rs
@@ -14,18 +14,18 @@ use localsend::discovery::{
 use localsend::http::dto_v2::RegisterDtoV2;
 use localsend::http::server::common::save::FileUploadTarget;
 use localsend::http::server::v2::{PrepareUploadDecisionV2, ServerEventV2, SessionEndReasonV2};
-use localsend::http::server::web::{WebConfig, WebI18n};
+use localsend::http::server::web::{WebConfig, WebMode};
 use localsend::http::server::{start_with_port, ServerConfigV2, ServerHandle};
 use localsend::model::discovery::ProtocolType;
 use localsend::model::transfer::FileDto;
-use localsend::multicast::{
-    InterfaceFilter, DEFAULT_MULTICAST_GROUP, DEFAULT_MULTICAST_GROUP_V6, DEFAULT_PORT,
-};
+use localsend::multicast::{DEFAULT_MULTICAST_GROUP, DEFAULT_MULTICAST_GROUP_V6, DEFAULT_PORT};
 use localsend::util::filename::{sanitize_with, Options, Rules};
+use localsend::util::interface::InterfaceFilter;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, PoisonError};
+use std::time::{Duration, SystemTime};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
@@ -54,6 +54,34 @@ pub struct ReceiveSession {
 pub type PendingMap = Arc<Mutex<HashMap<String, PendingReceive>>>;
 pub type ReceivingMap = Arc<Mutex<HashMap<String, ReceiveSession>>>;
 pub type SendCancelSlot = Arc<Mutex<Option<SendCancel>>>;
+/// Peers that said goodbye, and when. See [`DEPARTURE_PORT`].
+pub type DepartedPeers = Arc<Mutex<HashMap<String, SystemTime>>>;
+
+/// The port a departing device advertises in its goodbye.
+///
+/// The Readest app tells its peers over the register route when it is about to
+/// go dark, so they can drop it instead of waiting for it to stop answering.
+/// Port zero means "not listening": stored as a channel it would be both
+/// unsendable and, being the most recent confirmation, ranked above the peer's
+/// real address.
+pub const DEPARTURE_PORT: u16 = 0;
+
+/// How long a goodbye keeps a peer out of the list without a matching hello.
+///
+/// Bounded, because unlike the app this device runs no presence heartbeat and
+/// has no TTL to fall back on: a hello lost on the way back would otherwise
+/// hide a peer that is really there for as long as the service runs.
+pub const DEPARTURE_HOLD: Duration = Duration::from_secs(15);
+
+/// Whether a peer that said goodbye at `departed_at` is still held out of the
+/// list. A timestamp in the future (clock skew) counts as departed.
+pub fn peer_has_departed(departed_at: Option<SystemTime>, now: SystemTime) -> bool {
+    departed_at.is_some_and(|at| {
+        now.duration_since(at)
+            .map(|age| age < DEPARTURE_HOLD)
+            .unwrap_or(true)
+    })
+}
 
 /// A file offered for sending, resolved from a Lua-supplied path.
 pub struct SendFileJob {
@@ -87,6 +115,8 @@ pub struct Service {
     pub pending: PendingMap,
     pub receiving: ReceivingMap,
     pub send_cancel: SendCancelSlot,
+    /// Peers that said goodbye, and when. See [`DEPARTURE_PORT`].
+    pub departed: DepartedPeers,
     pub multicast_error: Option<String>,
     pub download_dir: PathBuf,
 }
@@ -137,11 +167,10 @@ pub async fn start(config: StartConfig) -> Result<Service, String> {
             // Cert-less senders (the stable LocalSend app) fall back to the
             // body fingerprint; without this WebConfig the server demands a
             // TLS client certificate and resets their handshake.
-            Some(WebConfig {
-                send: None,
-                upload: true,
-                i18n: WebI18n::default(),
-            }),
+            WebConfig {
+                mode: WebMode::Upload,
+                ..Default::default()
+            },
             stop_rx,
         )
         .await
@@ -197,6 +226,7 @@ pub async fn start(config: StartConfig) -> Result<Service, String> {
         pending: Arc::new(Mutex::new(HashMap::new())),
         receiving: Arc::new(Mutex::new(HashMap::new())),
         send_cancel: Arc::new(Mutex::new(None)),
+        departed: Arc::new(Mutex::new(HashMap::new())),
         multicast_error,
         download_dir,
     };
@@ -275,11 +305,23 @@ pub fn local_ips() -> Vec<String> {
 /// Peers discovered so far, as reported to Lua by `list_devices`. Ported
 /// from `device_payloads` in
 /// apps/readest-app/src-tauri/src/localsend/service.rs.
-pub fn device_payloads(discovery: &DiscoveryHandle) -> Vec<DevicePayload> {
+pub fn device_payloads(
+    discovery: &DiscoveryHandle,
+    departed: &DepartedPeers,
+) -> Vec<DevicePayload> {
+    let now = SystemTime::now();
+    let departed = lock(departed).clone();
     discovery
         .devices()
         .into_iter()
         .filter_map(|stateful| {
+            // Deliberately no presence TTL here, unlike the app: nothing on
+            // this side re-confirms peers on a heartbeat, so a TTL would age
+            // every peer out and never bring it back. A goodbye is the only
+            // signal this device gets that a peer has gone.
+            if peer_has_departed(departed.get(&stateful.device.fingerprint).copied(), now) {
+                return None;
+            }
             let http = stateful.get_best_channel().and_then(|c| c.http())?;
             // The best channel may be IPv6; a multi-homed device usually also
             // has an IPv4 channel, whose last octet is the "#<n>" tag shown
@@ -311,6 +353,7 @@ fn spawn_event_pump(service: &Service, mut server_rx: mpsc::Receiver<ServerEvent
     let send_cancel = service.send_cancel.clone();
     let download_dir = service.download_dir.clone();
     let discovery = service.discovery.clone();
+    let departed = service.departed.clone();
     let self_fingerprint = service.identity.fingerprint.clone();
     tokio::spawn(async move {
         while let Some(event) = server_rx.recv().await {
@@ -326,12 +369,36 @@ fn spawn_event_pump(service: &Service, mut server_rx: mpsc::Receiver<ServerEvent
                     Some(scope_id) => format!("{}%{scope_id}", ip.ip),
                     None => ip.ip.to_string(),
                 };
-                register_peer(&discovery, &self_fingerprint, host, info).await;
+                apply_register(&discovery, &departed, &self_fingerprint, host, info).await;
             } else {
                 handle_server_event(&pending, &receiving, &send_cancel, &download_dir, event);
             }
         }
     });
+}
+
+/// Applies a peer's register, telling an arrival from a goodbye.
+///
+/// A register advertising [`DEPARTURE_PORT`] means the peer is about to go
+/// dark; it is recorded as a departure and deliberately never reaches the
+/// discovery store, so the peer's real channel survives for the hello that
+/// clears the hold. Any other register is an arrival and cancels a hold.
+pub async fn apply_register(
+    discovery: &DiscoveryHandle,
+    departed: &DepartedPeers,
+    self_fingerprint: &str,
+    host: String,
+    info: RegisterDtoV2,
+) {
+    if info.fingerprint == self_fingerprint {
+        return;
+    }
+    if info.port == DEPARTURE_PORT {
+        lock(departed).insert(info.fingerprint, SystemTime::now());
+        return;
+    }
+    lock(departed).remove(&info.fingerprint);
+    register_peer(discovery, self_fingerprint, host, info).await;
 }
 
 /// Puts a peer that registered with this device's HTTP server into the
@@ -429,6 +496,15 @@ fn handle_server_event(
                 session.ended = Some(reason);
                 maybe_push_receive_end(&mut sessions, &session_id, download_dir);
             }
+        }
+        ServerEventV2::ListenerFailed { error } => {
+            // The OS invalidated the listening socket and the core stopped the
+            // server; it would still be announced but could accept nothing.
+            // Kindles do not reclaim sockets the way iOS does, so this is
+            // effectively dormant here -- surface it rather than dying quietly.
+            events::push(&Event::Error {
+                message: format!("LocalSend server stopped: {error}"),
+            });
         }
         ServerEventV2::CancelReceived { ip, session_id } => {
             // The peer cancelled a session this device is sending.
@@ -1033,13 +1109,15 @@ mod tests {
     /// `test_discovery` in
     /// apps/readest-app/src-tauri/src/localsend/service.rs's own tests.
     async fn test_discovery(alias: &str) -> Arc<DiscoveryHandle> {
+        // Three tests share the alias "Reader", and the clock is too coarse
+        // to separate two that start together: they built the SAME path, and
+        // whichever finished first removed the directory out from under the
+        // other (`could not save identity.pem`). A counter is exact.
+        static NEXT_DIR: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let dir = std::env::temp_dir().join(format!(
             "lsffi-disc-{alias}-{}-{}",
             std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+            NEXT_DIR.fetch_add(1, Ordering::Relaxed)
         ));
         std::fs::create_dir_all(&dir).unwrap();
         let identity = Identity::load_or_generate(
@@ -1070,6 +1148,10 @@ mod tests {
         discovery
     }
 
+    fn no_departures() -> DepartedPeers {
+        Arc::new(Mutex::new(HashMap::new()))
+    }
+
     fn register_dto(fingerprint: &str) -> RegisterDtoV2 {
         RegisterDtoV2 {
             alias: "Phone".into(),
@@ -1097,7 +1179,7 @@ mod tests {
         )
         .await;
 
-        let devices = device_payloads(&discovery);
+        let devices = device_payloads(&discovery, &no_departures());
         assert_eq!(devices.len(), 1);
         assert_eq!(devices[0].fingerprint, "peer-fp");
         assert_eq!(devices[0].host, "192.168.2.135");
@@ -1117,7 +1199,94 @@ mod tests {
         )
         .await;
 
-        assert!(device_payloads(&discovery).is_empty());
+        assert!(device_payloads(&discovery, &no_departures()).is_empty());
+    }
+
+    // The Readest app announces `port: 0` over the register route when it is
+    // about to go dark (DEPARTURE_PORT, app-side #6049). Without a guard the
+    // koplugin stored that as a real channel and kept offering an unsendable
+    // peer.
+    #[test]
+    fn a_goodbye_hides_a_peer_that_is_still_answering() {
+        let now = SystemTime::now();
+        assert!(peer_has_departed(Some(now), now));
+        assert!(peer_has_departed(
+            Some(now - DEPARTURE_HOLD + Duration::from_secs(1)),
+            now
+        ));
+        // Bounded, so a lost hello cannot hide a live device for good. The
+        // koplugin has no presence TTL to fall back on, so this is the only
+        // thing that ever puts the peer back.
+        assert!(!peer_has_departed(
+            Some(now - DEPARTURE_HOLD - Duration::from_secs(1)),
+            now
+        ));
+        assert!(!peer_has_departed(None, now));
+    }
+
+    #[tokio::test]
+    async fn device_payloads_drop_a_peer_that_said_goodbye_until_it_says_hello() {
+        let discovery = test_discovery("Reader").await;
+        let departed = no_departures();
+        register_peer(
+            &discovery,
+            "self-fp",
+            "192.168.2.135".into(),
+            register_dto("peer-fp"),
+        )
+        .await;
+        assert_eq!(device_payloads(&discovery, &departed).len(), 1);
+
+        lock(&departed).insert("peer-fp".into(), SystemTime::now());
+        assert!(
+            device_payloads(&discovery, &departed).is_empty(),
+            "a peer that said goodbye must leave the list at once"
+        );
+
+        // The hello clears the hold, even though nothing about the peer's
+        // stored channel changed.
+        lock(&departed).remove("peer-fp");
+        assert_eq!(device_payloads(&discovery, &departed).len(), 1);
+    }
+
+    // A goodbye must not be stored as a channel: port 0 is unsendable, and it
+    // would outrank the peer's real channel as the most recent confirmation.
+    #[tokio::test]
+    async fn a_goodbye_register_never_becomes_a_channel() {
+        let discovery = test_discovery("Reader").await;
+        let departed = no_departures();
+        register_peer(
+            &discovery,
+            "self-fp",
+            "192.168.2.135".into(),
+            register_dto("peer-fp"),
+        )
+        .await;
+
+        let mut goodbye = register_dto("peer-fp");
+        goodbye.port = DEPARTURE_PORT;
+        apply_register(
+            &discovery,
+            &departed,
+            "self-fp",
+            "192.168.2.135".into(),
+            goodbye,
+        )
+        .await;
+
+        assert!(device_payloads(&discovery, &departed).is_empty());
+        // And the real channel is still what a later hello restores.
+        apply_register(
+            &discovery,
+            &departed,
+            "self-fp",
+            "192.168.2.135".into(),
+            register_dto("peer-fp"),
+        )
+        .await;
+        let devices = device_payloads(&discovery, &departed);
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].port, FIRST_PORT);
     }
 
     #[tokio::test]
@@ -1142,7 +1311,7 @@ mod tests {
             })
             .await;
 
-        let devices = device_payloads(&discovery);
+        let devices = device_payloads(&discovery, &no_departures());
         assert_eq!(devices.len(), 1);
         assert_eq!(devices[0].fingerprint, "peer-fp");
         assert_eq!(devices[0].device_type.as_deref(), Some("mobile"));

--- a/apps/readest.koplugin/native/localsend-bin/src/service.rs
+++ b/apps/readest.koplugin/native/localsend-bin/src/service.rs
@@ -310,7 +310,16 @@ pub fn device_payloads(
     departed: &DepartedPeers,
 ) -> Vec<DevicePayload> {
     let now = SystemTime::now();
-    let departed = lock(departed).clone();
+    // Only a hello removes a fingerprint, so a peer that said goodbye and never
+    // came back would be held for the life of the service. Dropping the lapsed
+    // entries here -- the one place that reads the ledger -- bounds it by the
+    // departures still in force, and leaves every survivor departed by
+    // definition, so the check below is a lookup rather than a comparison.
+    let departed = {
+        let mut departed = lock(departed);
+        departed.retain(|_, at| peer_has_departed(Some(*at), now));
+        departed
+    };
     discovery
         .devices()
         .into_iter()
@@ -319,7 +328,7 @@ pub fn device_payloads(
             // this side re-confirms peers on a heartbeat, so a TTL would age
             // every peer out and never bring it back. A goodbye is the only
             // signal this device gets that a peer has gone.
-            if peer_has_departed(departed.get(&stateful.device.fingerprint).copied(), now) {
+            if departed.contains_key(&stateful.device.fingerprint) {
                 return None;
             }
             let http = stateful.get_best_channel().and_then(|c| c.http())?;
@@ -1247,6 +1256,36 @@ mod tests {
         // stored channel changed.
         lock(&departed).remove("peer-fp");
         assert_eq!(device_payloads(&discovery, &departed).len(), 1);
+    }
+
+    // Only a later hello removes a fingerprint, so a peer that says goodbye and
+    // never comes back would sit in the ledger for the life of the service --
+    // and every list_devices would carry it. An expired hold must be forgotten,
+    // not merely ignored.
+    #[tokio::test]
+    async fn an_expired_departure_is_forgotten_not_just_ignored() {
+        let discovery = test_discovery("Reader").await;
+        let departed = no_departures();
+        register_peer(
+            &discovery,
+            "self-fp",
+            "192.168.2.135".into(),
+            register_dto("peer-fp"),
+        )
+        .await;
+
+        let stale = SystemTime::now() - DEPARTURE_HOLD - Duration::from_secs(1);
+        lock(&departed).insert("peer-fp".into(), stale);
+        lock(&departed).insert("peer-that-never-came-back".into(), stale);
+
+        // The hold has lapsed, so the peer is listed again ...
+        assert_eq!(device_payloads(&discovery, &departed).len(), 1);
+        // ... and neither entry is still held, including the one for a peer
+        // that is not in the discovery store at all.
+        assert!(
+            lock(&departed).is_empty(),
+            "an expired departure must not be retained for the life of the service"
+        );
     }
 
     // A goodbye must not be stored as a channel: port 0 is unsendable, and it

--- a/apps/readest.koplugin/scripts/build-koplugin.mjs
+++ b/apps/readest.koplugin/scripts/build-koplugin.mjs
@@ -116,6 +116,9 @@ function main() {
       `${PLUGIN_NAME}/spec/*`,
       `${PLUGIN_NAME}/.busted`,
       `${PLUGIN_NAME}/native/*`,
+      // Locally built plugin zips land in the plugin dir; without this they
+      // get swept into the new zip (megabytes of stale nested copies).
+      `${PLUGIN_NAME}/*.koplugin.zip`,
     ];
     const binDir = path.join(PLUGIN_DIR, 'bin');
     const bins = fs.existsSync(binDir) ? fs.readdirSync(binDir) : [];


### PR DESCRIPTION
Found while verifying Nearby BookDrop v2 (#6023) and the iOS suspension work (#6049) against the KOReader plugin on a **Kindle Voyage** (armv7, kernel 3.0.35) over a real LAN.

The good news first: interop already worked. Discovery both ways, the Kindle held its place in the new AirDrop picker well past the 4.5s `PRESENCE_TTL`, a book went app → plugin byte-identical, and one came back the other way. The receive dialog showed the **"Always accept from …" checkbox**, which is hidden entirely when `certVerified` is false — so the plugin's TLS client cert is seen and koplugin senders can be paired. That was assumed by BookDrop v2 Phase 1 but never checked on a device.

Three real problems turned up alongside it.

### The localsend pin was a dangling SHA

The crate pinned `3cae1825`, which is reachable from **no ref** on the fork — the `readest` branch was rebased and replayed that same SO_REUSEPORT patch as `1609ca7c`. Builds only kept working because GitHub serves unadvertised SHAs; one repo GC away from breaking CI and every release.

Now pinned to `1609ca7c`, the revision the app already uses. Safe to move: the wire protocol is **identical** between the two — every diff is additive API (`SocketsFailed`, `ListenerFailed`, `discover_staged`, `discover_known_http_channels`) or client hardening (`no_proxy`, no-redirect, ALPN http/1.1-only). No DTO changed. Three call sites moved:

- `InterfaceFilter` → `localsend::util::interface`
- `WebConfig` gained `mode`, and `start_with_port` takes it unwrapped
- `ServerEventV2::ListenerFailed` — this match has no catch-all, so it must be handled. The arm surfaces `Event::Error` (Lua already has an `error` handler) and is dormant on Linux, where nothing reclaims a live socket the way iOS does.

### The plugin did not understand a goodbye

#6049 made the app announce `port: 0` over the register route when it is about to go dark. `register_peer` stored that verbatim — an unsendable channel that, being the most recent confirmation, **outranked the peer's real address** — and `device_payloads` had no departure filter to hide it. So once the app went dark, the plugin went on offering a Readest device that no send could reach.

Registers now go through `apply_register`, which records a goodbye without ever touching the discovery store, so the real channel survives for the hello that clears the hold. `device_payloads` drops departed peers.

Two deliberate asymmetries with the app, both commented in the code:

- The hold is **bounded at 15s**, because this side runs no presence heartbeat and has no TTL to fall back on — a lost hello must not hide a live peer for good.
- There is **no presence TTL here at all**. For the same reason: it would age every peer out with nothing to bring it back.

### `build-koplugin.mjs` packaged stale copies of itself

Locally built plugin zips sitting in the plugin directory were swept into the new one. 6.3 MB → 5.7 MB.

### Also: a pre-existing test flake

`cargo test` failed about half the time, on the old revision too (confirmed by stashing: 2 of 4 runs). `test_discovery` built its temp directory from `alias + pid + nanos`, three tests share the alias `"Reader"`, and the clock is too coarse to separate two that start together — they built the same path and whichever finished first removed it out from under the other (`could not save identity.pem`). A counter is exact. 5/5 green after.

## Verification

Gates: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (clean), `cargo test` 27/27 ×3, `cargo test --test protocol -- --ignored` 2/2, `pnpm lint`, `pnpm format:check`, `pnpm test` 10812, `pnpm lint:lua`, `pnpm test:lua` 347.

On the Kindle after the fixes, with rebuilt armv7 binaries (zip and binary md5-matched end to end), posting a `RegisterDtoV2` straight at the helper's HTTPS register route:

```
1. discovered             : ["Readest@192.168.2.120:53318"]
   -> goodbye register (port 0) => HTTP 200
2. after GOODBYE          : []
   -> hello register (port 53318) => HTTP 200
3. after HELLO            : ["Readest@192.168.2.120:53318"]
```

The peer returns at its **real** port, not 0. A koplugin → app send on the new revision still completes (`send_end {status:"sent", filesSent:1}`) with the pairing checkbox present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device discovery so recently departed devices are handled more accurately and can reappear when they reconnect.
  * Recently departed devices remain visible for a short period before being removed from discovery results.
  * Goodbye notifications no longer appear as unusable discovery entries.
  * Added clearer error reporting when the local service cannot start.

* **Build Improvements**
  * Prevented previously generated plugin archives from being included inside new plugin packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->