### PR TITLE
fix: guard reader reloads, search views, and sentence navigation

### DIFF
--- a/apps/readest-app/src/__tests__/components/SearchBar.test.tsx
+++ b/apps/readest-app/src/__tests__/components/SearchBar.test.tsx
@@ -8,6 +8,10 @@ const mocks = vi.hoisted(() => ({
   progress: null as { section: { current: number } } | null,
   searchLibraryBooks: vi.fn(),
   viewSearch: vi.fn(),
+  viewAvailable: true,
+  setSearchResults: vi.fn(),
+  setSearchError: vi.fn(),
+  resolveSearchResultCfis: vi.fn(),
   // Stable like the real context value; a fresh object per render would
   // re-fire the [appService, isVisible] effect and double the search.
   appService: { deleteDir: vi.fn().mockResolvedValue(undefined) },
@@ -17,7 +21,7 @@ const mocks = vi.hoisted(() => ({
 // replays resolved results for highlighting.
 vi.mock('@/services/librarySearchService', () => ({
   createLibrarySearchSession: () => ({ close: vi.fn().mockResolvedValue(undefined) }),
-  resolveSearchResultCfis: vi.fn(async () => []),
+  resolveSearchResultCfis: mocks.resolveSearchResultCfis,
   searchLibraryBooks: mocks.searchLibraryBooks,
 }));
 
@@ -40,7 +44,8 @@ vi.mock('@/store/bookDataStore', () => ({
 
 vi.mock('@/store/readerStore', () => ({
   useReaderStore: () => ({
-    getView: () => ({ search: mocks.viewSearch, clearSearch: vi.fn() }),
+    getView: () =>
+      mocks.viewAvailable ? { search: mocks.viewSearch, clearSearch: vi.fn() } : null,
     getProgress: () => mocks.progress,
     getViewSettings: () => ({}),
   }),
@@ -49,9 +54,9 @@ vi.mock('@/store/readerStore', () => ({
 vi.mock('@/store/sidebarStore', () => ({
   useSidebarStore: () => ({
     setSearchTerm: vi.fn(),
-    setSearchResults: vi.fn(),
+    setSearchResults: mocks.setSearchResults,
     setSearchProgress: vi.fn(),
-    setSearchError: vi.fn(),
+    setSearchError: mocks.setSearchError,
     setSearchStatus: vi.fn(),
     getSearchStatus: () => 'searching',
     getSearchNavState: () => ({ searchTerm: 'alice', searchError: null }),
@@ -69,11 +74,18 @@ vi.mock('@/hooks/useResponsiveSize', () => ({
 describe('SearchBar', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    mocks.viewAvailable = true;
     mocks.searchLibraryBooks.mockReset();
     mocks.searchLibraryBooks.mockImplementation(async function* () {
       yield { type: 'book-completed', book: { hash: 'book-hash' }, matchCount: 0 };
     });
     mocks.viewSearch.mockReset();
+    mocks.viewSearch.mockImplementation(async function* () {
+      yield 'done';
+    });
+    mocks.setSearchResults.mockClear();
+    mocks.setSearchError.mockClear();
+    mocks.resolveSearchResultCfis.mockReset().mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -89,9 +101,38 @@ describe('SearchBar', () => {
     });
   };
 
-  // A section-scoped search fired before the first relocate event used to
-  // destructure `section` off a null progress and throw, so the search never
-  // reached the service.
+  it('searches without a mounted reader view', async () => {
+    mocks.viewAvailable = false;
+    await renderBar();
+    expect(mocks.searchLibraryBooks).toHaveBeenCalledTimes(1);
+    expect(mocks.viewSearch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [false, false],
+    [false, true],
+    [true, false],
+  ])('keeps results when view availability changes from %s to %s', async (initial, final) => {
+    mocks.viewAvailable = initial;
+    mocks.resolveSearchResultCfis.mockResolvedValue([{ cfi: 'test-cfi' }]);
+    mocks.searchLibraryBooks.mockImplementation(async function* () {
+      yield {
+        type: 'result',
+        result: { index: 0, label: 'Chapter', subitems: [{ locator: {}, excerpt: 'Match' }] },
+      };
+      mocks.viewAvailable = final;
+      yield { type: 'book-completed', book: { hash: 'book-hash' }, matchCount: 1 };
+    });
+
+    await renderBar();
+
+    expect(mocks.setSearchResults).toHaveBeenLastCalledWith('book-1', [
+      { index: 0, label: 'Chapter', subitems: [{ cfi: 'test-cfi', excerpt: 'Match' }] },
+    ]);
+    expect(mocks.viewSearch).toHaveBeenCalledTimes(final ? 1 : 0);
+    expect(mocks.setSearchError).toHaveBeenLastCalledWith('book-1', null);
+  });
+
   it('searches the whole book when progress is not available yet', async () => {
     mocks.progress = null;
     await renderBar();

--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -1080,6 +1080,65 @@ describe('TTSController', () => {
   // "End of Chapter" sleep-timer mode. The distinction under test is auto
   // continuation vs. a deliberate user skip: both land on the same
   // cross-section path in forward(), but only the former may stop there.
+  describe('mark navigation before playback', () => {
+    test.each([
+      ['forward', 'Third sentence.'],
+      ['backward', 'First sentence.'],
+    ] as const)('%s preserves the current paragraph before stepping', async (direction, expected) => {
+      await controller.initViewTTS(0);
+      const { TTS } =
+        await vi.importActual<typeof import('foliate-js/tts.js')>('foliate-js/tts.js');
+      const { textWalker } = await vi.importActual<typeof import('foliate-js/text-walker.js')>(
+        'foliate-js/text-walker.js',
+      );
+      const doc = document.implementation.createHTMLDocument();
+      doc.body.innerHTML = '<p>First sentence.</p><p>Second sentence.</p><p>Third sentence.</p>';
+      const tts = new TTS(doc, textWalker, () => NodeFilter.FILTER_ACCEPT, vi.fn(), 'sentence');
+      tts.start();
+      const ssml = tts.next()!;
+      const mark = new DOMParser().parseFromString(ssml, 'application/xml').querySelector('mark')!;
+      tts.setMark(mark.getAttribute('name')!);
+      mockView.tts = tts;
+
+      await controller[direction](true);
+
+      expect(tts.getLastRange()?.toString()).toBe(expected);
+    });
+
+    test.each([
+      'forward',
+      'backward',
+    ] as const)('%s initializes a fresh text iterator', async (direction) => {
+      await controller.initViewTTS(0);
+      const { TTS } =
+        await vi.importActual<typeof import('foliate-js/tts.js')>('foliate-js/tts.js');
+      const { textWalker } = await vi.importActual<typeof import('foliate-js/text-walker.js')>(
+        'foliate-js/text-walker.js',
+      );
+      const doc = document.implementation.createHTMLDocument();
+      doc.body.innerHTML = '<p>First sentence.</p><p>Second sentence.</p>';
+      mockView.tts = new TTS(doc, textWalker, () => NodeFilter.FILTER_ACCEPT, vi.fn(), 'sentence');
+
+      await expect(controller[direction](true)).resolves.toBeUndefined();
+    });
+
+    test.each([
+      'forward',
+      'backward',
+    ] as const)('%s handles a section without readable text', async (direction) => {
+      await controller.initViewTTS(0);
+      const { TTS } =
+        await vi.importActual<typeof import('foliate-js/tts.js')>('foliate-js/tts.js');
+      const { textWalker } = await vi.importActual<typeof import('foliate-js/text-walker.js')>(
+        'foliate-js/text-walker.js',
+      );
+      const doc = document.implementation.createHTMLDocument();
+      mockView.tts = new TTS(doc, textWalker, () => NodeFilter.FILTER_ACCEPT, vi.fn(), 'sentence');
+
+      await expect(controller[direction](true)).resolves.toBeUndefined();
+    });
+  });
+
   describe('stopAtChapterEnd', () => {
     // Park on the last paragraph of the section: both cursors run dry, so
     // forward() falls through to the cross-section branch.

--- a/apps/readest-app/src/__tests__/store/reader-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/reader-store.test.ts
@@ -331,6 +331,18 @@ describe('readerStore', () => {
   });
 
   describe('recreateViewer', () => {
+    test.each(['', 'closed-book'])('does not reload a missing viewer (%s)', (key) => {
+      const initViewState = vi.fn().mockResolvedValue(undefined);
+      const original = useReaderStore.getState().initViewState;
+      useReaderStore.setState({ initViewState });
+      try {
+        useReaderStore.getState().recreateViewer({} as never, key);
+        expect(initViewState).not.toHaveBeenCalled();
+      } finally {
+        useReaderStore.setState({ initViewState: original });
+      }
+    });
+
     // Regression test for #5277: `initViewState` already mints a fresh
     // viewerKey, so minting a second one here remounted <FoliateViewer> twice.
     // The abandoned first mount kept opening the same bookDoc and left an extra

--- a/apps/readest-app/src/__tests__/store/reader-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/reader-store.test.ts
@@ -343,6 +343,23 @@ describe('readerStore', () => {
       }
     });
 
+    test.each([
+      { key: '', loading: true, error: null },
+      { key: '', loading: false, error: 'Failed to load book.' },
+      { key: 'another-book', loading: false, error: null },
+    ])('does not reload an invalid stored view: %j', (viewState) => {
+      seedViewState('book-1', viewState);
+      const initViewState = vi.fn().mockResolvedValue(undefined);
+      const original = useReaderStore.getState().initViewState;
+      useReaderStore.setState({ initViewState });
+      try {
+        useReaderStore.getState().recreateViewer({} as never, 'book-1');
+        expect(initViewState).not.toHaveBeenCalled();
+      } finally {
+        useReaderStore.setState({ initViewState: original });
+      }
+    });
+
     // Regression test for #5277: `initViewState` already mints a fresh
     // viewerKey, so minting a second one here remounted <FoliateViewer> twice.
     // The abandoned first mount kept opening the same bookDoc and left an extra

--- a/apps/readest-app/src/app/reader/components/sidebar/SearchBar.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/SearchBar.tsx
@@ -97,7 +97,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ isVisible, bookKey, onHideSearchB
     localStorage.removeItem(historyStorageKey);
   };
 
-  const view = getView(bookKey)!;
+  const view = getView(bookKey);
   // Reader search runs against the same per-book search.db the library page
   // uses; the session caches the opened book and index handle across queries.
   const searchSessionRef = useRef<LibrarySearchSession | null>(null);
@@ -206,7 +206,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ isVisible, bookKey, onHideSearchB
       setSearchProgress(bookKey, 0);
       setSearchStatus(bookKey, 'searching');
       setSearchError(bookKey, null);
-      view.clearSearch();
+      getView(bookKey)?.clearSearch();
 
       // progress is null until the book emits its first relocate event, so a
       // search fired right after opening has no current section to scope to.
@@ -288,8 +288,9 @@ const SearchBar: React.FC<SearchBarProps> = ({ isVisible, bookKey, onHideSearchB
 
         // Replay the resolved matches through the view so every CFI gets its
         // search highlight; the view does no searching of its own here.
-        if (!stopped() && results.length > 0) {
-          for await (const item of view.search({ ...searchConfig, query: term, results })) {
+        const currentView = getView(bookKey);
+        if (!stopped() && currentView && results.length > 0) {
+          for await (const item of currentView.search({ ...searchConfig, query: term, results })) {
             if (stopped()) return;
             if (item === 'done') break;
           }
@@ -310,6 +311,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ isVisible, bookKey, onHideSearchB
       bookData,
       appService,
       getConfig,
+      getView,
       setSearchResults,
       setSearchProgress,
       setSearchError,

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -1699,7 +1699,14 @@ export class TTSController extends EventTarget {
     await this.stop(isPlaying);
     if (!isPlaying) this.state = 'backward-paused';
 
-    const ssml = byMark ? this.#getTts()?.prevMark(!isPlaying) : this.#getTts()?.prev(!isPlaying);
+    const tts = this.#getTts();
+    // Mark navigation needs a current paragraph. resume() positions a fresh
+    // iterator without resetting an existing position; empty sections return no SSML.
+    const ssml = byMark
+      ? tts?.resume()
+        ? tts.prevMark(!isPlaying)
+        : undefined
+      : tts?.prev(!isPlaying);
     if (!ssml) {
       await this.#handleNavigationWithoutSSML(() => this.#initTTSForPrevSection(), isPlaying);
     } else {
@@ -1728,7 +1735,14 @@ export class TTSController extends EventTarget {
     await this.stop(isPlaying);
     if (!isPlaying) this.state = 'forward-paused';
 
-    const ssml = byMark ? this.#getTts()?.nextMark(!isPlaying) : this.#getTts()?.next(!isPlaying);
+    const tts = this.#getTts();
+    // Mark navigation needs a current paragraph. resume() positions a fresh
+    // iterator without resetting an existing position; empty sections return no SSML.
+    const ssml = byMark
+      ? tts?.resume()
+        ? tts.nextMark(!isPlaying)
+        : undefined
+      : tts?.next(!isPlaying);
     if (!ssml) {
       if (isAutoAdvance && isPlaying && this.stopAtChapterEnd) {
         return await this.#stopAtChapterBoundary();

--- a/apps/readest-app/src/store/readerStore.ts
+++ b/apps/readest-app/src/store/readerStore.ts
@@ -563,6 +563,7 @@ export const useReaderStore = create<ReaderStore>((set, get) => ({
     })),
 
   recreateViewer: (envConfig: EnvConfigType, key: string) => {
+    if (!key || !get().viewStates[key]) return;
     const id = key.split('-')[0]!;
     // `initViewState` already mints a fresh `viewerKey` when the reload lands,
     // which is what remounts <FoliateViewer>. Minting a second one here

--- a/apps/readest-app/src/store/readerStore.ts
+++ b/apps/readest-app/src/store/readerStore.ts
@@ -563,7 +563,7 @@ export const useReaderStore = create<ReaderStore>((set, get) => ({
     })),
 
   recreateViewer: (envConfig: EnvConfigType, key: string) => {
-    if (!key || !get().viewStates[key]) return;
+    if (!key || get().viewStates[key]?.key !== key) return;
     const id = key.split('-')[0]!;
     // `initViewState` already mints a fresh `viewerKey` when the reload lands,
     // which is what remounts <FoliateViewer>. Minting a second one here


### PR DESCRIPTION
Three reader lifecycle errors could reject without handling: settings tried to recreate a viewer when no book was open, search assumed a mounted view, and sentence navigation accessed an unpositioned text iterator.

- [READEST-1SC](https://readest.sentry.io/issues/READEST-1SC): skip viewer recreation for empty or closed book keys. Normal book reloads still run.
- [READEST-1D](https://readest.sentry.io/issues/READEST-1D): allow indexed search without a mounted view and look up the current view when clearing or replaying highlights. Keep results if the view disappears during the scan.
- [READEST-240](https://readest.sentry.io/issues/READEST-240): position the current TTS paragraph before forward/backward sentence navigation. Preserve an existing position and handle sections without readable text.

All fixes are in application code; no dependency patches or dependency changes.

Validation: full Vitest suite passed (903 files, 10,918 tests; 4 files and 16 tests skipped). Formatting, TypeScript, and lint passed.

Regression tests reproduced the failures before the fixes, including the real Foliate TTS iterator. Additional tests cover retained sentence position and search results across view appearance/disappearance. Independent review found no remaining issues; no documentation changes needed.

Sentry issues remain open for post-release verification. The reload guard addresses the empty/closed-view path in READEST-1SC, not every possible missing-book failure. React update-depth errors and the Android window-plugin rejection need further investigation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search behavior when no reader view is mounted, while preserving results as view availability changes.
  - Fixed text-to-speech navigation before playback begins, including empty sections and moving between sections.
  - Prevented unnecessary reader reloads when reopening unavailable or closed content.
- **Tests**
  - Added regression coverage for search, text-to-speech mark navigation, and reader view recreation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->