### PR TITLE
feat(tts): skip inline parenthetical readings

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2547,5 +2547,8 @@
   "{{alias}} wants to send you {{count}} book(s)_two": "يريد {{alias}} إرسال كتابين إليك",
   "{{alias}} wants to send you {{count}} book(s)_few": "يريد {{alias}} إرسال {{count}} كتب إليك",
   "{{alias}} wants to send you {{count}} book(s)_many": "يريد {{alias}} إرسال {{count}} كتابًا إليك",
-  "{{alias}} wants to send you {{count}} book(s)_other": "يريد {{alias}} إرسال {{count}} كتاب إليك"
+  "{{alias}} wants to send you {{count}} book(s)_other": "يريد {{alias}} إرسال {{count}} كتاب إليك",
+  "Speech": "النطق",
+  "Skip Parenthetical Readings": "تخطي القراءات بين قوسين",
+  "Do not speak kana or Han readings shown after Han text": "عدم نطق قراءات الكانا أو الهان الظاهرة بعد نص الهان"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "BookOrbit সিঙ্ক",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "আপনার লাইব্রেরি, পড়ার অগ্রগতি এবং হাইলাইটগুলি আপনার Readest অ্যাকাউন্টে সংরক্ষণ করুন। আপনি যেকোনো সময় সেটিংসে এটি পরিবর্তন করতে পারেন।",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} আপনাকে {{count}}টি বই পাঠাতে চায়",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} আপনাকে {{count}}টি বই পাঠাতে চায়"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} আপনাকে {{count}}টি বই পাঠাতে চায়",
+  "Speech": "কথন",
+  "Skip Parenthetical Readings": "বন্ধনীর মধ্যের পাঠ এড়িয়ে যান",
+  "Do not speak kana or Han readings shown after Han text": "হান পাঠ্যের পরে দেখানো কানা বা হান পাঠ উচ্চারণ করবেন না"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2247,5 +2247,8 @@
   "ReadEra backup file (.bak)": "ReadEra གྲབས་ཉར་ཡིག་ཆ (.bak)",
   "BookOrbit Sync": "BookOrbit ཟླ་སྒྲིག",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "ཁྱེད་ཀྱི་དཔེ་མཛོད་དང་། ཀློག་པའི་ཡར་འཕེལ། གཙོ་གནད་བཅས་ཁྱེད་ཀྱི་ Readest རྩིས་ཐོའི་ནང་ཉར་ཚགས་བྱེད། འདི་ནི་དུས་ནམ་ཡིན་ཡང་སྒྲིག་སྟངས་ནང་བསྒྱུར་བཅོས་བྱེད་ཐུབ།",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} ཡིས་ཁྱེད་ལ་དེབ་ {{count}} སྐུར་འདོད་ཡོད།"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} ཡིས་ཁྱེད་ལ་དེབ་ {{count}} སྐུར་འདོད་ཡོད།",
+  "Speech": "སྐད་ཆ།",
+  "Skip Parenthetical Readings": "གུག་རྟགས་ནང་གི་ཀློག་ཚུལ་སྐྱུར་བ།",
+  "Do not speak kana or Han readings shown after Han text": "ཧན་ཡི་གེའི་རྗེས་སུ་བསྟན་པའི་ཀ་ནའམ་ཧན་གྱི་ཀློག་ཚུལ་མ་ཀློག"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "BookOrbit-Synchronisierung",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Speichern Sie Ihre Bibliothek, Ihren Lesefortschritt und Ihre Markierungen in Ihrem Readest-Konto. Sie können dies jederzeit in den Einstellungen ändern.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} möchte Ihnen {{count}} Buch senden",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} möchte Ihnen {{count}} Bücher senden"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} möchte Ihnen {{count}} Bücher senden",
+  "Speech": "Sprachausgabe",
+  "Skip Parenthetical Readings": "Lesungen in Klammern überspringen",
+  "Do not speak kana or Han readings shown after Han text": "Kana- oder Han-Lesungen nach Han-Text nicht vorlesen"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "Συγχρονισμός BookOrbit",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Αποθηκεύστε τη βιβλιοθήκη, την πρόοδο ανάγνωσης και τις επισημάνσεις σας στον λογαριασμό σας Readest. Μπορείτε να το αλλάξετε ανά πάσα στιγμή στις Ρυθμίσεις.",
   "{{alias}} wants to send you {{count}} book(s)_one": "Ο/Η {{alias}} θέλει να σας στείλει {{count}} βιβλίο",
-  "{{alias}} wants to send you {{count}} book(s)_other": "Ο/Η {{alias}} θέλει να σας στείλει {{count}} βιβλία"
+  "{{alias}} wants to send you {{count}} book(s)_other": "Ο/Η {{alias}} θέλει να σας στείλει {{count}} βιβλία",
+  "Speech": "Ομιλία",
+  "Skip Parenthetical Readings": "Παράλειψη αναγνώσεων σε παρενθέσεις",
+  "Do not speak kana or Han readings shown after Han text": "Να μην εκφωνούνται αναγνώσεις κάνα ή χαν μετά από κείμενο χαν"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2367,5 +2367,8 @@
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Guarda tu biblioteca, progreso de lectura y resaltados en tu cuenta de Readest. Puedes cambiar esto en cualquier momento en Configuraciones.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} quiere enviarte {{count}} libro",
   "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} quiere enviarte {{count}} libros",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} quiere enviarte {{count}} libros"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} quiere enviarte {{count}} libros",
+  "Speech": "Voz",
+  "Skip Parenthetical Readings": "Omitir lecturas entre paréntesis",
+  "Do not speak kana or Han readings shown after Han text": "No leer las lecturas en kana o han que aparecen después del texto han"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "همگام‌سازی BookOrbit",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "کتابخانه، وضعیت مطالعه و هایلایت‌های خود را در حساب Readest خود ذخیره کنید. می‌توانید این را هر زمان در تنظیمات تغییر دهید.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} می‌خواهد {{count}} کتاب برای شما بفرستد",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} می‌خواهد {{count}} کتاب برای شما بفرستد"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} می‌خواهد {{count}} کتاب برای شما بفرستد",
+  "Speech": "گفتار",
+  "Skip Parenthetical Readings": "رد کردن خوانش‌های داخل پرانتز",
+  "Do not speak kana or Han readings shown after Han text": "خوانش‌های کانا یا هان که پس از متن هان آمده‌اند خوانده نشوند"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2367,5 +2367,8 @@
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Stockez votre bibliothèque, votre progression de lecture et vos surlignages dans votre compte Readest. Vous pouvez modifier ce choix à tout moment dans les Paramètres.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} souhaite vous envoyer {{count}} livre",
   "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} souhaite vous envoyer {{count}} livres",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} souhaite vous envoyer {{count}} livres"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} souhaite vous envoyer {{count}} livres",
