### PR TITLE
fix(reader): restore EPUB namespace in section fragments

### DIFF
--- a/apps/readest-app/src/__tests__/utils/style-dom.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-dom.test.ts
@@ -692,13 +692,13 @@ describe('applyNamespacedAttributes', () => {
     expect(doc.querySelector('a')!.getAttributeNS(OPS, 'type')).toBe('noteref');
   });
 
-  it('picks up a declaration made further down the document', () => {
+  it('uses the EPUB fallback alongside an unrelated namespace declaration', () => {
     const doc = parseAsSrcdoc(
-      '<section xmlns:epub="http://www.idpf.org/2007/ops"><div epub:type="chapter">x</div></section>',
+      '<section xmlns:svg="http://www.w3.org/2000/svg"><a epub:type="noteref">1</a></section>',
       '',
     );
     applyNamespacedAttributes(doc);
-    expect(doc.querySelector('div')!.getAttributeNS(OPS, 'type')).toBe('chapter');
+    expect(doc.querySelector('a')!.getAttributeNS(OPS, 'type')).toBe('noteref');
   });
 
   it('leaves the reserved xml and xmlns names untouched', () => {
@@ -719,7 +719,7 @@ describe('applyNamespacedAttributes', () => {
     );
     applyNamespacedAttributes(doc);
     expect(doc.querySelector('#a')!.getAttributeNS(OPS, 'type')).toBe('chapter');
-    expect(doc.querySelector('#b')!.getAttributeNS(OPS, 'type')).toBeNull();
+    expect(doc.querySelector('#b')!.getAttributeNS(OPS, 'type')).toBe('chapter');
   });
 
   it('restores the outer binding once a rebinding subtree ends', () => {

--- a/apps/readest-app/src/__tests__/utils/style-dom.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-dom.test.ts
@@ -686,6 +686,12 @@ describe('applyNamespacedAttributes', () => {
     expect(doc.querySelector('div')!.getAttributeNS(OPS, 'type')).toBe('chapter');
   });
 
+  it('restores the standard EPUB namespace when a section fragment lost its declaration', () => {
+    const doc = parseAsSrcdoc('<a epub:type="noteref">1</a>', '');
+    applyNamespacedAttributes(doc);
+    expect(doc.querySelector('a')!.getAttributeNS(OPS, 'type')).toBe('noteref');
+  });
+
   it('picks up a declaration made further down the document', () => {
     const doc = parseAsSrcdoc(
       '<section xmlns:epub="http://www.idpf.org/2007/ops"><div epub:type="chapter">x</div></section>',

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1335,6 +1335,7 @@ export const applyScrollModeClass = (document: Document, isScrollMode: boolean) 
 
 // A prefixed attribute name, e.g. the `epub:type` of `epub:type="chapter"`.
 const PREFIXED_ATTR_REGEX = /^([A-Za-z_][\w.-]*):([A-Za-z_][\w.-]*)$/;
+const EPUB_OPS_NAMESPACE = 'http://www.idpf.org/2007/ops';
 
 /**
  * Re-attach the namespaces an XHTML section declared to its prefixed
@@ -1352,6 +1353,9 @@ const PREFIXED_ATTR_REGEX = /^([A-Za-z_][\w.-]*):([A-Za-z_][\w.-]*)$/;
  * callers are unaffected either way.
  */
 export const applyNamespacedAttributes = (document: Document) => {
+  const hasNamespaceDeclaration = Array.from(document.querySelectorAll('*')).some((element) =>
+    Array.from(element.attributes).some(({ name }) => name.startsWith('xmlns:')),
+  );
   // `xmlns:` declarations survive HTML parsing as ordinary attributes, but only
   // as attributes: nothing scopes them any more, so a prefix has to be resolved
   // the way XML would resolve it, from the element's own ancestor chain. A flat
@@ -1368,7 +1372,13 @@ export const applyNamespacedAttributes = (document: Document) => {
     for (const { name, value } of Array.from(element.attributes)) {
       const [, prefix, localName] = PREFIXED_ATTR_REGEX.exec(name) ?? [];
       if (!prefix) continue;
-      const uri = lookupNamespace(element, prefix);
+      // Foliate can hand us a section fragment rather than the source XHTML
+      // document, so the declaration on the original <html> may be gone.
+      // `epub` has one fixed namespace in EPUB, which is enough to restore the
+      // selectors used by the book's stylesheet (including noteref markers).
+      const uri =
+        lookupNamespace(element, prefix) ??
+        (!hasNamespaceDeclaration && prefix === 'epub' ? EPUB_OPS_NAMESPACE : null);
       if (uri && !element.hasAttributeNS(uri, localName!)) {
         element.setAttributeNS(uri, name, value);
       }

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1353,9 +1353,6 @@ const EPUB_OPS_NAMESPACE = 'http://www.idpf.org/2007/ops';
  * callers are unaffected either way.
  */
 export const applyNamespacedAttributes = (document: Document) => {
-  const hasNamespaceDeclaration = Array.from(document.querySelectorAll('*')).some((element) =>
-    Array.from(element.attributes).some(({ name }) => name.startsWith('xmlns:')),
-  );
   // `xmlns:` declarations survive HTML parsing as ordinary attributes, but only
   // as attributes: nothing scopes them any more, so a prefix has to be resolved
   // the way XML would resolve it, from the element's own ancestor chain. A flat
@@ -1377,8 +1374,7 @@ export const applyNamespacedAttributes = (document: Document) => {
       // `epub` has one fixed namespace in EPUB, which is enough to restore the
       // selectors used by the book's stylesheet (including noteref markers).
       const uri =
-        lookupNamespace(element, prefix) ??
-        (!hasNamespaceDeclaration && prefix === 'epub' ? EPUB_OPS_NAMESPACE : null);
+        lookupNamespace(element, prefix) ?? (prefix === 'epub' ? EPUB_OPS_NAMESPACE : null);
       if (uri && !element.hasAttributeNS(uri, localName!)) {
         element.setAttributeNS(uri, name, value);
       }


### PR DESCRIPTION
## Summary

- Restore the standard EPUB namespace for prefixed attributes in section fragments that lost their `xmlns:epub` declaration.
- Fix Standard Ebooks noteref markers rendering as baseline text instead of superscript.
- Add a regression test for `a epub:type="noteref"` in a declaration-less fragment.

## Reproduction

- Report: Windows 11, Readest 0.12.6
- EPUB: Samuel Taylor Coleridge and Robert Southey, *The Fall of Robespierre* Advanced EPUB
- Source: https://standardebooks.org/ebooks/samuel-taylor-coleridge_robert-southey/the-fall-of-robespierre
- Symptom: half-title-page endnote markers are not superscript in Readest, while Sigil renders them correctly.

## Verification

- Focused namespace regression tests: 10 passed
- Biome formatting/check: passed
- TypeScript and lint: passed
- Full pre-push Vitest suite was attempted but stalled after emitting the existing `Not implemented: navigation to another Document` message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed EPUB content styling so `epub:type` attributes correctly use the standard EPUB namespace when a section fragment does not declare one.
  * Improved namespace handling so unrelated declarations do not prevent the EPUB fallback, while correctly respecting declarations scoped to the relevant content.

* **Tests**
  * Added regression coverage for namespace restoration in EPUB section fragments, including scoped and out-of-scope namespace declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->