### PR TITLE
fix(audiobookshelf): add web CORS setup hint

### DIFF
--- a/apps/readest-app/src/__tests__/components/settings/abs-form.test.tsx
+++ b/apps/readest-app/src/__tests__/components/settings/abs-form.test.tsx
@@ -110,6 +110,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.unstubAllEnvs();
 });
 
 const fillAndConnect = () => {
@@ -122,6 +123,32 @@ const fillAndConnect = () => {
 };
 
 describe('ABSForm', () => {
+  test('shows Audiobookshelf CORS setup guidance on the web', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'web');
+
+    render(<ABSForm onBack={vi.fn()} />);
+
+    const setupGuide = screen.getByRole('link', {
+      name: 'View the Audiobookshelf CORS setup guide',
+    });
+    expect(setupGuide.parentElement?.textContent).toContain(
+      "Using Readest on the web? Add this site's origin to Allowed CORS Origins in your Audiobookshelf server settings.",
+    );
+    expect(setupGuide.getAttribute('href')).toBe(
+      'https://audiobookshelf.org/docs/documentation/server-management/cors/',
+    );
+  });
+
+  test('hides Audiobookshelf CORS setup guidance in the native app', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'tauri');
+
+    render(<ABSForm onBack={vi.fn()} />);
+
+    expect(
+      screen.queryByRole('link', { name: 'View the Audiobookshelf CORS setup guide' }),
+    ).toBeNull();
+  });
+
   test('renders the empty-state connect form when no server is configured', () => {
     render(<ABSForm onBack={vi.fn()} />);
     expect(screen.getByLabelText('Server URL')).not.toBeNull();

--- a/apps/readest-app/src/__tests__/components/settings/abs-form.test.tsx
+++ b/apps/readest-app/src/__tests__/components/settings/abs-form.test.tsx
@@ -34,7 +34,8 @@ vi.mock('@/context/EnvContext', () => ({
 }));
 
 vi.mock('@/hooks/useTranslation', () => ({
-  useTranslation: () => (key: string) => key,
+  useTranslation: () => (key: string, options?: Record<string, string>) =>
+    key.replace('{{origin}}', options?.['origin'] ?? '{{origin}}'),
 }));
 
 vi.mock('@/utils/settingsSync', () => ({
@@ -132,7 +133,7 @@ describe('ABSForm', () => {
       name: 'View the Audiobookshelf CORS setup guide',
     });
     expect(setupGuide.parentElement?.textContent).toContain(
-      "Using Readest on the web? Add this site's origin to Allowed CORS Origins in your Audiobookshelf server settings.",
+      `Using Readest on the web? Add ${window.location.origin} to Allowed CORS Origins in your Audiobookshelf server settings.`,
     );
     expect(setupGuide.getAttribute('href')).toBe(
       'https://audiobookshelf.org/docs/documentation/server-management/cors/',

--- a/apps/readest-app/src/components/settings/integrations/ABSForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/ABSForm.tsx
@@ -34,8 +34,10 @@ const isValidAbsUrl = (url: string): boolean => /^https?:\/\//i.test(url);
 const ABSForm: React.FC<ABSFormProps> = ({ onBack }) => {
   const _ = useTranslation();
   const { envConfig, appService } = useEnv();
+  const isWeb = isWebAppPlatform();
   const servers = useABSServerStore((state) => state.servers).filter((server) => !server.deletedAt);
   const [activeServerId, setActiveServerId] = useState<string | null>(null);
+  const [webOrigin, setWebOrigin] = useState('');
 
   const [url, setUrl] = useState('');
   const [username, setUsername] = useState('');
@@ -44,6 +46,10 @@ const ABSForm: React.FC<ABSFormProps> = ({ onBack }) => {
   const [connectError, setConnectError] = useState('');
 
   const activeServer = servers.find((server) => server.id === activeServerId);
+
+  useEffect(() => {
+    if (isWeb) setWebOrigin(window.location.origin);
+  }, [isWeb]);
 
   const handleConnect = async () => {
     const trimmedUrl = normalizeAbsUrl(url);
@@ -218,11 +224,12 @@ const ABSForm: React.FC<ABSFormProps> = ({ onBack }) => {
                 </button>
               </div>
             </form>
-            {isWebAppPlatform() && (
+            {isWeb && webOrigin && (
               <Tips>
                 <li>
                   {_(
-                    "Using Readest on the web? Add this site's origin to Allowed CORS Origins in your Audiobookshelf server settings.",
+                    'Using Readest on the web? Add {{origin}} to Allowed CORS Origins in your Audiobookshelf server settings.',
+                    { origin: webOrigin },
                   )}{' '}
                   <a
                     href='https://audiobookshelf.org/docs/documentation/server-management/cors/'

--- a/apps/readest-app/src/components/settings/integrations/ABSForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/ABSForm.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import React, { useEffect, useState } from 'react';
 import { MdCloudSync } from 'react-icons/md';
 import { useEnv } from '@/context/EnvContext';
-import type { EnvConfigType } from '@/services/environment';
+import { isWebAppPlatform, type EnvConfigType } from '@/services/environment';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useABSServerStore } from '@/store/absServerStore';
 import { useLibraryStore } from '@/store/libraryStore';
@@ -15,7 +15,7 @@ import type { AppService } from '@/types/system';
 import { parseAbsFilePath } from '@/utils/audiobook';
 import { eventDispatcher } from '@/utils/event';
 import SubPageHeader from '../SubPageHeader';
-import { BoxedList, NavigationRow, SectionTitle, SettingsSwitchRow } from '../primitives';
+import { BoxedList, NavigationRow, SectionTitle, SettingsSwitchRow, Tips } from '../primitives';
 
 interface ABSFormProps {
   onBack: () => void;
@@ -218,6 +218,24 @@ const ABSForm: React.FC<ABSFormProps> = ({ onBack }) => {
                 </button>
               </div>
             </form>
+            {isWebAppPlatform() && (
+              <Tips>
+                <li>
+                  {_(
+                    "Using Readest on the web? Add this site's origin to Allowed CORS Origins in your Audiobookshelf server settings.",
+                  )}{' '}
+                  <a
+                    href='https://audiobookshelf.org/docs/documentation/server-management/cors/'
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    className='link link-primary'
+                  >
+                    {_('View the Audiobookshelf CORS setup guide')}
+                  </a>
+                  .
+                </li>
+              </Tips>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- Show web users the exact current Readest origin from `window.location.origin` to add under **Allowed CORS Origins** on their Audiobookshelf server.
- Resolve the browser origin after hydration so server rendering remains safe.
- Link directly to Audiobookshelf's official CORS setup guide.
- Keep the browser-only guidance hidden in Tauri desktop and mobile builds.
- Cover both platform branches and the rendered origin with component tests.

## Test Coverage

```text
ABSForm render
├── [★★★ TESTED] web build → resolve and display the current origin with the official guide URL
└── [★★★ TESTED] Tauri build → omit browser-only CORS guidance

Coverage: 2/2 new code paths (100%)
```

Tests: 998 → 998 test files (+0 new; 2 cases added)

## Pre-Landing Review

No issues found.

## Design Review

Design Review (lite): no issues found. The hint reuses the existing e-ink-compatible `Tips` primitive.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN

## Plan Completion

No plan file detected.

## Verification Results

- `pnpm test`: 10,814 passed, 16 skipped
- `pnpm lint`: TypeScript and Biome passed
- `pnpm build`: Next.js production build passed
- Repository pre-push formatting, lint, and test gates passed

## Test plan

- [x] Web builds display `window.location.origin` in the CORS setup hint.
- [x] Tauri builds omit the browser-only hint.
- [x] Full unit suite, lint, type-checking, formatting, and production build pass.

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added web-specific guidance when configuring an Audiobookshelf server, including the required site origin, Allowed CORS Origins instructions, and a link to the official setup guide.
  - Guidance appears only in the web app and remains hidden in the native desktop app.

- **Tests**
  - Added coverage for platform-specific visibility, origin interpolation, and the documentation link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->