+  "Speech": "Lecture vocale",
+  "Skip Parenthetical Readings": "Ignorer les lectures entre parenthèses",
+  "Do not speak kana or Han readings shown after Han text": "Ne pas prononcer les lectures en kana ou en han affichées après un texte en han"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2367,5 +2367,8 @@
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "אחסן את הספרייה, התקדמות הקריאה וההדגשות שלך בחשבון Readest שלך. תוכל לשנות זאת בכל עת בהגדרות.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} רוצה לשלוח לכם ספר אחד",
   "{{alias}} wants to send you {{count}} book(s)_two": "{{alias}} רוצה לשלוח לכם {{count}} ספרים",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} רוצה לשלוח לכם {{count}} ספרים"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} רוצה לשלוח לכם {{count}} ספרים",
+  "Speech": "דיבור",
+  "Skip Parenthetical Readings": "דלג על קריאות בסוגריים",
+  "Do not speak kana or Han readings shown after Han text": "אל תקריא קריאות בקאנה או בהאן המוצגות אחרי טקסט בהאן"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "BookOrbit सिंक",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "अपनी लाइब्रेरी, पढ़ने की प्रगति और हाइलाइट्स को अपने Readest खाते में संग्रहीत करें। आप इसे कभी भी सेटिंग्स में बदल सकते हैं।",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} आपको {{count}} पुस्तक भेजना चाहता है",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} आपको {{count}} पुस्तकें भेजना चाहता है"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} आपको {{count}} पुस्तकें भेजना चाहता है",
+  "Speech": "वाक्",
+  "Skip Parenthetical Readings": "कोष्ठक में दिए उच्चारण छोड़ें",
+  "Do not speak kana or Han readings shown after Han text": "हान पाठ के बाद दिखाए गए काना या हान उच्चारण न बोलें"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "BookOrbit szinkronizálás",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Tárolja könyvtárát, olvasási haladását és kiemeléseit a Readest-fiókjában. Ezt bármikor megváltoztathatja a Beállításokban.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} {{count}} könyvet szeretne küldeni Önnek",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} {{count}} könyvet szeretne küldeni Önnek"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} {{count}} könyvet szeretne küldeni Önnek",
+  "Speech": "Beszéd",
+  "Skip Parenthetical Readings": "Zárójeles olvasatok kihagyása",
+  "Do not speak kana or Han readings shown after Han text": "A han szöveg után megjelenő kana- vagy han-olvasatokat ne olvassa fel"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2247,5 +2247,8 @@
   "ReadEra backup file (.bak)": "File cadangan ReadEra (.bak)",
   "BookOrbit Sync": "Sinkronisasi BookOrbit",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Simpan perpustakaan, progres membaca, dan sorotan Anda di akun Readest Anda. Anda dapat mengubahnya kapan saja di Pengaturan.",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} ingin mengirimi Anda {{count}} buku"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} ingin mengirimi Anda {{count}} buku",
+  "Speech": "Ucapan",
+  "Skip Parenthetical Readings": "Lewati Bacaan dalam Tanda Kurung",
+  "Do not speak kana or Han readings shown after Han text": "Jangan ucapkan bacaan kana atau Han yang ditampilkan setelah teks Han"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2367,5 +2367,8 @@
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Archivia la tua biblioteca, il progresso di lettura e le evidenziazioni nel tuo account Readest. Puoi modificarlo in qualsiasi momento nelle Impostazioni.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} vuole inviarti {{count}} libro",
   "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} vuole inviarti {{count}} libri",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} vuole inviarti {{count}} libri"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} vuole inviarti {{count}} libri",
+  "Speech": "Voce",
+  "Skip Parenthetical Readings": "Ignora letture tra parentesi",
+  "Do not speak kana or Han readings shown after Han text": "Non pronunciare le letture kana o han mostrate dopo il testo han"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2247,5 +2247,8 @@
   "ReadEra backup file (.bak)": "ReadEra のバックアップファイル (.bak)",
   "BookOrbit Sync": "BookOrbit同期",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "ライブラリ、読書進捗、ハイライトを Readest アカウントに保存します。設定でいつでも変更できます。",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}}が{{count}}冊の本を送信しようとしています"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}}が{{count}}冊の本を送信しようとしています",
+  "Speech": "読み上げ",
+  "Skip Parenthetical Readings": "括弧内の読みをスキップ",
+  "Do not speak kana or Han readings shown after Han text": "漢字の後に表示される仮名または漢字の読みを読み上げない"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "BookOrbit სინქრონიზაცია",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "შეინახეთ თქვენი ბიბლიოთეკა, კითხვის პროგრესი და მარკირებები თქვენს Readest ანგარიშში. ამის შეცვლა ნებისმიერ დროს შეგიძლიათ პარამეტრებში.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}}-ს სურს გამოგიგზავნოთ {{count}} წიგნი",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}}-ს სურს გამოგიგზავნოთ {{count}} წიგნი"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}}-ს სურს გამოგიგზავნოთ {{count}} წიგნი",
+  "Speech": "მეტყველება",
+  "Skip Parenthetical Readings": "ფრჩხილებში მოცემული წაკითხვის გამოტოვება",
+  "Do not speak kana or Han readings shown after Han text": "არ წაიკითხოს ჰანის ტექსტის შემდეგ ნაჩვენები კანა ან ჰანის წაკითხვები"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2247,5 +2247,8 @@
   "ReadEra backup file (.bak)": "ReadEra 백업 파일 (.bak)",
   "BookOrbit Sync": "BookOrbit 동기화",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "라이브러리, 읽기 진행 상황, 하이라이트를 Readest 계정에 저장합니다. 설정에서 언제든지 변경할 수 있습니다.",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}}이(가) 책 {{count}}권을 보내려고 합니다"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}}이(가) 책 {{count}}권을 보내려고 합니다",
+  "Speech": "음성",
+  "Skip Parenthetical Readings": "괄호 안 읽기 건너뛰기",
+  "Do not speak kana or Han readings shown after Han text": "한자 뒤에 표시된 가나 또는 한자 읽기를 발음하지 않음"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2247,5 +2247,8 @@
   "ReadEra backup file (.bak)": "Fail sandaran ReadEra (.bak)",
   "BookOrbit Sync": "Penyegerakan BookOrbit",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Simpan perpustakaan, kemajuan bacaan dan penonjolan anda dalam akaun Readest anda. Anda boleh mengubahnya pada bila-bila masa dalam Tetapan.",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} mahu menghantar {{count}} buku kepada anda"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} mahu menghantar {{count}} buku kepada anda",
