### PR TITLE
fix(tts): stop Android narration rewinding when the block cursor stalls

### DIFF
--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-client.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-client.test.ts
@@ -524,14 +524,71 @@ describe('MediaOverlayClient playback', () => {
       await pending;
     }
     const el = audio();
-    // The reader scrubs somewhere unrelated before the next block plays.
-    el.advanceTo(120);
+    // The reader scrubs back before the start of the block about to play.
+    el.advanceTo(0.2);
 
     const second = client.speak(section.ssmlForBlock(1)!, signal);
     await second.next();
 
     expect(el.seeks.at(-1)).toBe(3);
     expect(el.currentTime).toBe(3);
+  });
+
+  // A backward navigation (scrub back, previous-paragraph) targets a clip the
+  // recording has already passed, and there the seek IS the point: without it
+  // the button does nothing audible.
+  test('seeks back when the block itself is behind the playhead', async () => {
+    await setup();
+    const signal = new AbortController().signal;
+
+    const first = client.speak(section.ssmlForBlock(0)!, signal);
+    await first.next();
+    for (const t of [1, 2, 3.04]) {
+      const pending = first.next();
+      audio().advanceTo(t);
+      await pending;
+    }
+    const el = audio();
+    el.advanceTo(4.5);
+
+    // Back to block 0, whose clips (0s-3s) are all behind the playhead.
+    const again = client.speak(section.ssmlForBlock(0)!, signal);
+    await again.next();
+
+    expect(el.seeks.at(-1)).toBe(0);
+    expect(el.currentTime).toBe(0);
+  });
+
+  // The native mobile player runs in-process, not in the WebView, so it keeps
+  // playing while the WebView's main thread is stalled or its timers throttled
+  // (a page-turn relayout, a section preload, the screen off). The block cursor
+  // — advanced by a JS poll of the clock — then falls behind the recording, and
+  // the next block's clip is already in the past. Seeking back to its clipBegin
+  // replays paragraphs the listener has already heard, which is what a reader
+  // hears as the narration jumping back every few paragraphs. The recording is
+  // the master clock: let the marks catch up to it instead.
+  test('does not rewind when the recording ran past the block during a stall', async () => {
+    await setup();
+    const signal = new AbortController().signal;
+
+    const first = client.speak(section.ssmlForBlock(0)!, signal);
+    await first.next();
+    for (const t of [1, 2, 3.04]) {
+      const pending = first.next();
+      audio().advanceTo(t);
+      await pending;
+    }
+    const el = audio();
+    const seeksAfterBlock0 = [...el.seeks];
+    // The stall: the recording rolled through block 1 (3s-6s) and beyond before
+    // the client was asked to speak it.
+    el.advanceTo(7.5);
+
+    const second = client.speak(section.ssmlForBlock(1)!, signal);
+    await second.next();
+
+    expect(el.seeks).toEqual(seeksAfterBlock0);
+    expect(el.currentTime).toBeCloseTo(7.5, 5);
   });
 
   test('preloading warms the audio file without starting playback', async () => {

--- a/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayClient.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayClient.ts
@@ -171,6 +171,10 @@ export class MediaOverlayClient implements TTSClient {
   #objectUrl: string | null = null;
   #audioLoad: { href: string; promise: Promise<NarrationClock> } | null = null;
   #currentPar: NarrationPar | null = null;
+  // Last par the recording actually rode, kept across the handover that ends
+  // every block (unlike #currentPar) so speak() can tell a stalled cursor
+  // catching up from a navigation backwards. Cleared with the clock itself.
+  #playedPar: NarrationPar | null = null;
   #nextChunkPosition: number | null = null;
   #handoverTimer: ReturnType<typeof setTimeout> | null = null;
   #rate = 1;
@@ -325,6 +329,7 @@ export class MediaOverlayClient implements TTSClient {
     this.#audio = null;
     this.#audioHref = null;
     this.#objectUrl = null;
+    this.#playedPar = null;
     if (this.#native && this.#player) {
       void this.#player.release();
     }
@@ -340,6 +345,7 @@ export class MediaOverlayClient implements TTSClient {
     // recording plays on under the engine that took over.
     this.#audio?.pause();
     this.#currentPar = null;
+    this.#playedPar = null;
     this.#audioLoad = null;
     this.#audio = null;
     this.#audioHref = null;
@@ -451,10 +457,24 @@ export class MediaOverlayClient implements TTSClient {
         runIndex === 0 && requestedStart !== null
           ? first.clipBegin + Math.min(Math.max(requestedStart, 0), first.clipEnd - first.clipBegin)
           : null;
+      const playhead = audio.currentTime;
       const alreadyRolling =
-        audio.currentTime >= first.clipBegin - CLIP_CONTINUITY_TOLERANCE_SEC &&
-        audio.currentTime < first.clipEnd;
-      if (requestedPosition !== null || !alreadyRolling) {
+        playhead >= first.clipBegin - CLIP_CONTINUITY_TOLERANCE_SEC && playhead < first.clipEnd;
+      // ...and the recording can be further along still. The native mobile
+      // player runs in-process rather than in the WebView, so it keeps playing
+      // while the WebView's main thread is stalled or its timers throttled (a
+      // page-turn relayout, a section preload, the screen off) and the block
+      // cursor — advanced by a JS poll of this clock — falls a paragraph or
+      // more behind. Seeking back to clipBegin then replays audio the listener
+      // has already heard. The recording is the master clock: leave it rolling
+      // and let the marks catch up as the clip loop walks the passed pars.
+      // Only clips strictly after the last one played count, so a deliberate
+      // backward navigation — and a replay of the par just heard — still seeks.
+      const ranPastWhileStalled =
+        playhead >= first.clipEnd &&
+        this.#playedPar?.audioHref === first.audioHref &&
+        first.clipBegin > this.#playedPar.clipBegin;
+      if (requestedPosition !== null || !(alreadyRolling || ranPastWhileStalled)) {
         await seekClock(audio, requestedPosition ?? first.clipBegin);
       }
       try {
@@ -472,6 +492,7 @@ export class MediaOverlayClient implements TTSClient {
           return;
         }
         this.#currentPar = par;
+        this.#playedPar = par;
         this.controller?.dispatchSpeakMark({
           offset: 0,
           name: par.markName,


### PR DESCRIPTION
## Problem

A reader on Android reported that an EPUB 3 Media Overlay audiobook "jumps back every 3-4 paragraphs" after updating to 0.12.6, replaying narration they had already heard.

## Root cause

`MediaOverlayClient.speak()` only keeps the recording rolling while the playhead sits inside `[clipBegin - CLIP_CONTINUITY_TOLERANCE_SEC, clipEnd)`. A playhead that has run **past** `clipEnd` falls outside that window and was treated exactly like one parked somewhere unrelated (a scrub), so the client seeked the recording **back** to `clipBegin`.

Block advance is a JS loop: `#waitUntil` polls `audio.currentTime` every 50 ms and the controller moves on when a clip ends. Through 0.12.1 Android played Media Overlays through an `HTMLAudioElement` inside the WebView, so a stalled main thread stalled the audio with it and the playhead could never outrun the cursor. Widening `isNativeNarrationPlatform()` to Android put playback on the in-process ExoPlayer, which keeps playing while the WebView is stalled or its timers throttled. Any stall longer than the next clip (the shortest in a typical chapter are about 5 s) leaves the cursor a paragraph behind, and the next `speak()` drags the audio back to the text instead of the text forward to the audio.

The 3-4 paragraph cadence is the page turn: paginator relayout plus the adjacent-section preload is the stall, and a phone-sized page holds 3-4 paragraphs.

## Fix

Track the last par the recording actually rode (`#playedPar`), kept across the handover that ends every block unlike `#currentPar`, and skip the seek when the playhead has run past a clip that comes **after** it in the same audio file. The recording is the master clock, so the marks catch up to it as the clip loop walks the pars already passed. The comparison is strict, so a deliberate backward navigation and a replay of the par just heard still seek.

## Verification

Xiaomi 13, `0.12.6` devtools build (md5-matched against the installed APK), with a real Media Overlay audiobook (one mp3 + one SMIL per chapter, one `<par>` per `<p>`).

Foreground playback is clean for 30+ minutes on both builds, so the stall was forced from CDP with a main-thread busy loop. The backward seek is visible in logcat as a flush of the narration decoder, which otherwise decodes continuously; the media-session keep-alive `silence.mp3` decoder flushes on its own fixed 10.0 s loop and is not the same one.

| | before | after |
| --- | --- | --- |
| foreground, 30+ min | clean | clean |
| forced JS stall | `seg40 -> seg41` (one paragraph) plus an off-grid narration-decoder flush at the resume instant, i.e. the backward seek | `seg9 -> seg10 -> seg11` in 1.44 s (catch-up), then `seg12` at the normal ~10 s cadence, and **no** off-grid flush |
| 12 min continuous | n/a | monotonic `seg10..39`, `seg0..40`, `seg0..`, two chapter boundaries crossed cleanly |

Unit coverage added to `media-overlay-client.test.ts`: the drift case must not rewind, a block behind the playhead must still seek, and a playhead before the clip must still seek.

`pnpm test` (10848 passed), `pnpm lint`, `pnpm format:check` all green on a clean worktree off `main`.

## Note

One observation I could not explain: on the fixed build a 45 s stall (ANR scale, far beyond what this targets) left playback stopped rather than resuming. A 25 s stall recovered cleanly and 12 minutes of playback afterwards was clean, and the unfixed build also stopped spontaneously several times in the same environment, so I cannot attribute it to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech playback when narration advances during a brief playback-status delay.
  * Prevented unnecessary rewinding and replaying of audio that has already been heard.
  * Preserved seeking behavior for deliberate backward navigation and replaying previously heard content.
  * Improved seeking when starting narration for content positioned behind the current playhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->