### PR TITLE
fix: await PDF destinations for TTS download chapters

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useTTSDownloads.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTTSDownloads.test.tsx
@@ -63,6 +63,82 @@ describe('useTTSDownloads', () => {
     useTTSDownloadStore.setState({ items: {} });
   });
 
+  test('awaits asynchronous PDF chapter destinations and skips rejected links', async () => {
+    const controller = makeController(() => new Map());
+    Object.assign(controller.view, {
+      book: { sections: [{}, {}, {}] },
+      resolveNavigation: async (href: string) => {
+        const index = JSON.parse(href) as number;
+        return { index };
+      },
+    });
+    mocks.getBookData.mockReturnValue({
+      bookDoc: {
+        toc: [
+          { label: 'First', href: '0' },
+          { label: 'Broken', href: '' },
+          { label: 'Last', href: '2' },
+        ],
+      },
+    });
+    const getController = () => controller;
+    const { result } = renderHook(() => useTTSDownloads('bookhash', getController, false));
+
+    await waitFor(() =>
+      expect(result.current.chapters.map((c) => [c.label, c.startSection, c.endSection])).toEqual([
+        ['First', 0, 2],
+        ['Last', 2, 3],
+      ]),
+    );
+  });
+
+  test('falls back to section rows when every asynchronous destination fails', async () => {
+    const controller = makeController(() => new Map());
+    Object.assign(controller.view, {
+      resolveNavigation: async () => {
+        throw new Error('Invalid destination');
+      },
+    });
+    mocks.getBookData.mockReturnValue({ bookDoc: { toc: [{ label: 'Broken', href: '' }] } });
+    const { result } = renderHook(() => useTTSDownloads('bookhash', () => controller, false));
+    await waitFor(() =>
+      expect(result.current.chapters[0]).toMatchObject({
+        key: 'section-0',
+        startSection: 0,
+        endSection: 1,
+      }),
+    );
+    await act(async () => {});
+  });
+
+  test('does not publish chapter destinations from a previous book', async () => {
+    const oldController = makeController(() => new Map());
+    const newController = makeController(() => new Map());
+    let finishOld: (value: { index: number }) => void = () => {};
+    Object.assign(oldController.view, {
+      resolveNavigation: () =>
+        new Promise<{ index: number }>((resolve) => {
+          finishOld = resolve;
+        }),
+    });
+    Object.assign(newController.view, { resolveNavigation: async () => ({ index: 0 }) });
+    mocks.getBookData.mockImplementation((key: string) => ({
+      bookDoc: { toc: [{ label: key, href: '0' }] },
+    }));
+    const { result, rerender } = renderHook(
+      ({ key, controller }) => useTTSDownloads(key, () => controller, false),
+      { initialProps: { key: 'old', controller: oldController } },
+    );
+    rerender({ key: 'new', controller: newController });
+    await waitFor(() => expect(result.current.chapters[0]?.label).toBe('new'));
+
+    await act(async () => {
+      finishOld({ index: 0 });
+    });
+
+    expect(result.current.chapters[0]?.label).toBe('new');
+  });
+
   test('uses the stable book hash for persisted rows and every manager operation', async () => {
     const controller = makeController(() => new Map());
     const getController = () => controller;
@@ -85,6 +161,7 @@ describe('useTTSDownloads', () => {
       expect(mocks.attachController).toHaveBeenCalledWith('bookhash', getController),
     );
     expect(result.current.items).toHaveLength(1);
+    await waitFor(() => expect(result.current.chapters).toHaveLength(1));
 
     act(() => result.current.downloadChapter(result.current.chapters[0]!));
     expect(mocks.queueChapter).toHaveBeenCalledWith('bookhash', result.current.chapters[0]);
@@ -116,6 +193,7 @@ describe('useTTSDownloads', () => {
 
     const { result } = renderHook(() => useTTSDownloads('bookhash', getController, true));
     await waitFor(() => expect(controller.getSectionCacheStatuses).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.chapters).toHaveLength(1));
     expect(result.current.statusOf(result.current.chapters[0]!)).toBe('none');
 
     statuses = new Map([[0, { total: 1, recorded: 1, packed: true, pinned: true, active: false }]]);

--- a/apps/readest-app/src/__tests__/services/tts-download-chapters.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-download-chapters.test.ts
@@ -16,8 +16,8 @@ const resolver = (map: Record<string, number>) => (href: string) =>
   href in map ? map[href]! : null;
 
 describe('deriveDownloadChapters', () => {
-  test('one chapter per TOC entry, spanning to the next chapter section', () => {
-    const chapters = deriveDownloadChapters(
+  test('one chapter per TOC entry, spanning to the next chapter section', async () => {
+    const chapters = await deriveDownloadChapters(
       [toc('One', 'a'), toc('Two', 'b'), toc('Three', 'c')],
       resolver({ a: 0, b: 2, c: 4 }),
       6,
@@ -29,8 +29,8 @@ describe('deriveDownloadChapters', () => {
     ]);
   });
 
-  test('flattens nested subitems in reading order', () => {
-    const chapters = deriveDownloadChapters(
+  test('flattens nested subitems in reading order', async () => {
+    const chapters = await deriveDownloadChapters(
       [toc('Part I', 'p1', [toc('Ch 1', 'c1'), toc('Ch 2', 'c2')]), toc('Part II', 'p2')],
       resolver({ p1: 0, c1: 1, c2: 2, p2: 3 }),
       4,
@@ -43,8 +43,8 @@ describe('deriveDownloadChapters', () => {
     ]);
   });
 
-  test('collapses consecutive entries that resolve to the same section', () => {
-    const chapters = deriveDownloadChapters(
+  test('collapses consecutive entries that resolve to the same section', async () => {
+    const chapters = await deriveDownloadChapters(
       [toc('Heading', 'h'), toc('Subheading', 'h#frag'), toc('Next', 'n')],
       resolver({ h: 1, 'h#frag': 1, n: 3 }),
       5,
@@ -55,8 +55,8 @@ describe('deriveDownloadChapters', () => {
     ]);
   });
 
-  test('a chapter that spans several TOC-less sections covers all of them', () => {
-    const chapters = deriveDownloadChapters(
+  test('a chapter that spans several TOC-less sections covers all of them', async () => {
+    const chapters = await deriveDownloadChapters(
       [toc('One', 'a'), toc('Two', 'b')],
       resolver({ a: 0, b: 5 }),
       8,
@@ -65,8 +65,8 @@ describe('deriveDownloadChapters', () => {
     expect(chapters[1]).toMatchObject({ startSection: 5, endSection: 8 });
   });
 
-  test('falls back to one row per section when there is no usable TOC', () => {
-    const chapters = deriveDownloadChapters([], resolver({}), 3);
+  test('falls back to one row per section when there is no usable TOC', async () => {
+    const chapters = await deriveDownloadChapters([], resolver({}), 3);
     expect(chapters).toEqual([
       { key: 'section-0', label: 'Section 1', depth: 0, startSection: 0, endSection: 1 },
       { key: 'section-1', label: 'Section 2', depth: 0, startSection: 1, endSection: 2 },
@@ -74,8 +74,8 @@ describe('deriveDownloadChapters', () => {
     ]);
   });
 
-  test('drops entries whose href does not resolve', () => {
-    const chapters = deriveDownloadChapters(
+  test('drops entries whose href does not resolve', async () => {
+    const chapters = await deriveDownloadChapters(
       [toc('Good', 'a'), toc('Broken', 'x'), toc('Also good', 'c')],
       resolver({ a: 0, c: 2 }),
       4,

--- a/apps/readest-app/src/app/reader/hooks/useTTSDownloads.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSDownloads.ts
@@ -43,6 +43,7 @@ export const useTTSDownloads = (
 ): UseTTSDownloadsResult => {
   const _ = useTranslation();
   const { getBookData } = useBookDataStore();
+  const [chapters, setChapters] = useState<DownloadChapter[]>([]);
   const [statuses, setStatuses] = useState<Map<number, SectionCacheStatus>>(new Map());
   const [cacheBytes, setCacheBytes] = useState(0);
   const [clearing, setClearing] = useState(false);
@@ -68,24 +69,32 @@ export const useTTSDownloads = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [supported, bookHash]);
 
-  const chapters = useMemo(() => {
-    if (!controller) return [];
+  useEffect(() => {
+    let cancelled = false;
+    setChapters([]);
+    if (!controller) return;
     const toc = getBookData(bookKey)?.bookDoc?.toc ?? [];
     const view = controller.view;
     const sectionCount = view?.book?.sections?.length ?? 0;
-    if (!sectionCount) return [];
-    return deriveDownloadChapters(
+    if (!sectionCount) return;
+    // PDF destinations resolve asynchronously; never start this work during render.
+    void deriveDownloadChapters(
       toc,
-      (href) => {
+      async (href) => {
         try {
-          return view.resolveNavigation(href)?.index ?? null;
+          return (await view.resolveNavigation(href))?.index ?? null;
         } catch {
           return null;
         }
       },
       sectionCount,
       (n) => _('Section {{index}}', { index: n }),
-    );
+    ).then((nextChapters) => {
+      if (!cancelled) setChapters(nextChapters);
+    });
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bookKey, controller, isOpen]);
 

--- a/apps/readest-app/src/services/tts/downloadChapters.ts
+++ b/apps/readest-app/src/services/tts/downloadChapters.ts
@@ -37,13 +37,13 @@ const flatten = (
   }
 };
 
-export const deriveDownloadChapters = (
+export const deriveDownloadChapters = async (
   toc: TOCItem[],
-  resolveSection: (href: string) => number | null,
+  resolveSection: (href: string) => number | null | Promise<number | null>,
   sectionCount: number,
   // User-facing label for TOC-less sections; the component injects i18n.
   sectionLabel: (oneBasedIndex: number) => string = (n) => `Section ${n}`,
-): DownloadChapter[] => {
+): Promise<DownloadChapter[]> => {
   const flat: { label: string; href: string; depth: number }[] = [];
   flatten(toc ?? [], 0, flat);
 
@@ -52,7 +52,7 @@ export const deriveDownloadChapters = (
   const seen = new Set<number>();
   const anchors: { key: string; label: string; depth: number; startSection: number }[] = [];
   for (const entry of flat) {
-    const section = resolveSection(entry.href);
+    const section = await resolveSection(entry.href);
     if (section === null || section < 0 || section >= sectionCount) continue;
     if (seen.has(section)) continue;
     seen.add(section);


### PR DESCRIPTION
Opening Read Aloud on a PDF could trigger an unhandled JSON rejection while building the download chapter list ([READEST-4R9](https://readest.sentry.io/issues/READEST-4R9)). PDF destinations resolve asynchronously, but the render-time callback read `.index` synchronously: valid destinations lost their labels, and rejected destinations escaped its try/catch.

Await destination resolution in an effect and build the chapter list asynchronously. Invalid links are skipped, an entirely unusable TOC still falls back to section rows, and results from a previous book or closed effect cannot overwrite the current list. Existing synchronous ebook destinations remain supported.

All changes are in application code. No dependency changes or library patches.

Validation: formatting, TypeScript, and lint passed. Full Vitest suite: 903 files and 10,924 tests passed; 4 files and 16 tests skipped. Independent review found no remaining issues.

Regression tests reproduced the JSON rejection and incorrect fallback before the fix. Coverage includes asynchronous valid/broken destinations, all-invalid fallback, late results after switching books, and the existing synchronous chapter grouping cases.

Sentry remains open for post-release verification. React update-depth issues and READEST-10K were also investigated; this PR does not claim to fix them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text-to-speech chapter detection for PDF books with asynchronously resolved destinations.
  - Added graceful handling for unavailable or rejected PDF links, including fallback to available section information.
  - Prevented chapter results from a previously opened book from appearing in the current book.
  - Chapter lists now reset while updated results are being discovered, reducing stale or incorrect download options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->