### PR TITLE
fix(annotator): keep PDF highlights visible in dark mode

### DIFF
--- a/apps/readest-app/src/__tests__/utils/overlayer-blend-mode.test.ts
+++ b/apps/readest-app/src/__tests__/utils/overlayer-blend-mode.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+
+import { getOverlayerBlendMode } from '@/utils/style';
+
+describe('getOverlayerBlendMode', () => {
+  it('multiplies onto a light page so the band darkens the paper', () => {
+    expect(getOverlayerBlendMode({ isDarkMode: false, isBwEink: false })).toBe('multiply');
+  });
+
+  it('screens onto a dark reflowable page so the band lightens the ink', () => {
+    expect(getOverlayerBlendMode({ isDarkMode: true, isBwEink: false })).toBe('screen');
+  });
+
+  it('masks with difference on B&W e-ink in either theme', () => {
+    expect(getOverlayerBlendMode({ isDarkMode: false, isBwEink: true })).toBe('difference');
+    expect(getOverlayerBlendMode({ isDarkMode: true, isBwEink: true })).toBe('difference');
+  });
+
+  // #5790 / #5930 / #5943: a PDF keeps the book's own white bitmap in dark mode
+  // unless the reader asked us to darken it, and `screen` over white paints no
+  // band at all — it only tints the glyphs.
+  it('multiplies over a PDF that stays light in dark mode', () => {
+    expect(
+      getOverlayerBlendMode({
+        isDarkMode: true,
+        isBwEink: false,
+        isFixedLayout: true,
+        format: 'PDF',
+      }),
+    ).toBe('multiply');
+  });
+
+  it('screens over a PDF the reader inverted into dark mode', () => {
+    expect(
+      getOverlayerBlendMode({
+        isDarkMode: true,
+        isBwEink: false,
+        isFixedLayout: true,
+        format: 'PDF',
+        invertImgColorInDark: true,
+      }),
+    ).toBe('screen');
+  });
+
+  it('screens over a PDF rendered with the theme page colors', () => {
+    expect(
+      getOverlayerBlendMode({
+        isDarkMode: true,
+        isBwEink: false,
+        isFixedLayout: true,
+        format: 'PDF',
+        applyThemeToPDF: true,
+      }),
+    ).toBe('screen');
+  });
+
+  it('ignores applyThemeToPDF for comic pages, which are never re-rendered', () => {
+    expect(
+      getOverlayerBlendMode({
+        isDarkMode: true,
+        isBwEink: false,
+        isFixedLayout: true,
+        format: 'CBZ',
+        applyThemeToPDF: true,
+      }),
+    ).toBe('multiply');
+  });
+
+  it('still multiplies on a light-theme PDF whatever the darkening settings say', () => {
+    expect(
+      getOverlayerBlendMode({
+        isDarkMode: false,
+        isBwEink: false,
+        isFixedLayout: true,
+        format: 'PDF',
+        invertImgColorInDark: true,
+        applyThemeToPDF: true,
+      }),
+    ).toBe('multiply');
+  });
+});

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -38,6 +38,7 @@ import {
   applyScrollModeClass,
   applyThemeModeClass,
   applyTranslationStyle,
+  getOverlayerBlendMode,
   getStyles,
   getThemeCode,
   keepTextAlignment,
@@ -994,6 +995,33 @@ const FoliateViewer: React.FC<{
     viewSettings?.contrast,
     viewSettings?.hideScrollbar,
     viewSettings?.isEink,
+  ]);
+
+  // The annotation overlay lives outside the content iframe, so its blend mode
+  // has to follow the page the highlight sits on rather than the app theme: a
+  // PDF keeps its own white bitmap in a dark theme unless the reader asked us
+  // to darken it (#5790, #5930, #5943). Scoped to this view so the library and
+  // reflowable books keep the global default from useTheme.
+  useEffect(() => {
+    if (!containerRef.current || !viewSettings) return;
+    containerRef.current.style.setProperty(
+      '--overlayer-highlight-blend-mode',
+      getOverlayerBlendMode({
+        isDarkMode,
+        isBwEink: !!viewSettings.isEink && !viewSettings.isColorEink,
+        isFixedLayout: bookDoc.rendition?.layout === 'pre-paginated',
+        invertImgColorInDark: !!viewSettings.invertImgColorInDark,
+        applyThemeToPDF: !!viewSettings.applyThemeToPDF,
+        format: bookData?.book?.format,
+      }),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isDarkMode,
+    viewSettings?.isEink,
+    viewSettings?.isColorEink,
+    viewSettings?.invertImgColorInDark,
+    viewSettings?.applyThemeToPDF,
   ]);
 
   useEffect(() => {

--- a/apps/readest-app/src/hooks/useTheme.ts
+++ b/apps/readest-app/src/hooks/useTheme.ts
@@ -5,6 +5,7 @@ import { useSettingsStore } from '@/store/settingsStore';
 import { useSafeAreaInsets } from './useSafeAreaInsets';
 import { applyCustomTheme, Palette, ThemeScope } from '@/styles/themes';
 import { getStatusBarHeight, setSystemUIVisibility } from '@/utils/bridge';
+import { getOverlayerBlendMode } from '@/utils/style';
 import { getOSPlatform } from '@/utils/misc';
 
 type UseThemeProps = {
@@ -134,9 +135,11 @@ export const useTheme = ({
       '--overlayer-highlight-opacity',
       isBwEink ? '1.0' : String(highlightOpacity),
     );
+    // The global default assumes a page painted in the theme colors. Books that
+    // keep their own page (PDFs, comics) override it per view in FoliateViewer.
     document.documentElement.style.setProperty(
       '--overlayer-highlight-blend-mode',
-      isBwEink ? 'difference' : isDarkMode ? 'screen' : 'multiply',
+      getOverlayerBlendMode({ isDarkMode, isBwEink: !!isBwEink }),
     );
     document.documentElement.style.setProperty(
       '--bg-texture-blend-mode',

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1545,6 +1545,41 @@ export const keepTextAlignment = (document: Document) => {
   }
 };
 
+/**
+ * Blend mode for the annotation overlay (`--overlayer-highlight-blend-mode`).
+ *
+ * The overlay is an SVG sibling of the content iframe, so it blends against
+ * whatever the page paints behind it — the mode has to follow the *page*
+ * background, not the app theme. `screen` lightens a dark page, but over a
+ * white one it is a no-op on the background and only tints the glyphs, which is
+ * how highlights went missing on PDFs in dark mode (#5790, #5930, #5943). A
+ * pre-paginated page keeps the book's own bitmap unless the reader asked us to
+ * invert it or to re-render it in the theme colors, so a dark theme alone says
+ * nothing about how dark the page is. Blending does not cross the iframe
+ * boundary in WebKit, which is why Apple platforms never showed the bug.
+ */
+export const getOverlayerBlendMode = ({
+  isDarkMode,
+  isBwEink,
+  isFixedLayout = false,
+  invertImgColorInDark = false,
+  applyThemeToPDF = false,
+  format,
+}: {
+  isDarkMode: boolean;
+  isBwEink: boolean;
+  isFixedLayout?: boolean;
+  invertImgColorInDark?: boolean;
+  applyThemeToPDF?: boolean;
+  format?: BookFormat;
+}): 'difference' | 'screen' | 'multiply' => {
+  if (isBwEink) return 'difference';
+  if (!isDarkMode) return 'multiply';
+  const isDarkPage =
+    !isFixedLayout || invertImgColorInDark || (format === 'PDF' && applyThemeToPDF);
+  return isDarkPage ? 'screen' : 'multiply';
+};
+
 export const applyFixedlayoutStyles = (
   document: Document,
   viewSettings: ViewSettings,


### PR DESCRIPTION
Closes #5790
Closes #5930
Closes #5943

## The bug

In a dark theme, a highlight on a PDF paints no band at all. The highlighted
words just change color: a yellow highlight turns the text olive, a blue one
is effectively invisible. Same for the TTS read-along highlight, which is why
#5943 was filed as "there is no visual indication of what is being read".

PDF only. EPUB is fine.

## Root cause

The annotation overlay is an SVG sibling of the content iframe (`Overlayer`
in foliate-js), and `Overlayer.highlight` composites it with
`mix-blend-mode: var(--overlayer-highlight-blend-mode)`. `useTheme` picked
that mode from the app theme alone:

```ts
isBwEink ? 'difference' : isDarkMode ? 'screen' : 'multiply'
```

`screen` is right for a dark page, and a reflowable book in dark mode really
does have one, because we repaint its background in the theme colors. A
pre-paginated page does not: it keeps the book's own bitmap. `applyThemeToPDF`
and `invertImgColorInDark` both default to `false`, so a PDF in a dark theme
is still a white page in a dark app frame.

`screen` over white is a no-op. `1 - (1-1)(1-Cs) = 1`, so the paper stays
white and the band never appears; only the black glyphs are lightened toward
the highlight color at 0.4 alpha, which is the color-shifted text in the
reports.

Blending does not cross the iframe boundary in WebKit, so the overlay there
degrades to `normal` and the highlight has always looked correct. That is why
this never showed on Safari, macOS or iOS, and reproduces on every Chromium
engine: Android WebView, WebView2 and the web build.

## The fix

Pick the blend mode from the page background rather than the app theme.
`getOverlayerBlendMode` in `utils/style.ts` is the single decision, used both
for the global default in `useTheme` and for a per-view override in
`FoliateViewer` that knows the book's layout and darkening settings.

| Page | Before | After |
| --- | --- | --- |
| Reflowable, dark theme | `screen` | `screen` |
| Reflowable, light theme | `multiply` | `multiply` |
| PDF darkened by invert / theme colors | `screen` | `screen` |
| PDF that stays light, dark theme | `screen` (bug) | `multiply` |
| PDF, light theme | `multiply` | `multiply` |
| B&W e-ink | `difference` | `difference` |

The override is set on the viewer container, so it cascades into the
foliate-view shadow DOM and leaves the library and every other route on the
global default.

## Verification

`getOverlayerBlendMode` has unit coverage for all six rows above (test written
first, failing before the fix). Full suite: 10880 passed. `pnpm lint` and
`pnpm format:check` clean.

Rendering checked end to end in Chrome and on a Xiaomi 13 running WebView 153,
the environment from the reports:

- PDF dark mode: the band appears, matching light mode.
- PDF light mode: 0 differing pixels before vs after.
- EPUB light and dark: 0 differing pixels before vs after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation highlight visibility across light and dark themes.
  * Corrected highlight blending for PDFs, comics, fixed-layout pages, and inverted images.
  * Improved overlay rendering on black-and-white and color e-ink displays.

* **Tests**
  * Added coverage for highlight blending across themes, e-ink modes, and supported fixed-layout formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->