### PR TITLE
fix(annotator): anchor the selection toolbar to the book cell

### DIFF
--- a/apps/readest-app/e2e/tests/annotation.spec.ts
+++ b/apps/readest-app/e2e/tests/annotation.spec.ts
@@ -125,11 +125,26 @@ test.describe('Annotation', () => {
     const layers = await reader.page.evaluate(() => {
       const zIndexOf = (el: Element | null | undefined) =>
         el ? getComputedStyle(el).zIndex : null;
+      // Find each band by what actually makes it one — the nearest ancestor
+      // that sets a z-index — rather than by the wrapper's positioning class.
+      // `div.fixed` used to stand in for that, and it silently stopped
+      // matching the toolbar when its wrapper became `absolute` (it has to
+      // be: the popup's coordinates are book-cell relative, so a fixed
+      // wrapper anchors it to the viewport and drags it off the selection).
+      // Reading the z-index directly pins the bands this test cares about
+      // without caring how either layer is positioned.
+      const layerOf = (el: Element | null | undefined) => {
+        for (let node = el?.parentElement; node; node = node.parentElement) {
+          const z = getComputedStyle(node).zIndex;
+          if (z !== 'auto') return z;
+        }
+        return null;
+      };
       const handle = document.querySelector('[data-testid="selection-handle"]');
       const popup = document.querySelector('.selection-popup');
       return {
-        handles: zIndexOf(handle?.closest('div.fixed')),
-        toolbar: zIndexOf(popup?.closest('div.fixed')),
+        handles: layerOf(handle),
+        toolbar: layerOf(popup),
         // Where the lookup popups and the note editor sheet sit. They unmount
         // the handles, but the layer they share must still outrank them.
         popupLayer: zIndexOf(popup),

--- a/apps/readest-app/src/__tests__/components/annotation-popup-layout.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotation-popup-layout.browser.test.tsx
@@ -221,3 +221,84 @@ describe('AnnotationPopup layout screenshot', () => {
     );
   });
 });
+
+// ── Anchoring ───────────────────────────────────────────────────────────
+
+// The popup is handed coordinates in the coordinate space of the book cell
+// (`#gridcell-<bookKey>`, `position: relative`): Annotator subtracts that
+// cell's rect in getPosition/getPopupPosition. Its own wrapper therefore must
+// not become a viewport-anchored containing block, or the toolbar renders
+// `cell.left` px off the selection — which is what a `fixed inset-0` stacking
+// wrapper did (#6036), visible as soon as the sidebar pushes the cell off the
+// viewport origin.
+const CELL_LEFT = 240;
+const CELL_TOP = 32;
+const ANCHOR = { x: 120, y: 90 };
+
+const renderInCell = (extra?: React.ReactNode) =>
+  render(
+    <div
+      id='gridcell-test'
+      style={{
+        position: 'relative',
+        marginLeft: CELL_LEFT,
+        marginTop: CELL_TOP,
+        width: 500,
+        height: 400,
+      }}
+    >
+      <AnnotationPopup
+        bookKey='test'
+        dir='ltr'
+        isVertical={false}
+        buttons={toolButtons}
+        notes={[]}
+        position={{ dir: 'down', point: ANCHOR }}
+        trianglePosition={{ dir: 'down', point: { x: ANCHOR.x + POPUP_W / 2, y: ANCHOR.y } }}
+        highlightOptionsVisible={false}
+        selectedStyle='highlight'
+        selectedColor='yellow'
+        popupWidth={POPUP_W}
+        popupHeight={POPUP_H}
+        onHighlight={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+      {extra}
+    </div>,
+  );
+
+describe('AnnotationPopup anchoring', () => {
+  it('anchors to the book cell it is positioned against, not the viewport', () => {
+    const { container } = renderInCell();
+    const cell = container.querySelector('#gridcell-test') as HTMLElement;
+    const popup = container.querySelector('#popup-container') as HTMLElement;
+    const cellRect = cell.getBoundingClientRect();
+    const popupRect = popup.getBoundingClientRect();
+    expect({
+      x: Math.round(popupRect.left - cellRect.left),
+      y: Math.round(popupRect.top - cellRect.top),
+    }).toEqual(ANCHOR);
+  });
+
+  it('still yields the pixels it shares with the z-[44] handle layer', () => {
+    const { container } = renderInCell(
+      // Stand-in for SelectionRangeEditor/AnnotationRangeEditor, which draw
+      // their grab handles over the selection the toolbar opens on. Inline
+      // styles, not Tailwind classes: this file is not a Tailwind source.
+      <div style={{ position: 'fixed', inset: 0, zIndex: 44, pointerEvents: 'none' }}>
+        <div
+          data-testid='handle'
+          style={{ position: 'absolute', inset: 0, pointerEvents: 'auto' }}
+        />
+      </div>,
+    );
+    const popupRect = (
+      container.querySelector('#popup-container') as HTMLElement
+    ).getBoundingClientRect();
+    const hit = document.elementFromPoint(
+      popupRect.left + popupRect.width / 2,
+      popupRect.top + popupRect.height / 2,
+    ) as HTMLElement | null;
+    expect(hit?.dataset['testid']).toBe('handle');
+  });
+});

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationPopup.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationPopup.tsx
@@ -84,12 +84,19 @@ const AnnotationPopup: React.FC<AnnotationPopupProps> = ({
     // under the toolbar their covered part stops dragging and fires whichever
     // tool button it landed on instead. Hence z-[43], below the handle layer
     // (z-[44]) but still above the paragraph/TTS chrome (z-40). Every other
-    // popup surface stays at z-50 and above the handles, which is why the
-    // wrapper is `fixed inset-0`: it makes the stacking context without
-    // moving the popup, whose containing block is still the viewport.
-    // `pointer-events-none` keeps the full-screen wrapper from swallowing the
-    // taps outside the popup that dismiss it.
-    <div dir={dir} className='pointer-events-none fixed inset-0 z-[43]'>
+    // popup surface stays at z-50 and above the handles, so the wrapper is
+    // only here to put this one at 43.
+    //
+    // `absolute`, never `fixed`: `position` is in the book cell's coordinate
+    // space (Annotator subtracts `#gridcell-<bookKey>`'s rect), and the cell
+    // is the popup's `relative` ancestor. A fixed wrapper re-anchors the popup
+    // to the viewport, which drops it `cell.left` px to the left of the
+    // selection the moment the cell leaves the viewport origin — sidebar open,
+    // or any book past the first in a split view. Inset to the cell, this
+    // still makes the stacking context without moving anything.
+    // `pointer-events-none` keeps the cell-covering wrapper from swallowing
+    // the taps outside the popup that dismiss it.
+    <div dir={dir} className='pointer-events-none absolute inset-0 z-[43]'>
       <Popup
         width={boxWidth}
         height={boxHeight}


### PR DESCRIPTION
## The bug

The annotation toolbar opened well to the left of the selection, with the
highlight style strip dragged along with it. Regression on `main`, not on
web.readest.com (it is not in v0.12.6).

It only shows when the book cell does not start at the viewport origin, which
is why it is easy to miss: sidebar open, or any book past the first in a split
view. With the sidebar open the toolbar lands 240px off.

## Root cause

#6036 (`88ea2de55`) needed the toolbar in its own stacking band, below the
range handles at `z-[44]`, and wrapped it in `pointer-events-none fixed
inset-0 z-[43]`. The comment claimed the wrapper "makes the stacking context
without moving the popup, whose containing block is still the viewport."

That last part was the wrong premise. `Annotator` computes every popup position
in the **book cell's** coordinate space: `getPosition` / `getPopupPosition`
subtract `#gridcell-<bookKey>`'s rect (`Annotator.tsx:266`), and that cell
(`relative h-full w-full overflow-hidden`, `BooksGrid.tsx:148`) was the popup's
containing block. `fixed` re-anchored it to the viewport, so the toolbar
rendered exactly `gridcell.left` px to the left of the selection.

Measured in Chrome with the sidebar open:

```
gridcell.left            = 240
popup.style.left         = 551.79   (cell-relative, correct)
popup viewport left      = 551.79   (should be 240 + 551.79 = 791.79)
offsetError              = 240.00   <- exactly gridcell.left
```

Only the toolbar was affected. The dictionary, translator and proofread popups
render as a bare `<Popup>` with no wrapper, so they kept the cell as their
containing block. The two range-editor handle layers are right to use `fixed`:
`getHandlePositionsFromRange` returns window coordinates, not cell ones. The
two layers do not share a coordinate space, and that is worth remembering
before touching either.

## The fix

`fixed inset-0` -> `absolute inset-0`. `absolute` + `z-[43]` still creates the
positioned, z-indexed stacking context #6036 needed, but insets to the cell, so
the coordinates land where they were measured. Comment rewritten to record why
it must never go back to `fixed`.

## Tests

New `AnnotationPopup anchoring` block in
`annotation-popup-layout.browser.test.tsx`:

- Renders the popup in a cell offset by (240, 32) and asserts it anchors to the
  cell. Fails on the old code with `{x: -120, y: 58}` against an expected
  `{x: 120, y: 90}`, off by exactly the cell offset.
- Hit-tests #6036's own invariant, so this cannot regress back: the `z-[44]`
  handle layer still wins the pixels it shares with the toolbar.

It has to be a browser test. jsdom has no layout, so it cannot see this class of
bug at all.

## Verification

- `pnpm test:browser` 55 files, 437 passed (includes the popup screenshot
  baselines and the z-order tests)
- `pnpm test` 10897 passed
- `pnpm lint` clean
- `pnpm format:check` clean
- Live in Chrome with the sidebar open: `offsetError: 0`, popup center 883.7
  against selection center 883.65

No `src-tauri/` or koplugin changes, so those gates do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved annotation popup positioning in split views and offset reading layouts.
  - Popups now remain anchored to the correct book cell instead of shifting relative to the viewport.
  - Preserved interaction behavior for annotation handles layered above the popup.

- **Tests**
  - Added regression coverage for popup anchoring and stacking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->