### PR TITLE
fix(annotator): stop PDF selections opening the translator popup

### DIFF
--- a/apps/readest-app/src/__tests__/components/annotator/AnnotatorLookupSurfaces.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotatorLookupSurfaces.test.tsx
@@ -1,4 +1,7 @@
 /**
+ * When a lookup surface (dictionary / translator / proofread) may open, and when
+ * it must stay shut.
+ *
  * #6018 — the dictionary flashed open and vanished on Android.
  *
  * `handleDictionary` (and its translator / proofread siblings) calls
@@ -30,6 +33,12 @@ const h = vi.hoisted(() => ({
   saveConfig: vi.fn(),
   updateBooknotes: vi.fn(),
   isTextSelected: { current: true },
+  // Swapped per test: the fixed-layout branch of `onLoad` used to wire PDF-only
+  // listeners, so a regression there is only visible with this on.
+  book: { format: 'EPUB', isFixedLayout: false },
+  // `onLoad` and friends, captured from the `useFoliateEvents` call so a test can
+  // fire a section load and drive the listeners it registers on the section doc.
+  foliateHandlers: null as null | Record<string, (event: Event) => void>,
   // Annotator's own `setSelection`, captured from the `useTextSelector` call
   // so a test can republish the selection exactly as the hook does.
   setSelection: null as
@@ -84,9 +93,9 @@ vi.mock('@/store/bookDataStore', () => {
     setConfig: vi.fn(),
     saveConfig: h.saveConfig,
     getBookData: () => ({
-      book: { format: 'EPUB', primaryLanguage: 'en' },
+      book: { format: h.book.format, primaryLanguage: 'en' },
       bookDoc: { metadata: { language: 'en' } },
-      isFixedLayout: false,
+      isFixedLayout: h.book.isFixedLayout,
     }),
     updateBooknotes: h.updateBooknotes,
   };
@@ -98,7 +107,7 @@ vi.mock('@/store/bookDataStore', () => {
 
 vi.mock('@/store/readerStore', () => {
   const state = {
-    getView: () => ({ deselect: vi.fn() }),
+    getView: () => ({ deselect: vi.fn(), getCFI: () => 'epubcfi(/6/2!/4/2)' }),
     getViewsById: () => [],
     getViewSettings: () => h.viewSettings,
   };
@@ -151,7 +160,11 @@ vi.mock('@/app/reader/hooks/useBookOrbitNotesSync', () => ({ useBookOrbitNotesSy
 vi.mock('@/app/reader/hooks/useReadwiseSync', () => ({ useReadwiseSync: () => {} }));
 vi.mock('@/app/reader/hooks/useHardcoverSync', () => ({ useHardcoverSync: () => {} }));
 vi.mock('@/app/reader/hooks/useNotionSync', () => ({ useNotionSync: () => {} }));
-vi.mock('@/app/reader/hooks/useFoliateEvents', () => ({ useFoliateEvents: () => {} }));
+vi.mock('@/app/reader/hooks/useFoliateEvents', () => ({
+  useFoliateEvents: (_view: unknown, handlers: Record<string, (event: Event) => void>) => {
+    h.foliateHandlers = handlers;
+  },
+}));
 vi.mock('@/app/reader/hooks/useRendererInputListeners', () => ({
   useRendererInputListeners: () => {},
 }));
@@ -262,6 +275,8 @@ const republishSelectionWithSuppressedHandles = async () => {
 
 beforeEach(() => {
   h.actions = null;
+  h.book = { format: 'EPUB', isFixedLayout: false };
+  h.foliateHandlers = null;
   h.config.booknotes = [];
   h.isTextSelected.current = true;
   h.setSelection = null;
@@ -289,5 +304,54 @@ describe('a lookup surface survives the selection it is anchored to being republ
 
     expect(screen.queryByTestId(testId)).toBeTruthy();
     expect(screen.queryByTestId('annotation-toolbar')).toBeNull();
+  });
+});
+
+/**
+ * #5821 — every PDF word selection on Android opened the translator popup.
+ *
+ * Fixed-layout books used to wire their own `contextmenu` listener in `onLoad`
+ * that forced the translator surface open, from back when PDFs had no annotation
+ * toolbar of their own. Android dispatches `contextmenu` for the long press that
+ * selects a word, so the shortcut fired on every selection and buried the word —
+ * and the dictionary the reader had asked for — under an unrequested
+ * translation. iOS never reproduced it: WebKit dispatches no `contextmenu` for a
+ * long-press selection.
+ */
+describe('a context menu never opens a lookup surface by itself', () => {
+  // The ambient jsdom document, because jsdom implements `getSelection` only on
+  // the window's own document — a `createHTMLDocument` section doc has none, and
+  // the handler under test bails on it before doing anything at all.
+  const loadSection = async () => {
+    const doc = document;
+    const paragraph = doc.createElement('p');
+    paragraph.textContent = 'selected text';
+    doc.body.append(paragraph);
+    await act(async () => {
+      h.foliateHandlers?.['onLoad']?.(
+        new CustomEvent('load', { detail: { doc, index: 0 } }) as Event,
+      );
+    });
+    return { doc, paragraph };
+  };
+
+  test.each([
+    ['a fixed-layout book', true, 'PDF'],
+    ['a reflowable book', false, 'EPUB'],
+  ])('%s answers a contextmenu with no translator', async (_label, isFixedLayout, format) => {
+    h.book = { format, isFixedLayout };
+    render(<Annotator bookKey='book-1' contentInsets={{ top: 0, right: 0, bottom: 0, left: 0 }} />);
+    const { doc, paragraph } = await loadSection();
+
+    const range = doc.createRange();
+    range.selectNodeContents(paragraph);
+    doc.getSelection()?.removeAllRanges();
+    doc.getSelection()?.addRange(range);
+
+    await act(async () => {
+      paragraph.dispatchEvent(new Event('contextmenu', { bubbles: true, cancelable: true }));
+    });
+
+    expect(screen.queryByTestId('translator-surface')).toBeNull();
   });
 });

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -550,37 +550,13 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     detail.doc?.addEventListener('pointerup', handlePointerUp.bind(null, doc, index));
     detail.doc?.addEventListener('selectionchange', handleSelectionchange.bind(null, doc, index));
 
