### PR TITLE
fix(novel): decode imported pages with the charset they declare

### DIFF
--- a/apps/readest-app/src/__tests__/services/novel/chapter-list.test.ts
+++ b/apps/readest-app/src/__tests__/services/novel/chapter-list.test.ts
@@ -221,6 +221,10 @@ describe('byline author fallback', () => {
     expect(toc.weak.author).toBe(false);
   });
 
+  it('does not adopt a later field or a chapter title when the byline is empty', () => {
+    expect(authorOf('<span>作者：</span><span>日期：2026-08-24</span>')).toBe('');
+  });
+
   it('reports no author when the page has no byline', () => {
     expect(authorOf('<p>\u6700\u65b0\u66f4\u65b0</p>')).toBe('');
   });

--- a/apps/readest-app/src/__tests__/services/novel/chapter-list.test.ts
+++ b/apps/readest-app/src/__tests__/services/novel/chapter-list.test.ts
@@ -161,6 +161,71 @@ describe('metadata confidence', () => {
   });
 });
 
+/** Chapter rows for a byline fixture — enough to clear MIN_CHAPTER_LINKS. */
+const bylineRows = Array.from(
+  { length: 6 },
+  (_, i) => `<li><a href="/tongren/11542/${i + 1}.html">\u7b2c${i + 1}\u8282</a></li>`,
+).join('\n');
+
+const bylinePage = (byline: string) => `<!DOCTYPE html><html><head>
+<title>\u5c0f\u8bf4\u540d_\u540c\u4eba\u5c0f\u8bf4\u7f51</title>
+</head><body>
+<div class="infos">${byline}</div>
+<ul>${bylineRows}</ul>
+</body></html>`;
+
+const authorOf = (byline: string) =>
+  parseChapterList(bylinePage(byline), 'https://www.trxs.cc/tongren/11542.html')!.author;
+
+describe('byline author fallback', () => {
+  it('does not swallow a following labelled field (trxs.cc shape)', () => {
+    // <span>作者：<a>五月不行</a></span>日期：2026-08-24
+    expect(
+      authorOf(
+        '<div class="date"> <span>\u4f5c\u8005\uff1a' +
+          '<a href="/author/9275/x.html">\u4e94\u6708\u4e0d\u884c</a></span>' +
+          '\u65e5\u671f\uff1a2026-08-24</div>',
+      ),
+    ).toBe('\u4e94\u6708\u4e0d\u884c');
+  });
+
+  it('stops at a following label inside one text node', () => {
+    expect(
+      authorOf('<p>\u4f5c\u8005\uff1a\u4e94\u6708\u4e0d\u884c\u65e5\u671f\uff1a2026-08-24</p>'),
+    ).toBe('\u4e94\u6708\u4e0d\u884c');
+  });
+
+  it('reads a plain inline byline', () => {
+    expect(authorOf('<p>\u4f5c\u8005\uff1a\u5929\u8695\u571f\u8c46</p>')).toBe(
+      '\u5929\u8695\u571f\u8c46',
+    );
+  });
+
+  it('accepts an ASCII colon and the 著者 label', () => {
+    expect(authorOf('<p>\u8457\u8005: \u5929\u8695\u571f\u8c46</p>')).toBe(
+      '\u5929\u8695\u571f\u8c46',
+    );
+  });
+
+  it('stops at whitespace, so trailing text on the line is not part of the name', () => {
+    expect(authorOf('<p>作者：五月不行 (完结) 469章</p>')).toBe('五月不行');
+  });
+
+  it('still prefers real work metadata over the byline', () => {
+    const page = bylinePage('<p>\u4f5c\u8005\uff1a\u5929\u8695\u571f\u8c46</p>').replace(
+      '</head>',
+      '<meta property="og:novel:author" content="Someone Else"/></head>',
+    );
+    const toc = parseChapterList(page, 'https://www.trxs.cc/tongren/11542.html')!;
+    expect(toc.author).toBe('Someone Else');
+    expect(toc.weak.author).toBe(false);
+  });
+
+  it('reports no author when the page has no byline', () => {
+    expect(authorOf('<p>\u6700\u65b0\u66f4\u65b0</p>')).toBe('');
+  });
+});
+
 describe('parseWorkMetadata', () => {
   it('reads the work title and byline from a chapter page', () => {
     const meta = parseWorkMetadata(

--- a/apps/readest-app/src/__tests__/services/novel/novel-import.test.ts
+++ b/apps/readest-app/src/__tests__/services/novel/novel-import.test.ts
@@ -461,6 +461,18 @@ describe('decodeHtmlBody', () => {
     expect(decodeHtmlBody(body, 'text/html; charset=x-nonsense')).toContain('福尔摩斯');
   });
 
+  it('accepts a single-quoted charset attribute', () => {
+    const body = bytesOf("<html><head><meta charset='big5'><title>", BIG5_HOLMES, '</title>');
+    expect(decodeHtmlBody(body, 'text/html')).toContain('福爾摩斯');
+  });
+
+  it('ignores a charset declaration inside a comment', () => {
+    const body = bytesOf(
+      '<html><head><!-- <meta charset="gbk"> --><title>福尔摩斯</title></head></html>',
+    );
+    expect(decodeHtmlBody(body, 'text/html')).toContain('<title>福尔摩斯</title>');
+  });
+
   it('ignores a charset declared past the sniffing window', () => {
     const body = bytesOf(
       `<html><head><!--${'p'.repeat(1100)}--><meta charset="gbk"><title>`,

--- a/apps/readest-app/src/__tests__/services/novel/novel-import.test.ts
+++ b/apps/readest-app/src/__tests__/services/novel/novel-import.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { configureZip } from '@/utils/zip';
-import { downloadNovel, fetchNovelToc, isNovelImportCancelled } from '@/services/novel/novelImport';
+import {
+  decodeHtmlBody,
+  downloadNovel,
+  fetchNovelToc,
+  isNovelImportCancelled,
+} from '@/services/novel/novelImport';
 import { stableIdentifier } from '@/services/send/conversion/convertToEpub';
 import { ConversionError } from '@/services/send/conversion/types';
 import type { NovelToc } from '@/services/novel/chapterList';
@@ -382,6 +387,117 @@ describe('transient upstream failures', () => {
       expect(files.get('OEBPS/chapter3.xhtml')).not.toContain('could not be downloaded');
     } finally {
       vi.useRealTimers();
+    }
+  });
+});
+
+/**
+ * GB2312 bytes for 福尔摩斯 — the opening of the title on the page from the
+ * report (https://www.trxs.cc/tongren/11542.html), which serves gb2312 with
+ * no charset on the HTTP response.
+ */
+const GB2312_HOLMES = Uint8Array.from([0xb8, 0xa3, 0xb6, 0xfb, 0xc4, 0xa6, 0xcb, 0xb9]);
+const BIG5_HOLMES = Uint8Array.from([0xba, 0xd6, 0xba, 0xb8, 0xbc, 0xaf, 0xb4, 0xb5]);
+/** GB2312 bytes for 第 and 章, so a fixture chapter row reads "第 N 章". */
+const GB2312_DI = Uint8Array.from([0xb5, 0xda]);
+const GB2312_ZHANG = Uint8Array.from([0xd5, 0xc2]);
+
+const bytesOf = (...parts: (string | Uint8Array)[]): Uint8Array<ArrayBuffer> => {
+  const chunks = parts.map((part) =>
+    typeof part === 'string' ? new TextEncoder().encode(part) : part,
+  );
+  const out = new Uint8Array(chunks.reduce((n, chunk) => n + chunk.length, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+};
+
+describe('decodeHtmlBody', () => {
+  it('honors a meta http-equiv charset when the response header has none', () => {
+    const body = bytesOf(
+      '<html><head><meta http-equiv="Content-Type" content="text/html; charset=gb2312" />',
+      '<title>',
+      GB2312_HOLMES,
+      '</title></head><body></body></html>',
+    );
+    expect(decodeHtmlBody(body, 'text/html')).toContain('<title>福尔摩斯</title>');
+  });
+
+  it('honors a short meta charset tag', () => {
+    const body = bytesOf('<html><head><meta charset="gbk"><title>', GB2312_HOLMES, '</title>');
+    expect(decodeHtmlBody(body, null)).toContain('福尔摩斯');
+  });
+
+  it('prefers the response header charset over the meta tag', () => {
+    const body = bytesOf('<html><head><meta charset="utf-8"><title>', BIG5_HOLMES, '</title>');
+    expect(decodeHtmlBody(body, 'text/html; charset=big5')).toContain('福爾摩斯');
+  });
+
+  it('leaves a UTF-8 page untouched', () => {
+    const body = bytesOf('<html><head><title>福尔摩斯</title></head></html>');
+    expect(decodeHtmlBody(body, 'text/html; charset=utf-8')).toContain('福尔摩斯');
+  });
+
+  it('strips a UTF-8 BOM and ignores a contradicting declaration', () => {
+    const body = bytesOf(
+      new Uint8Array([0xef, 0xbb, 0xbf]),
+      '<html><head><meta charset="gbk"><title>福尔摩斯</title>',
+    );
+    const html = decodeHtmlBody(body, 'text/html; charset=gbk');
+    expect(html).toContain('福尔摩斯');
+    expect(html.startsWith('<html>')).toBe(true);
+  });
+
+  it('falls back to gb18030 for undeclared bytes that are not valid UTF-8', () => {
+    const body = bytesOf('<html><head><title>', GB2312_HOLMES, '</title></head></html>');
+    expect(decodeHtmlBody(body, 'text/html')).toContain('福尔摩斯');
+  });
+
+  it('falls back to UTF-8 for an unknown charset label', () => {
+    const body = bytesOf('<html><head><meta charset="x-nonsense"><title>福尔摩斯</title>');
+    expect(decodeHtmlBody(body, 'text/html; charset=x-nonsense')).toContain('福尔摩斯');
+  });
+
+  it('ignores a charset declared past the sniffing window', () => {
+    const body = bytesOf(
+      `<html><head><!--${'p'.repeat(1100)}--><meta charset="gbk"><title>`,
+      GB2312_HOLMES,
+      '</title>',
+    );
+    // Undeclared within the window, so the invalid-UTF-8 fallback still saves it.
+    expect(decodeHtmlBody(body, 'text/html')).toContain('福尔摩斯');
+  });
+});
+
+describe('defaultFetchPage charset handling', () => {
+  it('decodes a gb2312 chapter list served without a header charset', async () => {
+    const listing = Array.from({ length: 6 }, (_, i) => [
+      `<li><a href="/tongren/11542/${i + 1}.html">`,
+      GB2312_DI,
+      ` ${i + 1} `,
+      GB2312_ZHANG,
+      '</a></li>',
+    ]).flat();
+    const page = bytesOf(
+      '<html><head><meta http-equiv="Content-Type" content="text/html; charset=gb2312" /><title>',
+      GB2312_HOLMES,
+      '</title></head><body><ul>',
+      ...listing,
+      '</ul></body></html>',
+    );
+    const tauriFetch = vi.fn(
+      async () => new Response(page, { status: 200, headers: { 'content-type': 'text/html' } }),
+    );
+    vi.doMock('@tauri-apps/plugin-http', () => ({ fetch: tauriFetch }));
+    try {
+      const parsed = await fetchNovelToc('https://www.trxs.cc/tongren/11542.html');
+      expect(parsed.title).toBe('福尔摩斯');
+      expect(parsed.chapters[0]!.title).toBe('第 1 章');
+    } finally {
+      vi.doUnmock('@tauri-apps/plugin-http');
     }
   });
 });

--- a/apps/readest-app/src/services/novel/chapterList.ts
+++ b/apps/readest-app/src/services/novel/chapterList.ts
@@ -176,6 +176,51 @@ const WORK_TITLE_META = [
 ];
 const WORK_AUTHOR_META = ['meta[property="og:novel:author"]', 'meta[property="books:author"]'];
 
+/** Labels a novel site uses to introduce the writer's name. */
+const AUTHOR_LABEL = /(?:作者|著者)\s*[:：]\s*/;
+/**
+ * Field labels that sit right after the byline on the same line. The flattened
+ * text runs them into the name with no separator at all — "作者：五月不行"
+ * immediately followed by "日期：2026-08-24" — and no generic rule can tell
+ * where such a name ends, so the labels worth cutting at are named here.
+ */
+const NEXT_FIELD_LABEL = /(?:日期|时间|更新|状态|字数|分类|类别|类型|标签|来源|最新)\s*[:：]/;
+/** Text nodes to look past for the name when the label ends its own node. */
+const BYLINE_LOOKAHEAD = 3;
+
+/** Trim a byline candidate down to the name. A byline name runs up to the
+ *  first separator — whitespace included, since the rest of the line is other
+ *  fields, not more name. */
+const cleanAuthorName = (raw: string): string => {
+  const field = raw.trim().split(/[\s，,。；;、|/]/)[0] ?? '';
+  return (field.split(NEXT_FIELD_LABEL)[0] ?? '').slice(0, 32);
+};
+
+/**
+ * The writer's name from an on-page byline. Walks text nodes instead of
+ * matching the flattened `body.textContent`, so the name can be read out of the
+ * link that usually wraps it (`作者：<a>NAME</a></span>日期：…`) without the
+ * neighbouring field bleeding into it.
+ */
+const bylineAuthor = (doc: Document): string | null => {
+  const body = doc.body;
+  if (!body) return null;
+  const walker = doc.createTreeWalker(body, NodeFilter.SHOW_TEXT);
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const text = node.textContent || '';
+    const label = text.match(AUTHOR_LABEL);
+    if (label?.index === undefined) continue;
+    let name = cleanAuthorName(text.slice(label.index + label[0].length));
+    // The label can end its own node, with the name in a following one — and
+    // markup indentation often puts a whitespace node in between.
+    for (let ahead = 0; !name && ahead < BYLINE_LOOKAHEAD; ahead++) {
+      name = cleanAuthorName(walker.nextNode()?.textContent || '');
+    }
+    if (name) return name;
+  }
+  return null;
+};
+
 const extractMetadata = (
   doc: Document,
   pageUrl: string,
@@ -189,11 +234,7 @@ const extractMetadata = (
   // `meta[name=author]` is routinely set site-wide (to the operator, not the
   // writer), so it counts as a guess rather than work metadata.
   const workAuthor = metaContent(doc, WORK_AUTHOR_META);
-  const author =
-    workAuthor ||
-    metaContent(doc, ['meta[name="author"]']) ||
-    doc.body?.textContent?.match(/作者[:：]\s*([^\s，,。；;、]{1,32})/)?.[1] ||
-    '';
+  const author = workAuthor || metaContent(doc, ['meta[name="author"]']) || bylineAuthor(doc) || '';
 
   const rawCover = metaContent(doc, ['meta[property="og:image"]']);
   let coverUrl: string | null = null;

--- a/apps/readest-app/src/services/novel/chapterList.ts
+++ b/apps/readest-app/src/services/novel/chapterList.ts
@@ -185,9 +185,6 @@ const AUTHOR_LABEL = /(?:作者|著者)\s*[:：]\s*/;
  * where such a name ends, so the labels worth cutting at are named here.
  */
 const NEXT_FIELD_LABEL = /(?:日期|时间|更新|状态|字数|分类|类别|类型|标签|来源|最新)\s*[:：]/;
-/** Text nodes to look past for the name when the label ends its own node. */
-const BYLINE_LOOKAHEAD = 3;
-
 /** Trim a byline candidate down to the name. A byline name runs up to the
  *  first separator — whitespace included, since the rest of the line is other
  *  fields, not more name. */
@@ -211,10 +208,17 @@ const bylineAuthor = (doc: Document): string | null => {
     const label = text.match(AUTHOR_LABEL);
     if (label?.index === undefined) continue;
     let name = cleanAuthorName(text.slice(label.index + label[0].length));
-    // The label can end its own node, with the name in a following one — and
-    // markup indentation often puts a whitespace node in between.
-    for (let ahead = 0; !name && ahead < BYLINE_LOOKAHEAD; ahead++) {
-      name = cleanAuthorName(walker.nextNode()?.textContent || '');
+    if (!name) {
+      // The label can end its own node, with the name in a following one, and
+      // markup indentation often puts whitespace nodes in between. Only the
+      // first non-blank node can be the name: anything past it is the next
+      // field, so an empty byline must not reach for the date or a chapter.
+      for (let ahead = walker.nextNode(); ahead; ahead = walker.nextNode()) {
+        const candidate = (ahead.textContent || '').trim();
+        if (!candidate) continue;
+        name = cleanAuthorName(candidate);
+        break;
+      }
     }
     if (name) return name;
   }

--- a/apps/readest-app/src/services/novel/novelImport.ts
+++ b/apps/readest-app/src/services/novel/novelImport.ts
@@ -124,6 +124,68 @@ const withTransientRetry =
   };
 
 /**
+ * The number of leading bytes scanned for a `<meta>` charset declaration.
+ * Matches the prescan window browsers use for the same purpose.
+ */
+const CHARSET_SNIFF_BYTES = 1024;
+
+/** `charset=` out of a `Content-Type` value, quoted or bare. */
+const charsetOf = (contentType: string | null | undefined): string | null =>
+  contentType?.match(/charset\s*=\s*"?([^";,\s]+)/i)?.[1] ?? null;
+
+const decoderFor = (label: string | null): TextDecoder | null => {
+  if (!label) return null;
+  try {
+    return new TextDecoder(label, { ignoreBOM: false });
+  } catch {
+    // An unregistered label ("x-nonsense", a typo) — treat it as undeclared.
+    return null;
+  }
+};
+
+/** `<meta charset=…>` or `<meta http-equiv=content-type content="…charset=…">`
+ *  from the head of the document. The prescan is ASCII-only by design: every
+ *  encoding this matters for is ASCII-compatible in its markup. */
+const sniffMetaCharset = (bytes: Uint8Array): string | null => {
+  const head = new TextDecoder('windows-1252').decode(bytes.subarray(0, CHARSET_SNIFF_BYTES));
+  for (const tag of head.match(/<meta\b[^>]*>/gi) ?? []) {
+    const charset = tag.match(/\bcharset\s*=\s*"?([^";,>\s]+)/i)?.[1];
+    if (charset) return charset;
+  }
+  return null;
+};
+
+/**
+ * Decode a fetched page body the way a browser would.
+ *
+ * `Response.text()` always decodes as UTF-8 regardless of what the page says,
+ * so it turns a legacy-encoded site into mojibake — and Chinese web-novel
+ * sites overwhelmingly still serve GB2312/GBK, usually declaring it only in a
+ * `<meta>` tag because the HTTP `Content-Type` carries no charset. Follow the
+ * sniffing order that gets those pages right: BOM, then the response header,
+ * then the `<meta>` prescan.
+ */
+export function decodeHtmlBody(bytes: Uint8Array, contentType: string | null): string {
+  // A BOM outranks every declaration, and `TextDecoder` strips it for us.
+  const [b0, b1, b2] = bytes;
+  if (b0 === 0xff && b1 === 0xfe) return new TextDecoder('utf-16le').decode(bytes);
+  if (b0 === 0xfe && b1 === 0xff) return new TextDecoder('utf-16be').decode(bytes);
+  if (b0 === 0xef && b1 === 0xbb && b2 === 0xbf) return new TextDecoder('utf-8').decode(bytes);
+
+  const declared = decoderFor(charsetOf(contentType)) ?? decoderFor(sniffMetaCharset(bytes));
+  if (declared) return declared.decode(bytes);
+
+  // Nothing declared. UTF-8 when the bytes actually are UTF-8; otherwise
+  // GB18030, which decodes every byte sequence and is what an undeclared
+  // legacy page on this part of the web almost always turns out to be.
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return new TextDecoder('gb18030').decode(bytes);
+  }
+}
+
+/**
  * Fetch a page over the Tauri HTTP client with browser-shaped headers.
  * Novel-site chapter pages are server-rendered, so plain HTTP is enough —
  * spawning a `clip_url` webview per chapter would never scale to hundreds
@@ -150,7 +212,11 @@ const defaultFetchPage: FetchPage = async (url, signal) => {
       'fetch_failed',
     );
   }
-  return { html: await res.text(), finalUrl: res.url || url };
+  const body = new Uint8Array(await res.arrayBuffer());
+  return {
+    html: decodeHtmlBody(body, res.headers.get('content-type')),
+    finalUrl: res.url || url,
+  };
 };
 
 const defaultFetchCover: FetchCover = (url, referer) =>

--- a/apps/readest-app/src/services/novel/novelImport.ts
+++ b/apps/readest-app/src/services/novel/novelImport.ts
@@ -131,7 +131,7 @@ const CHARSET_SNIFF_BYTES = 1024;
 
 /** `charset=` out of a `Content-Type` value, quoted or bare. */
 const charsetOf = (contentType: string | null | undefined): string | null =>
-  contentType?.match(/charset\s*=\s*"?([^";,\s]+)/i)?.[1] ?? null;
+  contentType?.match(/charset\s*=\s*['"]?([^'";,\s]+)/i)?.[1] ?? null;
 
 const decoderFor = (label: string | null): TextDecoder | null => {
   if (!label) return null;
@@ -143,13 +143,22 @@ const decoderFor = (label: string | null): TextDecoder | null => {
   }
 };
 
-/** `<meta charset=…>` or `<meta http-equiv=content-type content="…charset=…">`
- *  from the head of the document. The prescan is ASCII-only by design: every
- *  encoding this matters for is ASCII-compatible in its markup. */
+/**
+ * `<meta charset=…>` or `<meta http-equiv=content-type content="…charset=…">`
+ * from the head of the document. The window is parsed rather than pattern
+ * matched, so a declaration sitting in a comment or a script string cannot be
+ * mistaken for a real one and the parser handles attribute quoting for us.
+ * Decoding it as windows-1252 first is safe: every encoding this matters for
+ * is ASCII-compatible in its markup.
+ */
 const sniffMetaCharset = (bytes: Uint8Array): string | null => {
   const head = new TextDecoder('windows-1252').decode(bytes.subarray(0, CHARSET_SNIFF_BYTES));
-  for (const tag of head.match(/<meta\b[^>]*>/gi) ?? []) {
-    const charset = tag.match(/\bcharset\s*=\s*"?([^";,>\s]+)/i)?.[1];
+  const doc = new DOMParser().parseFromString(head, 'text/html');
+  for (const meta of doc.querySelectorAll('meta')) {
+    const declared = /^content-type$/i.test(meta.getAttribute('http-equiv') || '')
+      ? charsetOf(meta.getAttribute('content'))
+      : meta.getAttribute('charset');
+    const charset = declared?.trim();
     if (charset) return charset;
   }
   return null;


### PR DESCRIPTION
From a user report: importing a web novel showed the title, the author and every
chapter name as mojibake.

Repro: Library -> Import -> **From Web Novel** -> `https://www.trxs.cc/tongren/11542.html`

| field | before | after |
| --- | --- | --- |
| title | `����Ħ˹С��ز����ܳ�Ϊ��Ȯ��` | `福尔摩斯小姐必不可能成为败犬！(五月不行)` |
| author | `五月不行日期：2026-08-24` | `五月不行` |
| chapters | 469, all mojibake | 469, all correct |

## Root cause

`defaultFetchPage` read the page with `await res.text()`. Per the fetch spec
`Response.text()` **always** decodes as UTF-8 and ignores the declared charset, so any
legacy-encoded site came back as mojibake. `trxs.cc` sends `Content-Type: text/html`
with no charset at all and declares `charset=gb2312` only in a `<meta http-equiv>` tag.

This was never platform specific: `Response.text()` behaves identically on macOS,
Windows, Android and iOS, so every platform was affected.

The garbled string is itself diagnostic. Interleaved U+FFFD with a few real
Latin-Extended characters is the signature of GBK bytes read as UTF-8: most GBK pairs
are invalid UTF-8 and become U+FFFD, but a pair with lead `C2`-`DF` and trail `80`-`BF`
decodes to a real character. `Ħ` is `C4 A6`, which is 摩 in GBK; `˹` is `CB B9`, which
is 斯.

## Fix

Read `res.arrayBuffer()` and decode through a new `decodeHtmlBody()` that follows the
browser's sniffing order:

1. BOM (UTF-8 / UTF-16LE / UTF-16BE), which outranks every declaration
2. the HTTP `Content-Type` charset
3. a 1024 byte `<meta>` prescan, covering both `<meta charset>` and the
   `http-equiv="Content-Type"` form
4. for a page that declares nothing: UTF-8 when the bytes really are UTF-8, else
   GB18030, which decodes every byte sequence

An unregistered charset label falls through to the next step rather than throwing.

### Byline author

The mojibake had been hiding a second defect, so this fixes it in the same pass. The
`作者[:：]` fallback ran over the flattened `body.textContent`, and its stop set
(`\s，,。；;、`) contained no CJK label, so an adjacent field ran straight into the name:

```html
<span>作者：<a>五月不行</a></span>日期：2026-08-24
```

`bylineAuthor()` walks text nodes instead, so the name is read out of the link that
usually wraps it.

Worth flagging for reviewers: the tempting generic cut, "split at the next CJK run
followed by a colon", is **wrong**. On `五月不行日期：` the first match is `不行日期：`,
which yields `五月`. Nothing generic can separate "name + label" from "all label" when
there is no delimiter, so `NEXT_FIELD_LABEL` enumerates the adjacent labels explicitly.

## Tests

15 new tests. `novel-import.test.ts` covers the decoder (meta `http-equiv`, short `<meta
charset>`, header precedence, BOM, the undeclared fallback, an unknown label, a
declaration past the sniffing window) plus one that mocks `@tauri-apps/plugin-http` and
reproduces the exact reported mojibake end to end. `chapter-list.test.ts` covers the
byline (the trxs.cc shape, a single text node, whitespace and punctuation stops, the
`著者` label, and that real work metadata still wins).

## Verification

- `pnpm test`: 10828 passed
- `pnpm lint` and `pnpm format:check`: clean
- Xiaomi 13 (Android), release APK md5 checked against the local build: title, author and
  all 469 chapter names correct; a 2 chapter import rendered 3323 characters with **0**
  replacement characters and no stray Latin-Extended (74.2% CJK)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved novel author detection from on-page bylines, including labelled and inline formats.
  - Preserved priority for author metadata embedded in the novel page.
  - Improved decoding of legacy-encoded novel pages, including GB2312/GB18030 and Big5 content.
  - Added support for detecting character encoding from headers, metadata, and byte-order marks.
  - Improved handling of invalid, unknown, missing, or misleading encoding declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->