+  "Speech": "Pertuturan",
+  "Skip Parenthetical Readings": "Langkau Bacaan dalam Kurungan",
+  "Do not speak kana or Han readings shown after Han text": "Jangan sebut bacaan kana atau Han yang dipaparkan selepas teks Han"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "BookOrbit-synchronisatie",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Sla je bibliotheek, leesvoortgang en markeringen op in je Readest-account. Je kunt dit altijd wijzigen in Instellingen.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} wil u {{count}} boek sturen",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} wil u {{count}} boeken sturen"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} wil u {{count}} boeken sturen",
+  "Speech": "Spraak",
+  "Skip Parenthetical Readings": "Lezingen tussen haakjes overslaan",
+  "Do not speak kana or Han readings shown after Han text": "Kana- of Han-lezingen na Han-tekst niet uitspreken"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2427,5 +2427,8 @@
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} chce wysłać Ci {{count}} książkę",
   "{{alias}} wants to send you {{count}} book(s)_few": "{{alias}} chce wysłać Ci {{count}} książki",
   "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} chce wysłać Ci {{count}} książek",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} chce wysłać Ci {{count}} książki"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} chce wysłać Ci {{count}} książki",
+  "Speech": "Mowa",
+  "Skip Parenthetical Readings": "Pomijaj odczyty w nawiasach",
+  "Do not speak kana or Han readings shown after Han text": "Nie odczytuj zapisów kana ani han wyświetlanych po tekście han"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2367,5 +2367,8 @@
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Armazene sua biblioteca, progresso de leitura e destaques na sua conta Readest. Você pode alterar isso a qualquer momento nas Configurações.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} quer enviar {{count}} livro para você",
   "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} quer enviar {{count}} livros para você",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} quer enviar {{count}} livros para você"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} quer enviar {{count}} livros para você",
+  "Speech": "Fala",
+  "Skip Parenthetical Readings": "Ignorar leituras entre parênteses",
+  "Do not speak kana or Han readings shown after Han text": "Não falar leituras em kana ou han exibidas após texto em han"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2367,5 +2367,8 @@
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Guarde a sua biblioteca, o progresso de leitura e os destaques na sua conta Readest. Pode alterar isto a qualquer momento nas Configurações.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} quer enviar-lhe {{count}} livro",
   "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} quer enviar-lhe {{count}} livros",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} quer enviar-lhe {{count}} livros"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} quer enviar-lhe {{count}} livros",
+  "Speech": "Fala",
+  "Skip Parenthetical Readings": "Ignorar leituras entre parênteses",
+  "Do not speak kana or Han readings shown after Han text": "Não ler pronúncias em kana ou han apresentadas após texto em han"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2367,5 +2367,8 @@
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Stochează-ți biblioteca, progresul citirii și evidențierile în contul tău Readest. Poți schimba această opțiune oricând în Setări.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} vrea să vă trimită {{count}} carte",
   "{{alias}} wants to send you {{count}} book(s)_few": "{{alias}} vrea să vă trimită {{count}} cărți",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} vrea să vă trimită {{count}} de cărți"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} vrea să vă trimită {{count}} de cărți",
+  "Speech": "Vorbire",
+  "Skip Parenthetical Readings": "Omite citirile dintre paranteze",
+  "Do not speak kana or Han readings shown after Han text": "Nu rosti citirile kana sau han afișate după textul han"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2427,5 +2427,8 @@
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} хочет отправить вам {{count}} книгу",
   "{{alias}} wants to send you {{count}} book(s)_few": "{{alias}} хочет отправить вам {{count}} книги",
   "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} хочет отправить вам {{count}} книг",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} хочет отправить вам {{count}} книги"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} хочет отправить вам {{count}} книги",
+  "Speech": "Речь",
+  "Skip Parenthetical Readings": "Пропускать чтения в скобках",
+  "Do not speak kana or Han readings shown after Han text": "Не произносить чтения каной или ханскими иероглифами после текста хан"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "BookOrbit සමමුහුර්තකරණය",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "ඔබේ පුස්තකාලය, කියවීමේ ප්‍රගතිය සහ ඉස්මතු කිරීම් ඔබේ Readest ගිණුමේ ගබඩා කරන්න. ඔබට ඕනෑම වේලාවක සැකසුම් තුළ මෙය වෙනස් කළ හැකිය.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} ඔබට පොත් {{count}}ක් යැවීමට කැමතියි",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} ඔබට පොත් {{count}}ක් යැවීමට කැමතියි"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} ඔබට පොත් {{count}}ක් යැවීමට කැමතියි",
+  "Speech": "කථනය",
+  "Skip Parenthetical Readings": "වරහන් තුළ ඇති කියවීම් මඟ හරින්න",
+  "Do not speak kana or Han readings shown after Han text": "හන් පෙළට පසුව පෙන්වන කනා හෝ හන් කියවීම් උච්චාරණය නොකරන්න"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2427,5 +2427,8 @@
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} vam želi poslati {{count}} knjigo",
   "{{alias}} wants to send you {{count}} book(s)_two": "{{alias}} vam želi poslati {{count}} knjigi",
   "{{alias}} wants to send you {{count}} book(s)_few": "{{alias}} vam želi poslati {{count}} knjige",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} vam želi poslati {{count}} knjig"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} vam želi poslati {{count}} knjig",
