### PR TITLE
fix(reader): make the reading ruler legible on e-ink

### DIFF
--- a/apps/readest-app/src/__tests__/components/ReadingRuler.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ReadingRuler.test.tsx
@@ -662,4 +662,60 @@ describe('ReadingRuler', () => {
       expect(rulerTop()).toBeGreaterThan(before);
     });
   });
+  describe('band presentation', () => {
+    const renderRuler = (settings: ViewSettings, color: 'transparent' | 'yellow') =>
+      render(
+        <ReadingRuler
+          bookKey='book-1'
+          isVertical={false}
+          rtl={false}
+          lines={2}
+          position={33}
+          opacity={0.5}
+          color={color}
+          bookFormat='EPUB'
+          viewSettings={settings}
+          gridInsets={{ top: 0, right: 0, bottom: 0, left: 0 }}
+        />,
+      );
+
+    it('tints the band with a backdrop filter on color displays', () => {
+      const { container } = renderRuler(viewSettings, 'yellow');
+      const ruler = container.querySelector('.ruler') as HTMLDivElement;
+
+      expect(ruler.getAttribute('style')).toContain('sepia');
+      expect(ruler.className).not.toContain('border');
+    });
+
+    it('outlines the colorless band on color displays', () => {
+      const { container } = renderRuler(viewSettings, 'transparent');
+      const ruler = container.querySelector('.ruler') as HTMLDivElement;
+
+      expect(ruler.getAttribute('style')).not.toContain('sepia');
+      expect(ruler.className).toContain('border-base-content/55');
+    });
+
+    it('drops the backdrop tint and outlines the band on e-ink', () => {
+      const einkSettings = { ...viewSettings, isEink: true } as ViewSettings;
+      const { container } = renderRuler(einkSettings, 'yellow');
+      const ruler = container.querySelector('.ruler') as HTMLDivElement;
+
+      expect(ruler.getAttribute('style')).not.toContain('sepia');
+      expect(ruler.className).toContain('border-base-content');
+      expect(ruler.className).not.toContain('border-base-content/55');
+    });
+
+    it('keeps the tint on color e-ink, still outlining the band', () => {
+      const colorEinkSettings = {
+        ...viewSettings,
+        isEink: true,
+        isColorEink: true,
+      } as ViewSettings;
+      const { container } = renderRuler(colorEinkSettings, 'yellow');
+      const ruler = container.querySelector('.ruler') as HTMLDivElement;
+
+      expect(ruler.getAttribute('style')).toContain('sepia');
+      expect(ruler.className).toContain('border-base-content');
+    });
+  });
 });

--- a/apps/readest-app/src/app/reader/components/ReadingRuler.tsx
+++ b/apps/readest-app/src/app/reader/components/ReadingRuler.tsx
@@ -281,7 +281,6 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
   // Cap the dynamic band at (lines + 1) line heights so a tall element (e.g. a
   // full-page image) inside the block doesn't expand the band to cover all of it.
   const maxBandSize = calculateReadingRulerSize(lines + 1, viewSettings, bookFormat);
-  const baseColor = READING_RULER_COLORS[color] || READING_RULER_COLORS['yellow'];
 
   const clampPosition = useCallback(
     (pos: number, dimension: number) =>
@@ -1092,6 +1091,21 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
     WebkitBackdropFilter: cssFilter,
   };
 
+  // Black-and-white e-ink renders every hue as the same gray, so the band's
+  // backdrop tint buys no color there and only costs contrast on the very text
+  // being read. Fall back to the colorless band on those panels; color e-ink
+  // can still show the tint the reader picked.
+  const isEink = !!viewSettings.isEink;
+  const tintBand = color !== 'transparent' && !(isEink && !viewSettings.isColorEink);
+  const bandStyle = tintBand ? backdropFilterStyle : { backgroundColor: 'transparent' };
+  // E-ink has no hover or shadow cues, so the band always needs a crisp 1px
+  // boundary; the translucent outline used on color displays washes out there.
+  const bandOutlineClass = isEink
+    ? 'border-base-content border'
+    : tintBand
+      ? ''
+      : 'border-base-content/55 border';
+
   // Animation transition for smooth auto-positioning
   const getTransitionStyle = (property: 'left' | 'top' | 'width' | 'height') =>
     shouldAnimate ? `${property} 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94)` : 'none';