-    // For PDF selections, enable right-click context menu to directly open translator popup.
-    if (bookData.isFixedLayout) {
-      detail.doc?.addEventListener('contextmenu', (e: Event) => {
-        // Prevent native menu to keep experience consistent
-        e.preventDefault();
-        e.stopPropagation();
-        try {
-          const sel = doc.getSelection?.();
-          if (!sel || sel.isCollapsed) return;
-          const range = sel.getRangeAt(0);
-          // Same text as the toolbar path, with PDF line wraps joined (#5814).
-          void getAnnotationText(range).then((text) => {
-            if (!text.trim()) return;
-            setSelection({
-              key: bookKey,
-              text,
-              range,
-              index,
-              cfi: view?.getCFI(index, range),
-              page: index + 1,
-            });
-            // Show translation popup preferentially for PDF right-click
-            setShowAnnotPopup(false);
-            setShowDeepLPopup(true);
-            setShowDictionaryPopup(false);
-          });
-        } catch (err) {
-          console.warn('PDF context menu translation failed:', err);
-        }
-      });
-    }
+    // Fixed-layout books used to wire their own `contextmenu` listener here that
+    // forced the translator popup open, from back when PDFs had no annotation
+    // toolbar of their own. The toolbar is shared with EPUB now, and the shortcut
+    // had become actively harmful: Android dispatches `contextmenu` for the long
+    // press that selects a word, so every PDF selection buried the word — and the
+    // dictionary the reader had asked for — under an unrequested translation
+    // (#5821). PDF selections now take the same path as every other format.
 
     // Disable the default context menu on mobile devices (selection handles suffice)
     detail.doc?.addEventListener('contextmenu', handleContextmenu);


### PR DESCRIPTION
Closes #5821.

## The bug

On Android, selecting a word in a PDF opened the translator popup on top of the dictionary the reader had actually asked for. The reporter is on GrapheneOS with all network permissions cut and an offline MDict OED loaded, and neither turning off Instant Translate nor switching translator provider changed anything, because no setting was ever consulted.

<img width="360" alt="the translator popup covering the dictionary sheet" src="https://github.com/user-attachments/assets/aecda9bd-e759-4b9f-95c6-1a61e8d64ac1" />

## Root cause

`onLoad` registered, for `bookData.isFixedLayout` only, a `contextmenu` listener that unconditionally did:

```ts
setShowAnnotPopup(false);
setShowDeepLPopup(true);
setShowDictionaryPopup(false);
```

It was written for desktop **right-click** ("For PDF selections, enable right-click context menu to directly open translator popup", #2430). But Android's WebView also dispatches `contextmenu` for a **long press**, which is the very gesture used to select a word, so the shortcut fired on every PDF word selection. With Instant Dictionary on, the deferred quick action then opened the dictionary at touchend, stacking both popups.

iOS never reproduced it: WebKit dispatches no `contextmenu` for a long-press text selection, running its own callout bar instead. Same family as #5596, where a single Android long press emits two independent signals.

## The fix

The annotation toolbar is shared by EPUB and PDF now, so the shortcut is obsolete. The branch is removed and PDF selections take the same path as every other format. Desktop right-click in a PDF now falls through to the native menu, exactly as it already did for EPUB (`handleContextmenu` only calls `preventDefault` for mobile / touch / pen).

## Verification on a Xiaomi 13

Firing a `contextmenu` on a PDF selection, scraping the resulting surfaces:

```
BEFORE  touch/pen/mouse -> "Original Text | Auto Detect | ..."   (translator, all three)
AFTER   touch/pen/mouse -> annotation toolbar + highlight strip
```

A real long press injected through the input pipeline arrives as `PointerEvent{pointerType:'touch', button:-1}`, confirming the WebView really does route that gesture through `contextmenu`.

## Regression test

`AnnotatorLookupSurfaces.test.tsx` gains a case that fires `onLoad`, selects text, dispatches `contextmenu`, and asserts no translator surface, for both a fixed-layout and a reflowable book. The #6018 harness is generalised so the book's format/layout is switchable and the `useFoliateEvents` mock captures the handlers.

The test was confirmed to go red against the pre-fix code. Two things had to be right for it to detect anything: jsdom implements `getSelection` only on the window's own document (a `createHTMLDocument` section doc has none, so the handler bailed instantly), and the `getView()` mock needed `getCFI`, without which the handler threw inside its `.then()` before ever setting the translator state.

`pnpm test`, `pnpm lint` and `pnpm format:check` all pass on this branch, rebased on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed PDF text selections so right-click or long-press actions open the appropriate annotation toolbar, dictionary, or quick action instead of always opening the translator.
  - Prevented the translator popup from opening unexpectedly from context-menu events in both PDF and EPUB books.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->