+  "Speech": "Govor",
+  "Skip Parenthetical Readings": "Preskoči branja v oklepajih",
+  "Do not speak kana or Han readings shown after Han text": "Ne izgovori zapisov v kani ali hanu, prikazanih za besedilom han"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "BookOrbit-synkronisering",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Lagra ditt bibliotek, dina läsframsteg och markeringar i ditt Readest-konto. Du kan ändra detta när som helst i Inställningar.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} vill skicka {{count}} bok till dig",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} vill skicka {{count}} böcker till dig"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} vill skicka {{count}} böcker till dig",
+  "Speech": "Tal",
+  "Skip Parenthetical Readings": "Hoppa över läsningar inom parentes",
+  "Do not speak kana or Han readings shown after Han text": "Läs inte upp kana- eller han-läsningar som visas efter han-text"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "BookOrbit ஒத்திசைவு",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "உங்கள் நூலகம், வாசிப்பு முன்னேற்றம் மற்றும் சிறப்பம்சங்களை உங்கள் Readest கணக்கில் சேமிக்கவும். இதை எப்போது வேண்டுமானாலும் அமைப்புகளில் மாற்றலாம்.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} உங்களுக்கு {{count}} புத்தகத்தை அனுப்ப விரும்புகிறார்",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} உங்களுக்கு {{count}} புத்தகங்களை அனுப்ப விரும்புகிறார்"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} உங்களுக்கு {{count}} புத்தகங்களை அனுப்ப விரும்புகிறார்",
+  "Speech": "பேச்சு",
+  "Skip Parenthetical Readings": "அடைப்புக்குறி வாசிப்புகளைத் தவிர்",
+  "Do not speak kana or Han readings shown after Han text": "ஹான் உரைக்குப் பின் காட்டப்படும் கனா அல்லது ஹான் வாசிப்புகளைப் பேச வேண்டாம்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2247,5 +2247,8 @@
   "ReadEra backup file (.bak)": "ไฟล์สำรองข้อมูลของ ReadEra (.bak)",
   "BookOrbit Sync": "การซิงค์ BookOrbit",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "จัดเก็บคลังหนังสือ ความคืบหน้าการอ่าน และไฮไลต์ของคุณไว้ในบัญชี Readest ของคุณ คุณสามารถเปลี่ยนได้ทุกเมื่อในการตั้งค่า",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} ต้องการส่งหนังสือ {{count}} เล่มให้คุณ"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} ต้องการส่งหนังสือ {{count}} เล่มให้คุณ",
+  "Speech": "เสียงพูด",
+  "Skip Parenthetical Readings": "ข้ามคำอ่านในวงเล็บ",
+  "Do not speak kana or Han readings shown after Han text": "ไม่อ่านคำอ่านคานะหรือฮั่นที่แสดงหลังข้อความฮั่น"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "BookOrbit Senkronizasyonu",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Kütüphanenizi, okuma ilerlemenizi ve vurgularınızı Readest hesabınızda saklayın. Bunu istediğiniz zaman Ayarlar'dan değiştirebilirsiniz.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} size {{count}} kitap göndermek istiyor",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} size {{count}} kitap göndermek istiyor"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} size {{count}} kitap göndermek istiyor",
+  "Speech": "Konuşma",
+  "Skip Parenthetical Readings": "Parantez İçindeki Okunuşları Atla",
+  "Do not speak kana or Han readings shown after Han text": "Han metninden sonra gösterilen kana veya Han okunuşlarını seslendirme"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2427,5 +2427,8 @@
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} хоче надіслати вам {{count}} книгу",
   "{{alias}} wants to send you {{count}} book(s)_few": "{{alias}} хоче надіслати вам {{count}} книги",
   "{{alias}} wants to send you {{count}} book(s)_many": "{{alias}} хоче надіслати вам {{count}} книг",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} хоче надіслати вам {{count}} книги"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} хоче надіслати вам {{count}} книги",
+  "Speech": "Мовлення",
+  "Skip Parenthetical Readings": "Пропускати читання в дужках",
+  "Do not speak kana or Han readings shown after Han text": "Не вимовляти читання каною або ханськими ієрогліфами після тексту хан"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2307,5 +2307,8 @@
   "BookOrbit Sync": "BookOrbit sinxronlash",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Kutubxonangiz, oʻqish jarayoni va belgilashlaringizni Readest hisobingizda saqlang. Buni istalgan vaqtda Sozlamalarda oʻzgartirishingiz mumkin.",
   "{{alias}} wants to send you {{count}} book(s)_one": "{{alias}} sizga {{count}} ta kitob yubormoqchi",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} sizga {{count}} ta kitob yubormoqchi"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} sizga {{count}} ta kitob yubormoqchi",
+  "Speech": "Nutq",
+  "Skip Parenthetical Readings": "Qavs ichidagi o‘qilishlarni o‘tkazib yuborish",
+  "Do not speak kana or Han readings shown after Han text": "Han matnidan keyin ko‘rsatilgan kana yoki Han o‘qilishlarini talaffuz qilmaslik"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2247,5 +2247,8 @@
   "ReadEra backup file (.bak)": "Tệp sao lưu ReadEra (.bak)",
   "BookOrbit Sync": "Đồng bộ BookOrbit",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "Lưu trữ thư viện, tiến trình đọc và điểm nổi bật của bạn trong tài khoản Readest của bạn. Bạn có thể thay đổi tùy chọn này bất cứ lúc nào trong Cài đặt.",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} muốn gửi cho bạn {{count}} cuốn sách"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} muốn gửi cho bạn {{count}} cuốn sách",
+  "Speech": "Giọng đọc",
+  "Skip Parenthetical Readings": "Bỏ qua cách đọc trong ngoặc",
+  "Do not speak kana or Han readings shown after Han text": "Không đọc cách đọc bằng kana hoặc Hán tự hiển thị sau văn bản Hán tự"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2247,5 +2247,8 @@
   "ReadEra backup file (.bak)": "ReadEra 备份文件 (.bak)",
   "BookOrbit Sync": "BookOrbit 同步",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "将您的书库、阅读进度和高亮存储在您的 Readest 账户中。您可以随时在设置中更改。",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} 想要向您发送 {{count}} 本书"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} 想要向您发送 {{count}} 本书",
+  "Speech": "语音",
+  "Skip Parenthetical Readings": "跳过括号内的读音",
+  "Do not speak kana or Han readings shown after Han text": "不朗读汉字文本后显示的假名或汉字读音"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2247,5 +2247,8 @@
   "ReadEra backup file (.bak)": "ReadEra 備份檔案 (.bak)",
   "BookOrbit Sync": "BookOrbit 同步",
   "Store your library, reading progress, and highlights in your Readest account. You can change this any time in Settings.": "將您的書庫、閱讀進度和高亮儲存在您的 Readest 帳戶中。您可以隨時在設定中變更。",
-  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} 想要傳送 {{count}} 本書給您"
+  "{{alias}} wants to send you {{count}} book(s)_other": "{{alias}} 想要傳送 {{count}} 本書給您",
+  "Speech": "語音",
+  "Skip Parenthetical Readings": "略過括號內的讀音",
+  "Do not speak kana or Han readings shown after Han text": "不朗讀漢字文字後顯示的假名或漢字讀音"
 }

