### PR TITLE
feat(audiobookshelf): stream ebook-only books

### DIFF
--- a/apps/readest-app/src/__tests__/services/abs-client.test.ts
+++ b/apps/readest-app/src/__tests__/services/abs-client.test.ts
@@ -154,6 +154,36 @@ describe('ABSClient', () => {
     expect(fetchMock.mock.calls[1]![0]).toBe('http://abs.local:13378/api/items/ebook1?expanded=1');
   });
 
+  it('bounds expanded-item requests for large libraries', async () => {
+    let active = 0;
+    let maxActive = 0;
+    fetchMock.mockImplementation(async (url: string) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active--;
+      if (url.includes('/api/libraries/')) {
+        return jsonResponse(200, {
+          total: 9,
+          results: Array.from({ length: 9 }, (_, i) => ({
+            id: `ebook${i}`,
+            mediaType: 'book',
+            media: { metadata: {}, numAudioFiles: 0 },
+          })),
+        });
+      }
+      return jsonResponse(200, {
+        mediaType: 'book',
+        media: { metadata: {}, numAudioFiles: 0, ebookFile: { ino: url, ebookFormat: 'epub' } },
+      });
+    });
+
+    const items = await client.getLibraryItems('l1');
+
+    expect(items).toHaveLength(9);
+    expect(maxActive).toBeLessThanOrEqual(8);
+  });
+
   it('openPlaybackSession posts to the book play path when no episodeId is given', async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse(200, { id: 'sess1', currentTime: 12, audioTracks: [] }),

--- a/apps/readest-app/src/__tests__/services/abs-client.test.ts
+++ b/apps/readest-app/src/__tests__/services/abs-client.test.ts
@@ -113,15 +113,15 @@ describe('ABSClient', () => {
         jsonResponse(200, {
           total: 3,
           results: [
-            { id: 'a', mediaType: 'book', media: { metadata: {} } },
-            { id: 'b', mediaType: 'book', media: { metadata: {} } },
+            { id: 'a', mediaType: 'book', media: { metadata: {}, numAudioFiles: 1 } },
+            { id: 'b', mediaType: 'book', media: { metadata: {}, numAudioFiles: 1 } },
           ],
         }),
       )
       .mockResolvedValueOnce(
         jsonResponse(200, {
           total: 3,
-          results: [{ id: 'c', mediaType: 'book', media: { metadata: {} } }],
+          results: [{ id: 'c', mediaType: 'book', media: { metadata: {}, numAudioFiles: 1 } }],
         }),
       );
     const items = await client.getLibraryItems('l1');
@@ -130,6 +130,28 @@ describe('ABSClient', () => {
       '/api/libraries/l1/items?limit=100&page=0',
     );
     expect(String(fetchMock.mock.calls[1]![0])).toContain('page=1');
+  });
+
+  it('expands audio-less book items to discover primary ebooks', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          total: 1,
+          results: [{ id: 'ebook1', mediaType: 'book', media: { metadata: {}, numAudioFiles: 0 } }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          id: 'ebook1',
+          mediaType: 'book',
+          media: { metadata: {}, numAudioFiles: 0, ebookFile: { ino: '1', ebookFormat: 'epub' } },
+        }),
+      );
+
+    const items = await client.getLibraryItems('l1');
+
+    expect(items[0]!.media.ebookFile).toEqual({ ino: '1', ebookFormat: 'epub' });
+    expect(fetchMock.mock.calls[1]![0]).toBe('http://abs.local:13378/api/items/ebook1?expanded=1');
   });
 
   it('openPlaybackSession posts to the book play path when no episodeId is given', async () => {

--- a/apps/readest-app/src/__tests__/services/abs-library-sync.test.ts
+++ b/apps/readest-app/src/__tests__/services/abs-library-sync.test.ts
@@ -85,6 +85,40 @@ describe('reconcileAbsBooks', () => {
     });
   });
 