@@ -1137,18 +1151,14 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
         <div
           className={clsx(
             'ruler pointer-events-none absolute bottom-0 top-0 my-2 rounded-2xl',
-            color === 'transparent' ? 'border-base-content/55 border' : '',
+            bandOutlineClass,
           )}
           style={{
             left: `${renderPosPct}%`,
             width: `${effectiveBandSize}px`,
             transform: 'translateX(-50%)',
             transition: getTransitionStyle('left'),
-            ...(color === 'transparent'
-              ? {
-                  backgroundColor: baseColor,
-                }
-              : backdropFilterStyle),
+            ...bandStyle,
           }}
         >
           {/* Keep the ruler body pass-through so text inside stays selectable. */}
@@ -1227,17 +1237,14 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
 
         {/* Column band */}
         <div
-          className={clsx(
-            'ruler pointer-events-none absolute rounded-2xl',
-            color === 'transparent' ? 'border-base-content/55 border' : '',
-          )}
+          className={clsx('ruler pointer-events-none absolute rounded-2xl', bandOutlineClass)}
           style={{
             left: `${bandLeft}px`,
             top: `${bandTop}px`,
             width: `${bandWidth}px`,
             height: `${bandHeight}px`,
             transition: bandTransition,
-            ...(color === 'transparent' ? { backgroundColor: baseColor } : backdropFilterStyle),
+            ...bandStyle,
           }}
         >
           <div
@@ -1286,18 +1293,14 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
       <div
         className={clsx(
           'ruler pointer-events-none absolute left-0 right-0 mx-2 rounded-2xl',
-          color === 'transparent' ? 'border-base-content/55 border' : '',
+          bandOutlineClass,
         )}
         style={{
           top: `${currentPosition}%`,
           height: `${effectiveBandSize}px`,
           transform: 'translateY(-50%)',
           transition: getTransitionStyle('top'),
-          ...(color === 'transparent'
-            ? {
-                backgroundColor: baseColor,
-              }
-            : backdropFilterStyle),
+          ...bandStyle,
         }}
       >
         <div


### PR DESCRIPTION
## Problem

The reading ruler had no e-ink handling at all.

Picking any ruler color applied a `backdrop-filter: sepia(...) saturate(2) hue-rotate(...)` tint over the band. A black-and-white e-ink panel renders every hue as the same gray, so that tint carries no color there and only lowers the contrast of the very text the ruler is meant to help you read, at the cost of an extra compositing pass on a slow-refresh screen.

The band's only outline was `border-base-content/55`, drawn just for the colorless ruler. A 55% translucent border washes out on e-ink, where the project convention is crisp 1px borders for delineation.

## Change

`ReadingRuler.tsx` derives the band presentation once and feeds all three layout branches (vertical, column-aware, horizontal), replacing three copies of the same `color === 'transparent' ? ... : ...` ternary pair:

- **`bandStyle`** drops the backdrop tint on black-and-white e-ink and falls back to the clear band. Color e-ink keeps the tint, since it can actually show it. The gate is `isEink && !isColorEink`, matching the existing precedent in `annotatorUtil.ts`.
- **`bandOutlineClass`** always draws a full-opacity `border-base-content` outline on e-ink, and keeps `border-base-content/55` for the colorless band on color displays.

Net effect is slightly less code than it replaces.

Two things deliberately left alone:

- The dim overlays still follow the opacity setting exactly. Overriding an explicit user control based on an unrelated condition would be hidden coupling.
- Transitions need no work: `.no-transitions *` in `globals.css` already disables them globally in e-ink mode.

`eink-bordered` is not usable here despite the general recommendation in CLAUDE.md, because its rule forces `background-color: base-100 !important`, which would paint the band opaque and hide the text underneath.

## Tests

Four cases in `ReadingRuler.test.tsx` pin the band presentation: tinted band on color displays, outlined colorless band, tint dropped plus crisp outline on black-and-white e-ink, and tint kept plus outline on color e-ink. The e-ink case was written first and confirmed failing on the sepia filter before the fix.

## Verification

- `pnpm test` — 10846 passed, 0 failed
- `pnpm lint` — clean
- `pnpm format:check` — clean

No `src-tauri/` or koplugin changes, so those gates do not apply. Not yet verified on a physical e-ink device.

## Context

Refs #6048. That request also asked to move the ruler color onto the surrounding lines and to auto-hide the outline above opacity 0.4; both are declined with reasoning in [this comment](https://github.com/readest/readest/issues/6048#issuecomment-5542344766). The issue is intentionally left open rather than closed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reading ruler band rendering on e-ink displays.
  * Removed color tinting on non-color e-ink screens for clearer reading.
  * Added a solid outline on e-ink displays while preserving appropriate tinting and translucent outlines on color screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->