--- a/apps/readest-app/src/__tests__/components/settings/TTSPanel.test.tsx
+++ b/apps/readest-app/src/__tests__/components/settings/TTSPanel.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import type { ViewSettings } from '@/types/book';
 
 const state = vi.hoisted(() => ({
+  uiLocale: 'ja',
   viewSettings: {
     ttsMediaMetadata: 'sentence',
     ttsPlayerStyle: 'full',
@@ -14,6 +15,11 @@ const state = vi.hoisted(() => ({
 
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => (value: string) => value,
+}));
+
+vi.mock('@/utils/misc', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/misc')>()),
+  getLocale: () => state.uiLocale,
 }));
 
 vi.mock('@/context/EnvContext', () => ({
@@ -58,6 +64,7 @@ import TTSPanel from '@/components/settings/TTSPanel';
 describe('TTSPanel inline reading annotations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    state.uiLocale = 'ja';
     state.viewSettings.ttsSkipInlineAnnotations = false;
   });
 
@@ -81,5 +88,13 @@ describe('TTSPanel inline reading annotations', () => {
         false,
       ),
     );
+  });
+
+  it('hides the switch when the UI language is not Japanese', () => {
+    state.uiLocale = 'en-US';
+
+    render(<TTSPanel bookKey='book-1' onRegisterReset={vi.fn()} />);
+
+    expect(screen.queryByText('Skip Parenthetical Readings')).toBeNull();
   });
 });