+  it('updates an existing audio book when it becomes ebook-only', () => {
+    const audioBook = reconcileAbsBooks({
+      server,
+      items: [item('i4', 'Converted')],
+      progress: [],
+      library: [],
+      lastPlayedAtByHash: new Map(),
+      now: 1,
+    }).upserts[0]!;
+    const ebookOnly: ABSLibraryItem = {
+      id: 'i4',
+      mediaType: 'book',
+      media: {
+        metadata: { title: 'Converted', authorName: 'Author A' },
+        ebookFile: { ino: '456', ebookFormat: 'epub' },
+      },
+    };
+
+    const { upserts } = reconcileAbsBooks({
+      server,
+      items: [ebookOnly],
+      progress: [],
+      library: [audioBook],
+      lastPlayedAtByHash: new Map(),
+      now: 2,
+    });
+
+    expect(upserts[0]).toMatchObject({
+      absMediaType: 'ebook',
+      metadata: { absMediaType: 'ebook' },
+      duration: undefined,
+    });
+  });
+
   describe('podcast shows', () => {
     it('creates a podcast show stub with absMediaType, undefined duration, and author from metadata.author', () => {
       const { upserts } = reconcileAbsBooks({

--- a/apps/readest-app/src/__tests__/services/abs-library-sync.test.ts
+++ b/apps/readest-app/src/__tests__/services/abs-library-sync.test.ts
@@ -61,6 +61,30 @@ describe('reconcileAbsBooks', () => {
     expect(upserts).toEqual([]);
   });
 
+  it('creates a streaming ebook stub when ABS exposes a primary ebook file', () => {
+    const ebookOnly: ABSLibraryItem = {
+      id: 'i3',
+      mediaType: 'book',
+      media: {
+        metadata: { title: 'Streamed EPUB', authorName: 'Author E' },
+        ebookFile: { ino: '123', ebookFormat: 'epub' },
+      },
+    };
+    const { upserts } = reconcileAbsBooks({
+      server,
+      items: [ebookOnly],
+      progress: [],
+      library: [],
+      lastPlayedAtByHash: new Map(),
+      now: 1,
+    });
+    expect(upserts[0]).toMatchObject({
+      format: 'ABS',
+      absMediaType: 'ebook',
+      filePath: makeAbsFilePath('srv1', 'i3'),
+    });
+  });
+
   describe('podcast shows', () => {
     it('creates a podcast show stub with absMediaType, undefined duration, and author from metadata.author', () => {
       const { upserts } = reconcileAbsBooks({

--- a/apps/readest-app/src/__tests__/services/cloud-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/cloud-service.test.ts
@@ -2,6 +2,8 @@ import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { deleteBook, uploadBook } from '@/services/cloudService';
 import { Book, BookFormat } from '@/types/book';
 import { BaseDir, FileSystem } from '@/types/system';
+import { useABSServerStore } from '@/store/absServerStore';
+import { makeAbsFilePath } from '@/utils/audiobook';
 
 // Mock external dependencies
 vi.mock('@/utils/book', () => ({
@@ -393,6 +395,31 @@ describe('cloudService', () => {
   });
 
   describe('uploadBook', () => {
+    test('materializes an ABS ebook before uploading it', async () => {
+      const server = useABSServerStore.getState().addServer({
+        name: 'ABS',
+        url: 'https://abs.example.test',
+        accessToken: 'token',
+      });
+      const book = createMockBook({
+        format: 'ABS' as BookFormat,
+        filePath: makeAbsFilePath(server.id, 'item-1'),
+        metadata: { title: 'Test Book', author: 'Author', language: 'en', absMediaType: 'ebook' },
+      });
+      vi.mocked(mockFs.exists).mockImplementation(async (path, base) => {
+        return base === 'Books' && path === `${book.hash}/cover.png`;
+      });
+      const resolveFilePath = vi.fn(async (path: string, base: BaseDir) => `${base}:${path}`);
+
+      await uploadBook(mockFs, resolveFilePath, book);
+
+      expect(mockFs.openFile).toHaveBeenNthCalledWith(
+        1,
+        'https://abs.example.test/api/items/item-1/ebook?token=token',
+        'None',
+      );
+    });
+
     test('clears stale file-sync deletion authorization when reviving a book', async () => {
       const book = createMockBook({
         deletedAt: 100,

--- a/apps/readest-app/src/__tests__/utils/audiobook.test.ts
+++ b/apps/readest-app/src/__tests__/utils/audiobook.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   isAudiobook,
+  buildAbsEbookUrl,
   makeAbsFilePath,
   parseAbsFilePath,
   splitLibraryOpenIds,
@@ -14,6 +15,12 @@ describe('audiobook helpers', () => {
     expect(parseAbsFilePath(path)).toEqual({ serverId: 'server-1', itemId: 'item-abc' });
   });
 
+  it('builds an authenticated ABS ebook URL', () => {
+    expect(buildAbsEbookUrl({ url: 'https://abs.example/', accessToken: 'a+b&c' }, 'item/1')).toBe(
+      'https://abs.example/api/items/item%2F1/ebook?token=a%2Bb%26c',
+    );
+  });
+
   it('parseAbsFilePath rejects non-abs paths', () => {
     expect(parseAbsFilePath('/books/x.epub')).toBeNull();
     expect(parseAbsFilePath(undefined)).toBeNull();
@@ -23,15 +30,25 @@ describe('audiobook helpers', () => {
   it('isAudiobook keys on the ABS format', () => {
     expect(isAudiobook({ format: 'ABS' })).toBe(true);
     expect(isAudiobook({ format: 'EPUB' })).toBe(false);
+    expect(
+      isAudiobook({
+        format: 'ABS',
+        metadata: { title: 'Ebook', author: 'A', language: '', absMediaType: 'ebook' },
+      }),
+    ).toBe(false);
   });
 });
 
 describe('splitLibraryOpenIds', () => {
-  const books: Record<string, Pick<Book, 'format'>> = {
+  const books: Record<string, Pick<Book, 'format' | 'metadata'>> = {
     a1: { format: 'ABS' },
     a2: { format: 'ABS' },
-    e1: { format: 'EPUB' },
-    e2: { format: 'EPUB' },
+    e1: { format: 'EPUB', metadata: undefined },
+    e2: { format: 'EPUB', metadata: undefined },
+    absEbook: {
+      format: 'ABS',
+      metadata: { title: 'E', author: 'A', language: '', absMediaType: 'ebook' },
+    },
   };
   const lookup = (hash: string) => books[hash];
 
@@ -47,6 +64,14 @@ describe('splitLibraryOpenIds', () => {
     expect(splitLibraryOpenIds(['e1'], lookup)).toEqual({
       audiobookHash: null,
       readerIds: ['e1'],
+      droppedAudiobooks: false,
+    });
+  });
+
+  it('leaves a streamed ABS ebook in the reader ids', () => {
+    expect(splitLibraryOpenIds(['absEbook'], lookup)).toEqual({
+      audiobookHash: null,
+      readerIds: ['absEbook'],
       droppedAudiobooks: false,
     });
   });

--- a/apps/readest-app/src/app/library/hooks/useOpenBook.ts
+++ b/apps/readest-app/src/app/library/hooks/useOpenBook.ts
@@ -7,7 +7,7 @@ import { useAppRouter } from '@/hooks/useAppRouter';
 import { hasFileSyncMirror, useMakeBookAvailable } from '@/hooks/useMakeBookAvailable';
 import { eventDispatcher } from '@/utils/event';
 import { navigateToReader, showReaderWindow } from '@/utils/nav';
-import { isAudiobook } from '@/utils/audiobook';
+import { isAbsEbook, isAudiobook } from '@/utils/audiobook';
 
 interface UseOpenBookOptions {
   setLoading: Dispatch<SetStateAction<boolean>>;
@@ -54,7 +54,13 @@ export const useOpenBook = ({ setLoading, handleBookDownload }: UseOpenBookOptio
       // missing LOCAL file is not evidence that the user wants the REMOTE copy
       // destroyed, and there the book is very likely still on the mirror;
       // `makeBookAvailable` below fetches it back instead.
-      if (book.filePath && !book.uploadedAt && !book.deletedAt && !hasFileSyncMirror()) {
+      if (
+        book.filePath &&
+        !isAbsEbook(book) &&
+        !book.uploadedAt &&
+        !book.deletedAt &&
+        !hasFileSyncMirror()
+      ) {
         const available = await appService?.isBookAvailable(book);
         if (!available) {
           eventDispatcher.dispatch('toast', {

--- a/apps/readest-app/src/hooks/useMakeBookAvailable.ts
+++ b/apps/readest-app/src/hooks/useMakeBookAvailable.ts
@@ -4,6 +4,7 @@ import { useEnv } from '@/context/EnvContext';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { getActiveFileSyncBackends } from '@/services/sync/cloudSyncProvider';
+import { isAbsEbook } from '@/utils/audiobook';
 
 /**
  * Whether a third-party file mirror (WebDAV / Google Drive / S3 / OneDrive) is
@@ -38,6 +39,7 @@ export const useMakeBookAvailable = ({
 
   return useCallback(
     async (book: Book) => {
+      if (isAbsEbook(book)) return true;
       // A book with no cloud copy has nothing to fetch; the callers already
       // handle the case where such a book's local file is gone. `uploadedAt` is
       // not the whole story for a file backend: it is stamped by the sync engine,

--- a/apps/readest-app/src/libs/document.ts
+++ b/apps/readest-app/src/libs/document.ts
@@ -104,7 +104,7 @@ export type BookMetadata = {
   // they ride across inside this synced metadata payload, exactly as a feed
   // book carries `feedUrl`. Built and read back in src/utils/audiobook.ts.
   absSource?: string;
-  absMediaType?: 'podcast';
+  absMediaType?: 'podcast' | 'ebook';
   absEpisodeCount?: number;
   absDuration?: number;
 };

--- a/apps/readest-app/src/services/appService.ts
+++ b/apps/readest-app/src/services/appService.ts
@@ -23,6 +23,7 @@ import { getLibraryFilename, getLibraryBackupFilename } from '@/utils/book';
 import { getDirPath, getFilename } from '@/utils/path';
 
 import { getOSPlatform } from '@/utils/misc';
+import { buildAbsEbookUrl, isAbsEbook, parseAbsFilePath } from '@/utils/audiobook';
 import { isStoragePermissionError, requestStoragePermission } from '@/utils/permission';
 import { ProgressHandler } from '@/utils/transfer';
 import { CustomTextureInfo } from '@/styles/textures';
@@ -596,6 +597,19 @@ export abstract class BaseAppService implements AppService {
   }
 
   async loadBookContent(book: Book): Promise<BookContent> {
+    if (isAbsEbook(book)) {
+      const parsed = parseAbsFilePath(book.filePath);
+      if (parsed) {
+        const { findABSServerById } = await import('@/store/absServerStore');
+        const server = findABSServerById(parsed.serverId);
+        if (server) {
+          return BookSvc.loadBookContent(this.fs, {
+            ...book,
+            url: buildAbsEbookUrl(server, parsed.itemId),
+          });
+        }
+      }
+    }
     return BookSvc.loadBookContent(this.fs, book);
   }
 

--- a/apps/readest-app/src/services/audiobookshelf/client.ts
+++ b/apps/readest-app/src/services/audiobookshelf/client.ts
@@ -1,5 +1,6 @@
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import { isTauriAppPlatform } from '@/services/environment';
+import { runWithConcurrency } from '@/utils/concurrency';
 import type {
   ABSLibrary,
   ABSLibraryItem,
@@ -9,6 +10,7 @@ import type {
 } from '@/types/audiobookshelf';
 
 const PAGE_SIZE = 100;
+const EXPANDED_ITEM_CONCURRENCY = 8;
 const ABS_DEVICE_ID_KEY = 'readest-abs-device-id';
 
 /**
@@ -272,16 +274,17 @@ export class ABSClient {
       if (data.results.length === 0 || items.length >= data.total) break;
       page += 1;
     }
-    return Promise.all(
-      items.map((item) =>
-        item.mediaType === 'book' &&
-        (item.media.numAudioFiles ?? item.media.numTracks ?? item.media.tracks?.length ?? 0) ===
-          0 &&
-        !item.media.ebookFile
-          ? this.getItemExpanded(item.id)
-          : item,
-      ),
+    const results = await runWithConcurrency(items, EXPANDED_ITEM_CONCURRENCY, async (item) =>
+      item.mediaType === 'book' &&
+      (item.media.numAudioFiles ?? item.media.numTracks ?? item.media.tracks?.length ?? 0) === 0 &&
+      !item.media.ebookFile
+        ? this.getItemExpanded(item.id)
+        : item,
     );
+    return results.map((outcome) => {
+      if ('error' in outcome) throw outcome.error;
+      return outcome.result;
+    });
   }
 
   async getItemExpanded(itemId: string): Promise<ABSLibraryItem> {

--- a/apps/readest-app/src/services/audiobookshelf/client.ts
+++ b/apps/readest-app/src/services/audiobookshelf/client.ts
@@ -272,7 +272,16 @@ export class ABSClient {
       if (data.results.length === 0 || items.length >= data.total) break;
       page += 1;
     }
-    return items;
+    return Promise.all(
+      items.map((item) =>
+        item.mediaType === 'book' &&
+        (item.media.numAudioFiles ?? item.media.numTracks ?? item.media.tracks?.length ?? 0) ===
+          0 &&
+        !item.media.ebookFile
+          ? this.getItemExpanded(item.id)
+          : item,
+      ),
+    );
   }
 
   async getItemExpanded(itemId: string): Promise<ABSLibraryItem> {

--- a/apps/readest-app/src/services/audiobookshelf/librarySync.ts
+++ b/apps/readest-app/src/services/audiobookshelf/librarySync.ts
@@ -24,6 +24,10 @@ const audioTrackCount = (item: ABSLibraryItem): number =>
 const isAudiobookItem = (item: ABSLibraryItem): boolean =>
   item.mediaType === 'book' && audioTrackCount(item) > 0;
 
+/** True for book-type items with a primary ebook and no audio tracks. */
+const isEbookItem = (item: ABSLibraryItem): boolean =>
+  item.mediaType === 'book' && audioTrackCount(item) === 0 && !!item.media.ebookFile;
+
 /** True for podcast show items. */
 const isPodcastItem = (item: ABSLibraryItem): boolean => item.mediaType === 'podcast';
 
@@ -73,7 +77,8 @@ export const reconcileAbsBooks = (input: {
 
   for (const item of items) {
     const podcast = isPodcastItem(item);
-    if (!podcast && !isAudiobookItem(item)) continue;
+    const ebook = isEbookItem(item);
+    if (!podcast && !isAudiobookItem(item) && !ebook) continue;
 
     const filePath = makeAbsFilePath(server.id, item.id);
     seenFilePaths.add(filePath);
@@ -82,12 +87,12 @@ export const reconcileAbsBooks = (input: {
     const serverAuthor = podcast
       ? (item.media.metadata.author ?? '')
       : (item.media.metadata.authorName ?? '');
-    const duration = podcast ? undefined : item.media.duration;
+    const duration = podcast || ebook ? undefined : item.media.duration;
     const primaryLanguage = item.media.metadata.language ?? undefined;
     const numEpisodes = podcast ? episodeCount(item) : undefined;
     // A show's own progress is never mapped — per-episode progress is a
     // later task, so a podcast item never looks up or applies server progress.
-    const itemProgress = podcast ? undefined : progressByItemId.get(item.id);
+    const itemProgress = podcast || ebook ? undefined : progressByItemId.get(item.id);
     const serverProgress: Book['progress'] = itemProgress
       ? [Math.round(itemProgress.currentTime), Math.round(itemProgress.duration)]
       : undefined;
@@ -154,7 +159,7 @@ export const reconcileAbsBooks = (input: {
         author: serverAuthor,
         sourceTitle: serverTitle,
         duration,
-        absMediaType: podcast ? 'podcast' : undefined,
+        absMediaType: podcast ? 'podcast' : ebook ? 'ebook' : undefined,
         episodeCount: numEpisodes,
         primaryLanguage,
         progress: podcast ? undefined : serverProgress,

--- a/apps/readest-app/src/services/audiobookshelf/librarySync.ts
+++ b/apps/readest-app/src/services/audiobookshelf/librarySync.ts
@@ -88,6 +88,7 @@ export const reconcileAbsBooks = (input: {
       ? (item.media.metadata.author ?? '')
       : (item.media.metadata.authorName ?? '');
     const duration = podcast || ebook ? undefined : item.media.duration;
+    const absMediaType = podcast ? 'podcast' : ebook ? 'ebook' : undefined;
     const primaryLanguage = item.media.metadata.language ?? undefined;
     const numEpisodes = podcast ? episodeCount(item) : undefined;
     // A show's own progress is never mapped — per-episode progress is a
@@ -127,6 +128,7 @@ export const reconcileAbsBooks = (input: {
         existing.title !== title ||
         existing.author !== author ||
         existing.duration !== duration ||
+        existing.absMediaType !== absMediaType ||
         existing.episodeCount !== numEpisodes ||
         !progressEqual(existing.progress, bookProgress) ||
         (existing.deletedAt ?? null) !== null ||
@@ -142,6 +144,7 @@ export const reconcileAbsBooks = (input: {
         author,
         sourceTitle: title,
         duration,
+        absMediaType,
         episodeCount: numEpisodes,
         primaryLanguage,
         progress: bookProgress,
@@ -159,7 +162,7 @@ export const reconcileAbsBooks = (input: {
         author: serverAuthor,
         sourceTitle: serverTitle,
         duration,
-        absMediaType: podcast ? 'podcast' : ebook ? 'ebook' : undefined,
+        absMediaType,
         episodeCount: numEpisodes,
         primaryLanguage,
         progress: podcast ? undefined : serverProgress,

--- a/apps/readest-app/src/services/bookContent.ts
+++ b/apps/readest-app/src/services/bookContent.ts
@@ -5,6 +5,8 @@ import { getDir, getLocalBookFilename } from '@/utils/book';
 import { isContentURI, isValidURL } from '@/utils/misc';
 import { isPseStreamFileName } from './opds/pseStream';
 import { isFeedBookUrl } from '@/services/rss/feedBookUrl';
+import { findABSServerById } from '@/store/absServerStore';
+import { buildAbsEbookUrl, isAbsEbook, parseAbsFilePath } from '@/utils/audiobook';
 
 export type BookContentSource =
   | { kind: 'managed'; path: string; base: 'Books'; legacy?: boolean }
@@ -49,6 +51,16 @@ export async function resolveBookContentSource(
   const managedPath = getLocalBookFilename(book);
   if (await fs.exists(managedPath, 'Books')) {
     return { kind: 'managed', path: managedPath, base: 'Books' };
+  }
+
+  if (isAbsEbook(book)) {
+    const parsed = parseAbsFilePath(book.filePath);
+    if (parsed) {
+      const server = findABSServerById(parsed.serverId);
+      if (server) {
+        return { kind: 'url', path: buildAbsEbookUrl(server, parsed.itemId), base: 'None' };
+      }
+    }
   }
 
   if (book.filePath) {

--- a/apps/readest-app/src/services/nativeAppService.ts
+++ b/apps/readest-app/src/services/nativeAppService.ts
@@ -26,6 +26,7 @@ import {
   tempDir,
 } from '@tauri-apps/api/path';
 import { type as osType } from '@tauri-apps/plugin-os';
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import { shareFile } from '@choochmeque/tauri-plugin-sharekit-api';
 
 import {
@@ -303,7 +304,7 @@ export const nativeFileSystem: FileSystem = {
     const { fp, baseDir } = this.resolvePath(normalizedPath, base);
     let fname = safeDecodePath(name || getFilename(fp));
     if (isValidURL(path)) {
-      return await new RemoteFile(path, fname).open();
+      return await new RemoteFile(path, fname, '', Date.now(), tauriFetch).open();
     } else if (isContentURI(path) || (isFileURI(path) && OS_TYPE === 'ios')) {
       fname = safeDecodePath(await basename(path));
       if (path.includes('com.android.externalstorage')) {

--- a/apps/readest-app/src/types/audiobookshelf.ts
+++ b/apps/readest-app/src/types/audiobookshelf.ts
@@ -80,6 +80,11 @@ export interface ABSLibraryItem {
     tracks?: ABSTrack[];
     chapters?: ABSChapter[];
     episodes?: ABSEpisode[];
+    /** Primary ebook file, present for ebook-backed book items. */
+    ebookFile?: {
+      ino?: string;
+      ebookFormat?: string;
+    };
   };
 }
 

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -155,10 +155,9 @@ export interface Book {
   // every import, like `format` — not user data, so it needs no LWW timestamp.
   hasNarration?: boolean;
   duration?: number; // total audio length in seconds (ABS audiobooks)
-  // Marks this ABS stub as a podcast show rather than an audiobook. Audiobook
-  // shows remain unmarked (absMediaType undefined) — presence of the field
-  // set to 'podcast' is the only signal.
-  absMediaType?: 'podcast';
+  // Marks this ABS stub as a podcast show or ebook rather than an audiobook.
+  // Audio books remain unmarked (absMediaType undefined).
+  absMediaType?: 'podcast' | 'ebook';
   // Episode count for an ABS podcast show stub. Drives the library grid's
   // episode-count badge and lets reconcileAbsBooks detect a new episode as a
   // change even though title/author/duration are otherwise unchanged.

--- a/apps/readest-app/src/utils/audiobook.ts
+++ b/apps/readest-app/src/utils/audiobook.ts
@@ -6,7 +6,16 @@ import type { Book } from '@/types/book';
 export const ABS_FILE_SCHEME = 'abs://';
 
 /** True when `book` is a streaming audiobook from an Audiobookshelf server (no local file). */
-export const isAudiobook = (book: Pick<Book, 'format'>): boolean => book.format === 'ABS';
+export const isAudiobook = (book: {
+  format: Book['format'];
+  metadata?: Book['metadata'];
+}): boolean => book.format === 'ABS' && book.metadata?.absMediaType !== 'ebook';
+
+/** True when `book` is an ebook streamed from an Audiobookshelf server. */
+export const isAbsEbook = (book: {
+  format: Book['format'];
+  metadata?: Book['metadata'];
+}): boolean => book.format === 'ABS' && book.metadata?.absMediaType === 'ebook';
 
 /** Builds the synthetic filePath for an ABS book: `abs://<serverId>/<itemId>`. */
 export const makeAbsFilePath = (serverId: string, itemId: string): string =>
@@ -42,6 +51,12 @@ export const buildAbsMediaUrl = (
   // otherwise be reparsed as query syntax and the media request fail auth.
   return `${base}${contentPath}${separator}token=${encodeURIComponent(server.accessToken ?? '')}`;
 };
+
+/** Authenticated URL for the primary ebook file on an ABS item. */
+export const buildAbsEbookUrl = (
+  server: Pick<ABSServer, 'url' | 'accessToken'>,
+  itemId: string,
+): string => buildAbsMediaUrl(server, `/api/items/${encodeURIComponent(itemId)}/ebook`);
 
 /**
  * Build the `metadata` payload an ABS stub syncs with.
@@ -114,7 +129,7 @@ export interface LibraryOpenSplit {
  */
 export const splitLibraryOpenIds = (
   ids: string[],
-  lookup: (hash: string) => Pick<Book, 'format'> | undefined,
+  lookup: (hash: string) => Pick<Book, 'format' | 'metadata'> | undefined,
 ): LibraryOpenSplit => {
   if (ids.length === 1) {
     const book = lookup(ids[0]!);

--- a/apps/readest-app/src/utils/file.ts
+++ b/apps/readest-app/src/utils/file.ts
@@ -283,6 +283,7 @@ export class NativeFile extends File implements ClosableFile {
 
 export class RemoteFile extends File implements ClosableFile {
   url: string;
+  #fetch: typeof fetch;
   #name: string;
   #lastModified: number;
   #size: number = -1;
@@ -298,10 +299,11 @@ export class RemoteFile extends File implements ClosableFile {
   static MAX_CACHE_ITEMS_SIZE: number = 128;
   static RANGE_SCHEME_ORIGIN = 'http://rangefile.localhost';
 
-  constructor(url: string, name?: string, type = '', lastModified = Date.now()) {
+  constructor(url: string, name?: string, type = '', lastModified = Date.now(), fetcher = fetch) {
     const basename = url.split('/').pop() || 'remote-file';
     super([], name || basename, { type, lastModified });
     this.url = url;
+    this.#fetch = fetcher;
     this.#name = name || basename;
     this.#type = type;
     this.#lastModified = lastModified;
@@ -344,7 +346,7 @@ export class RemoteFile extends File implements ClosableFile {
   }
 
   async _open_with_head() {
-    const response = await fetch(this.url, { method: 'HEAD' });
+    const response = await this.#fetch(this.url, { method: 'HEAD' });
     if (!response.ok) {
       throw new Error(`Failed to fetch file size: ${response.status}`);
     }
@@ -354,7 +356,7 @@ export class RemoteFile extends File implements ClosableFile {
   }
 
   async _open_with_range() {
-    const response = await fetch(this.url, { headers: { Range: `bytes=${0}-${1023}` } });
+    const response = await this.#fetch(this.url, { headers: { Range: `bytes=${0}-${1023}` } });
     if (!response.ok) {
       throw new Error(`Failed to fetch file size: ${response.status}`);
     }
@@ -366,7 +368,7 @@ export class RemoteFile extends File implements ClosableFile {
   async _open_with_query() {
     // No `Range` header — the rangefile handler returns the file size in
     // `X-Total-Size` and the requested bytes as a plain 200 body.
-    const response = await fetch(`${this.url}&start=0&end=0`);
+    const response = await this.#fetch(`${this.url}&start=0&end=0`);
     if (!response.ok) {
       throw new Error(`Failed to fetch file size: ${response.status}`);
     }
@@ -397,8 +399,8 @@ export class RemoteFile extends File implements ClosableFile {
     end = Math.min(this.size - 1, end);
     // console.log(`Fetching range: ${start}-${end}, size: ${end - start + 1}`);
     const response = this.#queryRange
-      ? await fetch(`${this.url}&start=${start}&end=${end}`)
-      : await fetch(this.url, { headers: { Range: `bytes=${start}-${end}` } });
+      ? await this.#fetch(`${this.url}&start=${start}&end=${end}`)
+      : await this.#fetch(this.url, { headers: { Range: `bytes=${start}-${end}` } });
     if (!response.ok) {
       throw new Error(`Failed to fetch range: ${response.status}`);
     }


### PR DESCRIPTION
## Summary

- Syncs ebook-only Audiobookshelf library items into Readest.
- Routes ABS ebooks to the reader instead of the audiobook player.
- Loads the primary ebook through the authenticated ABS endpoint using ranged requests.
- Closes #5972

## Test plan

- [x] ABS-focused Vitest tests (32 passed)
- [x] pnpm lint
- [x] Biome formatting check
- [ ] Full Vitest suite: local run stalled at an existing jsdom navigation message before completing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for ebook-only items from Audiobookshelf libraries.
  - Audiobookshelf ebooks can now be synchronized, represented in the library, and streamed using authenticated ebook links.
  - ABS ebooks are recognized as available without requiring a local download.
  - Improved handling when opening multiple library items so streamed ebooks remain available.

- **Bug Fixes**
  - Audiobookshelf ebooks are no longer skipped or incorrectly classified as audiobooks.
  - Ebook metadata and file paths are now preserved during synchronization.
  - Improved remote ebook loading in desktop environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->