### PR TITLE
feat(reader): zoom shortcuts adjust font size in reflowable books, closes #5694

### DIFF
--- a/apps/readest-app/e2e/pages/ReaderPage.ts
+++ b/apps/readest-app/e2e/pages/ReaderPage.ts
@@ -346,6 +346,19 @@ export class ReaderPage extends BasePage {
     throw new Error('no visible book section found in the viewer');
   }
 
+  /** Press one of the reader's zoom shortcuts. */
+  async pressZoomShortcut(key: '=' | '-' | '0'): Promise<void> {
+    await this.page.keyboard.press(`Control+${key}`);
+  }
+
+  /** The px font size the book text is currently rendered at. */
+  async bookFontSize(): Promise<number> {
+    const frame = await this.visibleSectionFrame();
+    return frame
+      .locator('body')
+      .evaluate((body) => Number.parseFloat(getComputedStyle(body).fontSize));
+  }
+
   /**
    * Select a paragraph of book text and raise the annotation popup.
    *

--- a/apps/readest-app/e2e/tests/reading.spec.ts
+++ b/apps/readest-app/e2e/tests/reading.spec.ts
@@ -55,6 +55,25 @@ test.describe('Reading', () => {
     expect(Number(after)).toBeGreaterThan(Number(before));
   });
 
+  test('zoom shortcuts step the font size of a reflowable book (#5694)', async ({ openBook }) => {
+    const reader = await openBook();
+    await reader.openTocChapter(3);
+    const before = await reader.bookFontSize();
+
+    await reader.pressZoomShortcut('=');
+    await expect.poll(() => reader.bookFontSize()).toBe(before + 1);
+
+    await reader.pressZoomShortcut('-');
+    await expect.poll(() => reader.bookFontSize()).toBe(before);
+
+    await reader.pressZoomShortcut('=');
+    await reader.pressZoomShortcut('=');
+    await expect.poll(() => reader.bookFontSize()).toBe(before + 2);
+
+    await reader.pressZoomShortcut('0');
+    await expect.poll(() => reader.bookFontSize()).toBe(before);
+  });
+
   test('adds and removes a bookmark', async ({ openBook }) => {
     const reader = await openBook();
     await reader.revealHeader();

--- a/apps/readest-app/src/__tests__/components/useBookShortcuts.test.tsx
+++ b/apps/readest-app/src/__tests__/components/useBookShortcuts.test.tsx
@@ -31,8 +31,13 @@ const currentViewState = {
   inited: true,
 };
 
+const currentBookData = {
+  isFixedLayout: false,
+};
+
 const currentViewSettings = {
   defaultFontSize: 16,
+  zoomLevel: 100,
   lineHeight: 1.5,
   readingRulerEnabled: true,
   writingMode: 'horizontal-tb',
@@ -81,16 +86,27 @@ vi.mock('@/store/sidebarStore', () => ({
 
 const mockSetSettingsDialogOpen = vi.fn();
 const mockSetSettingsDialogBookKey = vi.fn();
+const globalViewSettings = { defaultFontSize: 16 };
 vi.mock('@/store/settingsStore', () => ({
   useSettingsStore: () => ({
+    settings: { globalViewSettings },
     setSettingsDialogOpen: mockSetSettingsDialogOpen,
     setSettingsDialogBookKey: mockSetSettingsDialogBookKey,
   }),
 }));
 
+const mockSaveViewSettings = vi.fn();
+vi.mock('@/helpers/settings', () => ({
+  saveViewSettings: (...args: unknown[]) => mockSaveViewSettings(...args),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: { appPlatform: 'web' } }),
+}));
+
 vi.mock('@/store/bookDataStore', () => ({
   useBookDataStore: () => ({
-    getBookData: vi.fn(),
+    getBookData: () => currentBookData,
     getConfig: mockGetConfig,
     setConfig: mockSetConfig,
   }),
@@ -138,6 +154,10 @@ vi.mock('@/services/constants', () => ({
   MAX_ZOOM_LEVEL: 200,
   MIN_ZOOM_LEVEL: 50,
   ZOOM_STEP: 10,
+  MAX_FONT_SIZE: 120,
+  MIN_FONT_SIZE: 8,
+  FONT_SIZE_STEP: 1,
+  DEFAULT_BOOK_FONT: { defaultFontSize: 16 },
 }));
 
 vi.mock('@/app/reader/hooks/useBooksManager', () => ({
@@ -161,6 +181,10 @@ describe('useBookShortcuts', () => {
     currentViewSettings.rtl = false;
     currentViewSettings.paragraphMode.enabled = false;
     currentViewState.inited = true;
+    currentBookData.isFixedLayout = false;
+    currentViewSettings.defaultFontSize = 16;
+    currentViewSettings.zoomLevel = 100;
+    globalViewSettings.defaultFontSize = 16;
     mockView.book.dir = 'ltr';
     sideBarState.isSideBarPinned = false;
     sideBarState.isSideBarVisible = false;
@@ -316,5 +340,79 @@ describe('useBookShortcuts', () => {
     } else {
       expect(mockSetConfig).not.toHaveBeenCalled();
     }
+  });
+
+  describe('zoom shortcuts on reflowable books (#5694)', () => {
+    it('steps the font size up and keeps the change on the book', () => {
+      render(<Harness />);
+      shortcutState.actions?.['onZoomIn']?.();
+
+      expect(mockSaveViewSettings).toHaveBeenCalledWith(
+        { appPlatform: 'web' },
+        'book-1',
+        'defaultFontSize',
+        17,
+        true,
+      );
+      expect(mockView.renderer.setAttribute).not.toHaveBeenCalled();
+    });
+
+    it('steps the font size down', () => {
+      render(<Harness />);
+      shortcutState.actions?.['onZoomOut']?.();
+
+      expect(mockSaveViewSettings).toHaveBeenCalledWith(
+        { appPlatform: 'web' },
+        'book-1',
+        'defaultFontSize',
+        15,
+        true,
+      );
+    });
+
+    it('scales the step with the pinch factor', () => {
+      render(<Harness />);
+      eventDispatcher.dispatch('zoom-in', { factor: 4 });
+
+      expect(mockSaveViewSettings).toHaveBeenCalledWith(
+        { appPlatform: 'web' },
+        'book-1',
+        'defaultFontSize',
+        20,
+        true,
+      );
+    });
+
+    it('clamps the font size to the allowed range', () => {
+      currentViewSettings.defaultFontSize = 8;
+      render(<Harness />);
+      shortcutState.actions?.['onZoomOut']?.();
+
+      expect(mockSaveViewSettings).not.toHaveBeenCalled();
+    });
+
+    it('restores the global default font size on reset zoom', () => {
+      currentViewSettings.defaultFontSize = 24;
+      globalViewSettings.defaultFontSize = 18;
+      render(<Harness />);
+      shortcutState.actions?.['onResetZoom']?.();
+
+      expect(mockSaveViewSettings).toHaveBeenCalledWith(
+        { appPlatform: 'web' },
+        'book-1',
+        'defaultFontSize',
+        18,
+        true,
+      );
+    });
+
+    it('keeps scaling fixed-layout books instead of resizing text', () => {
+      currentBookData.isFixedLayout = true;
+      render(<Harness />);
+      shortcutState.actions?.['onZoomIn']?.();
+
+      expect(mockView.renderer.setAttribute).toHaveBeenCalledWith('scale-factor', 110);
+      expect(mockSaveViewSettings).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/readest-app/src/app/reader/hooks/useBookShortcuts.ts
+++ b/apps/readest-app/src/app/reader/hooks/useBookShortcuts.ts
@@ -7,7 +7,17 @@ import { useSettingsStore } from '@/store/settingsStore';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { tauriHandleClose, tauriHandleToggleFullScreen, tauriQuitApp } from '@/utils/window';
 import { eventDispatcher } from '@/utils/event';
-import { MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL, ZOOM_STEP } from '@/services/constants';
+import { useEnv } from '@/context/EnvContext';
+import { saveViewSettings } from '@/helpers/settings';
+import {
+  DEFAULT_BOOK_FONT,
+  FONT_SIZE_STEP,
+  MAX_FONT_SIZE,
+  MAX_ZOOM_LEVEL,
+  MIN_FONT_SIZE,
+  MIN_ZOOM_LEVEL,
+  ZOOM_STEP,
+} from '@/services/constants';
 import { getParagraphActionForKey } from '@/utils/paragraphPresentation';
 import { getScrollGapAttr } from '@/utils/webtoon';
 import { extendSelectionFromContents, KeyModifiers } from '@/utils/sel';
@@ -27,7 +37,8 @@ const useBookShortcuts = ({ sideBarBookKey, bookKeys }: UseBookShortcutsProps) =
     useReaderStore();
   const { toggleSideBar, setSideBarBookKey, setSideBarVisible, setSearchBarVisible } =
     useSidebarStore();
-  const { setSettingsDialogOpen, setSettingsDialogBookKey } = useSettingsStore();
+  const { settings, setSettingsDialogOpen, setSettingsDialogBookKey } = useSettingsStore();
+  const { envConfig } = useEnv();
   const { getBookData, getConfig, setConfig } = useBookDataStore();
   const { toggleNotebook } = useNotebookStore();
   const { getNextBookKey } = useBooksManager();
@@ -294,9 +305,25 @@ const useBookShortcuts = ({ sideBarBookKey, bookKeys }: UseBookShortcutsProps) =
     }
   };
 
+  // Reflowable books scale by text, not by page (issue #5694). The new size is
+  // saved with skipGlobal so zooming one book never resizes the whole library.
+  const applyFontSize = (fontSize: number) => {
+    const viewSettings = sideBarBookKey ? getViewSettings(sideBarBookKey) : null;
+    if (!sideBarBookKey || !viewSettings) return;
+    const clamped = Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, Math.round(fontSize)));
+    if (clamped === viewSettings.defaultFontSize) return;
+    saveViewSettings(envConfig, sideBarBookKey, 'defaultFontSize', clamped, true);
+  };
+
+  const isFixedLayout = () => !!getBookData(sideBarBookKey ?? '')?.isFixedLayout;
+
   const zoomInFactor = (factor = 1.0) => {
     if (!sideBarBookKey) return;
     const viewSettings = getViewSettings(sideBarBookKey)!;
+    if (!isFixedLayout()) {
+      applyFontSize(viewSettings.defaultFontSize + FONT_SIZE_STEP * factor);
+      return;
+    }
     const zoomLevel = viewSettings!.zoomLevel + ZOOM_STEP * factor;
     applyZoomLevel(Math.min(zoomLevel, MAX_ZOOM_LEVEL));
   };
@@ -304,6 +331,10 @@ const useBookShortcuts = ({ sideBarBookKey, bookKeys }: UseBookShortcutsProps) =
   const zoomOutFactor = (factor = 1.0) => {
     if (!sideBarBookKey) return;
     const viewSettings = getViewSettings(sideBarBookKey)!;
+    if (!isFixedLayout()) {
+      applyFontSize(viewSettings.defaultFontSize - FONT_SIZE_STEP * factor);
+      return;
+    }
     const zoomLevel = viewSettings!.zoomLevel - ZOOM_STEP * factor;
     applyZoomLevel(Math.max(zoomLevel, MIN_ZOOM_LEVEL));
   };
@@ -328,6 +359,12 @@ const useBookShortcuts = ({ sideBarBookKey, bookKeys }: UseBookShortcutsProps) =
 
   const resetZoom = () => {
     if (!sideBarBookKey) return;
+    if (!isFixedLayout()) {
+      applyFontSize(
+        settings.globalViewSettings?.defaultFontSize ?? DEFAULT_BOOK_FONT.defaultFontSize,
+      );
+      return;
+    }
     applyZoomLevel(100);
   };
 

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -961,6 +961,12 @@ export const MAX_ZOOM_LEVEL = 500;
 export const MIN_ZOOM_LEVEL = 50;
 export const ZOOM_STEP = 10;
 
+// Reflowable books have no scale factor, so the zoom shortcuts step the book's
+// own font size instead (issue #5694). The bounds match Settings > Font.
+export const MAX_FONT_SIZE = 120;
+export const MIN_FONT_SIZE = 8;
+export const FONT_SIZE_STEP = 1;
+
 export const MAX_CONTRAST = 300;
 export const MIN_CONTRAST = 50;
 export const CONTRAST_STEP = 10;


### PR DESCRIPTION
## Problem

The zoom shortcuts (`Ctrl/Cmd +`, `Ctrl/Cmd -`, `Ctrl/Cmd 0`) only did anything on fixed-layout documents, so they were dead keys in EPUB and MOBI. Reported in #5694 by a reader who drives the app from a small wireless remote and wants to change text size without reaching for the screen.

## Change

Reflowable books have no scale factor to change, but they do have a font size, which is what the font slider already adjusts.

- Zoom in / out step the book's own `defaultFontSize` by 1px, clamped to the 8-120px range Settings > Font already uses.
- Reset Zoom restores the global default font size.
- The write goes through `saveViewSettings(..., skipGlobal)`, so resizing one book never resizes the rest of the library, even for books whose settings scope is still global.
- `zoomLevel` stays at 100 for reflowable documents, because `getStyles` multiplies the font size by it.
- Fixed-layout documents keep the existing `scale-factor` path unchanged.

`Ctrl` + wheel over a reflowable book resizes text too, since it shares the same handler.

## Verification

New unit tests in `useBookShortcuts.test.tsx` cover stepping up and down, pinch-factor scaling, clamping, the reset target, and that the fixed-layout path is untouched. They were written first and fail against the previous code.

A new Playwright web e2e test presses the real shortcuts and reads the computed font size back out of the book iframe. Confirmed it fails with the fix reverted.

Also checked by hand in Chrome against a real library:

| Action | Moby-Dick (EPUB) | 0205857833.pdf (fixed layout) |
| --- | --- | --- |
| open | 16px | scale 79.67 |
| zoom in | 17px | 89.67 |
| zoom in | 18px | 99.67 |
| zoom out | 17px | 89.67 |
| reset | 16px | 100 |

With Moby-Dick left at 20px, opening another EPUB still rendered at 16px, and reloading Moby-Dick still showed 20px: the override is per book and survives a reload.

`pnpm test` (10886 passed), `pnpm lint`, and `pnpm format:check` are clean. No Rust or Lua files touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Zoom shortcuts now adjust font size for reflowable books.
  - Font size increases and decreases in controlled steps, remains within supported limits, and can be reset to the default.
  - Fixed-layout books continue to use scale-based zooming.

- **Tests**
  - Added coverage for zoom shortcuts, font-size limits, repeated adjustments, reset behavior, and fixed-layout zoom handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->