--- a/apps/readest-app/src/__tests__/components/settings/TTSPanel.test.tsx
+++ b/apps/readest-app/src/__tests__/components/settings/TTSPanel.test.tsx
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ViewSettings } from '@/types/book';
+
+const state = vi.hoisted(() => ({
+  viewSettings: {
+    ttsMediaMetadata: 'sentence',
+    ttsPlayerStyle: 'full',
+    ttsHighlightGranularity: 'word',
+    ttsHighlightOptions: { style: 'highlight', color: '#808080' },
+    ttsSkipInlineAnnotations: false,
+  } as unknown as ViewSettings,
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (value: string) => value,
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {} }),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({ getViewSettings: () => state.viewSettings }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({
+    settings: {
+      globalViewSettings: state.viewSettings,
+      globalReadSettings: { customTtsHighlightColors: [] },
+    },
+    setSettings: vi.fn(),
+    saveSettings: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useResetSettings', () => ({
+  useResetViewSettings: () => vi.fn(),
+}));
+
+vi.mock('@/helpers/settings', () => ({
+  saveViewSettings: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/services/tts/providers/bookCacheStore', () => ({
+  getTTSCacheConfig: () => ({ enabled: false, syncEnabled: false, budgetMB: 200 }),
+  setTTSCacheConfig: vi.fn(),
+}));
+
+vi.mock('@/components/settings/theme/TTSHighlightStyleEditor', () => ({
+  default: () => null,
+}));
+
+import { saveViewSettings } from '@/helpers/settings';
+import TTSPanel from '@/components/settings/TTSPanel';
+
+describe('TTSPanel inline reading annotations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.viewSettings.ttsSkipInlineAnnotations = false;
+  });
+
+  afterEach(cleanup);
+
+  it('shows an opt-in switch and persists it as a view setting', async () => {
+    render(<TTSPanel bookKey='book-1' onRegisterReset={vi.fn()} />);
+    const row = screen.getByText('Skip Parenthetical Readings').closest('label')!;
+    const toggle = row.querySelector('input[type="checkbox"]') as HTMLInputElement;
+
+    expect(toggle.checked).toBe(false);
+    fireEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(saveViewSettings).toHaveBeenCalledWith(
+        {},
+        'book-1',
+        'ttsSkipInlineAnnotations',
+        true,
+        false,
+        false,
+      ),
+    );
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
@@ -59,6 +59,7 @@ const mockViewSettings = {
   ttsSentenceGap: 0.15,
   ttsParagraphGap: 0.3,
   ttsHighlightOptions: { style: 'highlight', color: '#ffff00' },
+  ttsSkipInlineAnnotations: false,
   isEink: false,
   ttsMediaMetadata: 'sentence',
   translationEnabled: false,
@@ -155,6 +156,7 @@ vi.mock('@/services/tts', () => ({
       initViewTTS: vi.fn().mockResolvedValue(undefined),
       updateHighlightOptions: vi.fn(),
       setHighlightGranularity: vi.fn(),
+      setSkipInlineAnnotations: vi.fn(),
       setLang: vi.fn(),
       setRate: vi.fn(),
       setSentenceGap: vi.fn(),
@@ -395,6 +397,13 @@ describe('useTTSControl concurrent tts-speak events', () => {
 
       // The assertion that matters: exactly one controller was constructed.
       expect(ttsControllerInstances.length).toBe(1);
+      expect(
+        (
+          ttsControllerInstances[0] as {
+            setSkipInlineAnnotations: ReturnType<typeof vi.fn>;
+          }
+        ).setSkipInlineAnnotations,
+      ).toHaveBeenCalledWith(false);
 
       // Release any pending init() promises so the dispatch chain can unwind
       // cleanly (otherwise the act() would never settle).
@@ -1115,6 +1124,7 @@ describe('useTTSControl background session lifecycle', () => {
       getSpokenSentence: vi.fn().mockReturnValue(null),
       updateHighlightOptions: vi.fn(),
       setHighlightGranularity: vi.fn(),
+      setSkipInlineAnnotations: vi.fn(),
       getVoiceId: vi.fn().mockReturnValue(''),
       setTargetLang: vi.fn(),
       setLang: vi.fn(),
@@ -1150,6 +1160,7 @@ describe('useTTSControl background session lifecycle', () => {
       mockView,
       expect.objectContaining({ bookKey: 'book-1' }),
     );
+    expect(liveController.setSkipInlineAnnotations).toHaveBeenCalledWith(false);
   });
 });
 

--- a/apps/readest-app/src/__tests__/services/constants.test.ts
+++ b/apps/readest-app/src/__tests__/services/constants.test.ts
@@ -653,6 +653,7 @@ describe('services/constants', () => {
       expect(typeof DEFAULT_TTS_CONFIG.ttsVoice).toBe('string');
       expect(typeof DEFAULT_TTS_CONFIG.ttsLocation).toBe('string');
       expect(typeof DEFAULT_TTS_CONFIG.ttsMediaMetadata).toBe('string');
+      expect(DEFAULT_TTS_CONFIG.ttsSkipInlineAnnotations).toBe(false);
     });
 
     it('has ttsHighlightOptions with style and color', () => {

--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -1600,6 +1600,45 @@ describe('TTSController', () => {
   });
 
   describe('preloadNextSSML', () => {
+    test('keeps inline readings in synthesized speech when the option is disabled', async () => {
+      mockView.tts = {
+        next: vi
+          .fn()
+          .mockReturnValueOnce('<speak>彼は憂鬱（ゆううつ）な気分だった。</speak>')
+          .mockReturnValue(undefined),
+        prev: vi.fn(),
+        doc: {},
+      } as unknown as FoliateView['tts'];
+
+      await controller.preloadNextSSML(1);
+
+      expect(controller.ttsClient.speak).toHaveBeenCalledWith(
+        expect.stringContaining('（ゆううつ）'),
+        expect.anything(),
+        true,
+      );
+    });
+
+    test('removes inline readings from synthesized speech when the option is enabled', async () => {
+      mockView.tts = {
+        next: vi
+          .fn()
+          .mockReturnValueOnce('<speak>彼は憂鬱（ゆううつ）な気分だった。</speak>')
+          .mockReturnValue(undefined),
+        prev: vi.fn(),
+        doc: {},
+      } as unknown as FoliateView['tts'];
+      controller.setSkipInlineAnnotations(true);
+
+      await controller.preloadNextSSML(1);
+
+      expect(controller.ttsClient.speak).toHaveBeenCalledWith(
+        expect.not.stringContaining('（ゆううつ）'),
+        expect.anything(),
+        true,
+      );
+    });
+
     test('calls tts.next() and tts.prev() synchronously without async gaps between them', async () => {
       // This test verifies the fix for a race condition where async gaps between
       // tts.next() calls in preloadNextSSML allowed #speak() to interleave and

--- a/apps/readest-app/src/__tests__/services/tts-inline-annotations.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-inline-annotations.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  stripInlineReadingAnnotations,
+  stripInlineReadingAnnotationsFromSSML,
+} from '@/services/tts/inlineAnnotations';
+
+const spokenText = (ssml: string): string => {
+  const doc = new DOMParser().parseFromString(ssml, 'application/xml');
+  return doc.documentElement.textContent ?? '';
+};
+
+describe('inline TTS reading annotations', () => {
+  it.each([
+    ['彼は憂鬱（ゆううつ）な気分だった。', '彼は憂鬱な気分だった。'],
+    ['彼は憂鬱(ゆううつ)な気分だった。', '彼は憂鬱な気分だった。'],
+    ['彼は憂鬱《ゆううつ》な気分だった。', '彼は憂鬱な気分だった。'],
+    ['辭（辞）を引く。', '辭を引く。'],
+  ])('removes a kana or Han reading after a Han base: %s', (source, expected) => {
+    expect(stripInlineReadingAnnotations(source)).toBe(expected);
+  });
+
+  it('removes an annotation even when SSML elements split it from its base', () => {
+    const ssml =
+      '<speak xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="ja">' +
+      '<lang xml:lang="ja">彼は憂鬱</lang><mark name="0"/>（<lang xml:lang="ja">ゆううつ</lang>）' +
+      'な気分だった。</speak>';
+
+    expect(spokenText(stripInlineReadingAnnotationsFromSSML(ssml))).toBe('彼は憂鬱な気分だった。');
+  });
+
+  it.each([
+    'Chapter 1（第一章）',
+    '憂鬱（melancholy）な気分だった。',
+    '憂鬱（ゆう、うつ）な気分だった。',
+    '憂鬱 （ゆううつ）な気分だった。',
+    '彼は（ゆううつ）な気分だった。',
+  ])('keeps text that does not match the conservative reading heuristic: %s', (source) => {
+    expect(stripInlineReadingAnnotations(source)).toBe(source);
+  });
+
+  it('returns malformed SSML unchanged', () => {
+    const malformed = '<speak>憂鬱（ゆううつ）';
+    expect(stripInlineReadingAnnotationsFromSSML(malformed)).toBe(malformed);
+  });
+});

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -333,6 +333,9 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
             getSectionLabel: () => getProgress(bookKey)?.sectionLabel,
           });
         }
+        controller.setSkipInlineAnnotations(
+          getViewSettings(bookKey)?.ttsSkipInlineAnnotations ?? false,
+        );
         await controller.attachView(view, {
           bookKey,
           preprocessCallback: preprocessSSMLForTTS,
@@ -826,6 +829,12 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     }
   }, [viewSettings?.ttsHighlightGranularity]);
 
+  useEffect(() => {
+    ttsControllerRef.current?.setSkipInlineAnnotations(
+      viewSettings?.ttsSkipInlineAnnotations ?? false,
+    );
+  }, [viewSettings?.ttsSkipInlineAnnotations]);
+
   // handleStop (defined before handleTTSSpeak/handleTTSStop which reference it)
   const handleStop = useCallback(
     async (bookKey: string) => {
@@ -946,6 +955,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
           preprocessSSMLForTTS,
           handleSectionChange,
         );
+        ttsController.setSkipInlineAnnotations(viewSettings.ttsSkipInlineAnnotations ?? false);
         // The constructor takes the view directly (attachView, which also binds
         // this, only runs on the background-session reattach path), so set the
         // book key here or the per-book audio cache never gets a hash to open.

--- a/apps/readest-app/src/components/settings/TTSPanel.tsx
+++ b/apps/readest-app/src/components/settings/TTSPanel.tsx
@@ -31,6 +31,9 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
   const [ttsHighlightGranularity, setTtsHighlightGranularity] = useState<TTSHighlightGranularity>(
     viewSettings.ttsHighlightGranularity ?? 'word',
   );
+  const [ttsSkipInlineAnnotations, setTtsSkipInlineAnnotations] = useState(
+    viewSettings.ttsSkipInlineAnnotations ?? false,
+  );
   const [ttsHighlightStyle, setTtsHighlightStyle] = useState(
     viewSettings.ttsHighlightOptions.style,
   );
@@ -57,6 +60,7 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
       ttsHighlightGranularity: setTtsHighlightGranularity as React.Dispatch<
         React.SetStateAction<string>
       >,
+      ttsSkipInlineAnnotations: setTtsSkipInlineAnnotations,
     });
   };
 
@@ -89,6 +93,19 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ttsHighlightGranularity]);
+
+  useEffect(() => {
+    if (ttsSkipInlineAnnotations === viewSettings.ttsSkipInlineAnnotations) return;
+    saveViewSettings(
+      envConfig,
+      bookKey,
+      'ttsSkipInlineAnnotations',
+      ttsSkipInlineAnnotations,
+      false,
+      false,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ttsSkipInlineAnnotations]);
 
   const handleTTSStyleChange = (style: TTSHighlightStyle) => {
     setTtsHighlightStyle(style);
@@ -138,6 +155,16 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
         onCustomColorsChange={handleCustomTtsColorsChange}
         data-setting-id='settings.tts.ttsHighlightStyle'
       />
+
+      <BoxedList title={_('Speech')} data-setting-id='settings.tts.speech'>
+        <SettingsSwitchRow
+          label={_('Skip Parenthetical Readings')}
+          description={_('Do not speak kana or Han readings shown after Han text')}
+          checked={ttsSkipInlineAnnotations}
+          onChange={() => setTtsSkipInlineAnnotations(!ttsSkipInlineAnnotations)}
+          data-setting-id='settings.tts.skipInlineAnnotations'
+        />
+      </BoxedList>
 
       <BoxedList title={_('Media Info')} data-setting-id='settings.tts.mediaMetadata'>
         <SettingsRow label={_('Player Style')} data-setting-id='settings.tts.playerStyle'>

--- a/apps/readest-app/src/components/settings/TTSPanel.tsx
+++ b/apps/readest-app/src/components/settings/TTSPanel.tsx
@@ -5,6 +5,7 @@ import { useSettingsStore } from '@/store/settingsStore';
 import { useResetViewSettings } from '@/hooks/useResetSettings';
 import { useTranslation } from '@/hooks/useTranslation';
 import { saveViewSettings } from '@/helpers/settings';
+import { getLocale } from '@/utils/misc';
 import { SettingsPanelPanelProp } from './SettingsDialog';
 import {
   TTSHighlightGranularity,
@@ -21,6 +22,7 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
   const { getViewSettings } = useReaderStore();
   const { settings, setSettings, saveSettings } = useSettingsStore();
   const viewSettings = getViewSettings(bookKey) || settings.globalViewSettings;
+  const isJapaneseUI = getLocale().toLowerCase().split('-')[0] === 'ja';
 
   const [ttsMediaMetadata, setTtsMediaMetadata] = useState<TTSMediaMetadataMode>(
     viewSettings.ttsMediaMetadata ?? 'sentence',
@@ -156,15 +158,17 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
         data-setting-id='settings.tts.ttsHighlightStyle'
       />
 
-      <BoxedList title={_('Speech')} data-setting-id='settings.tts.speech'>
-        <SettingsSwitchRow
-          label={_('Skip Parenthetical Readings')}
-          description={_('Do not speak kana or Han readings shown after Han text')}
-          checked={ttsSkipInlineAnnotations}
-          onChange={() => setTtsSkipInlineAnnotations(!ttsSkipInlineAnnotations)}
-          data-setting-id='settings.tts.skipInlineAnnotations'
-        />
-      </BoxedList>
+      {isJapaneseUI && (
+        <BoxedList title={_('Speech')} data-setting-id='settings.tts.speech'>
+          <SettingsSwitchRow
+            label={_('Skip Parenthetical Readings')}
+            description={_('Do not speak kana or Han readings shown after Han text')}
+            checked={ttsSkipInlineAnnotations}
+            onChange={() => setTtsSkipInlineAnnotations(!ttsSkipInlineAnnotations)}
+            data-setting-id='settings.tts.skipInlineAnnotations'
+          />
+        </BoxedList>
+      )}
 
       <BoxedList title={_('Media Info')} data-setting-id='settings.tts.mediaMetadata'>
         <SettingsRow label={_('Player Style')} data-setting-id='settings.tts.playerStyle'>

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -486,6 +486,7 @@ export const DEFAULT_TTS_CONFIG: TTSConfig = {
   ttsHighlightGranularity: 'word',
   ttsMediaMetadata: 'sentence',
   ttsPlayerStyle: 'full',
+  ttsSkipInlineAnnotations: false,
 };
 
 export const DEFAULT_TRANSLATOR_CONFIG: TranslatorConfig = {

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -49,6 +49,10 @@ import {
   type NarratedAudioChapter,
 } from './pairedAudiobook';
 import { SKIP_BACKWARD_SEC, SKIP_FORWARD_SEC } from '@/services/playback/playbackSource';
+import {
+  stripInlineReadingAnnotations,
+  stripInlineReadingAnnotationsFromSSML,
+} from './inlineAnnotations';
 
 // App-wide monotonic sequence for 'tts-position' events. A fresh TTSController
 // is constructed per `tts-speak`, so a per-instance counter would restart at 0
@@ -147,6 +151,7 @@ export class TTSController extends EventTarget {
   #awaitingAudio = false;
   #ttsDoc: Document | null = null;
   #ttsGranularity: TTSGranularity = 'sentence';
+  #skipInlineAnnotations = false;
 
   // Word-level highlight state for the currently spoken chunk. Armed by a
   // successful dispatchSpeakMark, populated by prepareSpeakWords when a TTS
@@ -612,6 +617,13 @@ export class TTSController extends EventTarget {
     this.#highlightGranularity = granularity;
   }
 
+  setSkipInlineAnnotations(enabled: boolean) {
+    if (this.#skipInlineAnnotations === enabled) return;
+    this.#skipInlineAnnotations = enabled;
+    this.#sectionTimeline = null;
+    this.#timelineSectionIndex = -1;
+  }
+
   // The reader's visible section can intentionally diverge from the section
   // queued by Read Aloud (for example while paused at a chapter boundary).
   // Expose the session cursor so player surfaces never have to infer it from
@@ -806,7 +818,11 @@ export class TTSController extends EventTarget {
         createTTSNodeFilter(),
         this.#ttsGranularity,
       )) {
-        sentences.push({ ...entry, text: entry.range.toString() });
+        const text = entry.range.toString();
+        sentences.push({
+          ...entry,
+          text: this.#skipInlineAnnotations ? stripInlineReadingAnnotations(text) : text,
+        });
       }
     }
     // The section moved on while this was being enumerated: these sentences
@@ -1448,6 +1464,10 @@ export class TTSController extends EventTarget {
 
     if (this.preprocessCallback) {
       ssml = await this.preprocessCallback(ssml);
+    }
+
+    if (this.#skipInlineAnnotations) {
+      ssml = stripInlineReadingAnnotationsFromSSML(ssml);
     }
 
     return ssml;

--- a/apps/readest-app/src/services/tts/inlineAnnotations.ts
+++ b/apps/readest-app/src/services/tts/inlineAnnotations.ts
@@ -1,0 +1,62 @@
+interface TextSlice {
+  node: Text;
+  start: number;
+  end: number;
+}
+
+interface TextRange {
+  start: number;
+  end: number;
+}
+
+// Plain-text ruby has no semantic markup to distinguish it from prose. Keep
+// the opt-in heuristic conservative: the base must end in a Han ideograph and
+// the enclosed text may contain only Han or kana-script characters.
+const INLINE_READING =
+  /([\p{Unified_Ideograph}\u3005\u3006\u3007\u303b])(?:（[\p{Unified_Ideograph}\u3005\u3006\u3007\u303bぁ-ゖ゛-ゟァ-ヿ]+）|\([\p{Unified_Ideograph}\u3005\u3006\u3007\u303bぁ-ゖ゛-ゟァ-ヿ]+\)|《[\p{Unified_Ideograph}\u3005\u3006\u3007\u303bぁ-ゖ゛-ゟァ-ヿ]+》)/gu;
+
+const getAnnotationRanges = (text: string): TextRange[] =>
+  Array.from(text.matchAll(INLINE_READING), (match) => ({
+    start: match.index + match[1]!.length,
+    end: match.index + match[0].length,
+  }));
+
+export const stripInlineReadingAnnotations = (text: string): string =>
+  text.replace(INLINE_READING, (_match, base: string) => base);
+
+export const stripInlineReadingAnnotationsFromSSML = (ssml: string): string => {
+  const doc = new DOMParser().parseFromString(ssml, 'application/xml');
+  if (doc.querySelector('parsererror')) return ssml;
+
+  const slices: TextSlice[] = [];
+  const walker = doc.createTreeWalker(doc.documentElement, NodeFilter.SHOW_TEXT);
+  let text = '';
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const value = node.nodeValue ?? '';
+    slices.push({ node: node as Text, start: text.length, end: text.length + value.length });
+    text += value;
+  }
+
+  const ranges = getAnnotationRanges(text);
+  if (ranges.length === 0) return ssml;
+
+  for (const slice of slices) {
+    const cuts = ranges
+      .filter((range) => range.start < slice.end && range.end > slice.start)
+      .map((range) => ({
+        start: Math.max(range.start, slice.start) - slice.start,
+        end: Math.min(range.end, slice.end) - slice.start,
+      }));
+    if (cuts.length === 0) continue;
+
+    let cursor = 0;
+    let value = '';
+    for (const cut of cuts) {
+      value += slice.node.data.slice(cursor, cut.start);
+      cursor = cut.end;
+    }
+    slice.node.data = value + slice.node.data.slice(cursor);
+  }
+
+  return new XMLSerializer().serializeToString(doc);
+};

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -398,6 +398,7 @@ export interface TTSConfig {
   ttsHighlightGranularity: TTSHighlightGranularity;
   ttsMediaMetadata: TTSMediaMetadataMode;
   ttsPlayerStyle: TTSPlayerStyle;
+  ttsSkipInlineAnnotations: boolean;
 }
 
 export interface TranslatorConfig {


### PR DESCRIPTION
## Summary

- Show a Japanese-UI-only opt-in **Skip Parenthetical Readings** TTS setting for plain-text ruby written as `憂鬱（ゆううつ）`, `憂鬱(ゆううつ)`, or `憂鬱《ゆううつ》`.
- Remove only conservative Han-plus-kana/Han reading annotations at the final synthesized TTS timeline and SSML boundary, preserving the visible book text and SSML marks.
- Apply the setting to new, active, and reattached background TTS sessions while leaving recorded narration unchanged.
- Translate the setting copy across all supported locales.

Closes #5954

## Test Coverage

```text
CODE PATHS                                      USER FLOWS
[+] Default/config                              [+] Settings UI
  └── [★★★ TESTED] opt-in defaults false          ├── [★★ TESTED] renders unchecked
                                                   ├── [★★ TESTED] persists false → true
                                                   └── [GAP] true → false/reset persistence
[+] Inline annotation filter                   [+] Start/reattach TTS
  ├── [★★★ TESTED] （kana）, (kana), 《kana》       ├── [★★ TESTED] new controller receives false
  ├── [★★★ TESTED] Han gloss                      ├── [★★ TESTED] adopted controller receives false
  ├── [★★★ TESTED] conservative exclusions        ├── [GAP] enabled value on new/adopted sessions
  ├── [★★★ TESTED] cross-element SSML              └── [GAP] toggle updates active session
  ├── [★★★ TESTED] malformed XML fallback
  └── [GAP] multiple annotations plus exact
             valid-SSML/mark preservation
[+] TTSController                              [+] Synthesized playback
  ├── [★★ TESTED] final SSML boundary disabled     ├── [★★ TESTED] option off speaks annotation
  ├── [★★ TESTED] final SSML boundary enabled      └── [★★ TESTED] option on skips annotation
  ├── [GAP] enabled timeline text filtering
  └── [GAP] setting change invalidates/rebuilds timeline

COVERAGE: 23/28 paths tested (82%)
QUALITY: ★★★ edge/error coverage for parsing; ★★ behavior coverage for UI/controller wiring
```

Tests: 999 → 1001 (+2 files). Coverage gate: PASS (82%, target 80%).

## Pre-Landing Review

No issues found.

## Design Review

Design Review (lite): no issues found. The setting uses the existing boxed-list and switch primitives, including the established e-ink treatment.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN. The branch contains only the requested TTS behavior, setting, tests, and translations.

## Plan Completion

No relevant plan file detected; completion audit skipped.

## Verification Results

No plan verification section was available; verification used the repository test, lint, translation, and build commands below.

## Documentation

Documentation is current. Existing documentation does not enumerate individual TTS settings and remains accurate.

## Test plan

- [x] Full Vitest suite: 901 files passed, 10,857 tests passed; 4 files/16 tests skipped
- [x] Settings visibility: shown for Japanese UI locales and hidden otherwise
- [x] TypeScript and Biome lint: 2,338 files checked
- [x] Translation validation: no untranslated placeholders
- [x] Production Next/Tauri-target build and static export completed
- [x] Repository pre-push hook passed format, lint, and the full test suite

Generated with OpenAI Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Japanese-language text-to-speech option to skip parenthetical kana or Han readings following Han text.
  - The preference is saved with reader settings and applies when starting, resuming, or updating speech playback.

- **Localization**
  - Added translations for the new speech controls across supported languages.

- **Tests**
  - Added coverage for the setting, playback behavior, annotation handling, and default configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
