### PR TITLE
fix: skip desktop fullscreen commands on mobile

### DIFF
--- a/apps/readest-app/src/__tests__/utils/window.test.ts
+++ b/apps/readest-app/src/__tests__/utils/window.test.ts
@@ -138,6 +138,24 @@ function makeFullscreenWindow({
 }
 
 describe('tauriHandleToggleFullScreen', () => {
+  test.each([
+    'android',
+    'ios',
+  ] as const)('does not invoke desktop fullscreen commands on %s', async (platform) => {
+    vi.mocked(osType).mockReturnValue(platform);
+    const win = makeFullscreenWindow({ isFullscreen: false, isMaximized: false });
+    win.isFullscreen.mockRejectedValue(new Error('Plugin window not initialized'));
+    vi.mocked(getCurrentWindow).mockReturnValue(
+      win as unknown as ReturnType<typeof getCurrentWindow>,
+    );
+
+    await expect(tauriHandleToggleFullScreen()).resolves.toBeUndefined();
+
+    expect(getCurrentWindow).not.toHaveBeenCalled();
+    expect(win.isFullscreen).not.toHaveBeenCalled();
+    expect(win.setFullscreen).not.toHaveBeenCalled();
+  });
+
   test('enters fullscreen when the window is maximized (Phosh / Windows-maximized case)', async () => {
     // On Phosh the window is always maximized, and on Windows users often run
     // maximized. The fullscreen button must still enter fullscreen instead of

--- a/apps/readest-app/src/utils/window.ts
+++ b/apps/readest-app/src/utils/window.ts
@@ -90,6 +90,11 @@ export const tauriHandleOnCloseWindow = async (callback: () => void) => {
 let wasMaximizedBeforeFullscreen = false;
 
 export const tauriHandleToggleFullScreen = async () => {
+  // Reader/library shortcuts also run on mobile, where Tauri does not
+  // register the desktop fullscreen commands (READEST-10K).
+  const platform = await osType();
+  if (platform === 'android' || platform === 'ios') return;
+
   const currentWindow = getCurrentWindow();
   const isFullscreen = await currentWindow.isFullscreen();
   // Toggle fullscreen regardless of the maximized state. Previously a maximized
@@ -109,14 +114,13 @@ export const tauriHandleToggleFullScreen = async () => {
     // Unmaximize first and restore the maximized state on exit. Other
     // platforms must keep entering fullscreen straight from the maximized
     // state (Phosh windows are always maximized).
-    wasMaximizedBeforeFullscreen =
-      (await osType()) === 'windows' && (await currentWindow.isMaximized());
+    wasMaximizedBeforeFullscreen = platform === 'windows' && (await currentWindow.isMaximized());
     if (wasMaximizedBeforeFullscreen) {
       await currentWindow.unmaximize();
     }
     await currentWindow.setFullscreen(true);
   }
-  if ((await osType()) === 'linux') {
+  if (platform === 'linux') {
     linuxWindowRestoreTransparentBg();
   }
 };


### PR DESCRIPTION
Fullscreen shortcuts in the reader and library run on Android/iOS because their callers only check for Tauri. The shared helper then invokes `is_fullscreen`, which Tauri registers only on desktop; on Android this can reject with `Plugin window not initialized`.

Skip native fullscreen operations on Android/iOS before accessing the window API. Keep the existing Windows maximize/restore and Linux fullscreen behavior. This is an application-code fix with no dependency changes.

Related: [READEST-10K](https://readest.sentry.io/issues/READEST-10K). This fixes a reachable unsupported-command path; the stackless Sentry events do not establish that it explains all occurrences. Leave release verification pending.

Validation: both new mobile regression cases failed before the fix. Focused window and reader-shortcut tests pass (35 tests). Formatting, TypeScript/Biome, and the full unit suite passed (10,926 tests; 16 skipped). Independent review found no actionable issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fullscreen toggle behavior on Android and iOS by avoiding unsupported desktop fullscreen operations.
  * Preserved existing Windows maximized-state handling and Linux display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->