### PR TITLE
fix(tts): stop a redundant PDF render detaching the ranges TTS reads

### DIFF
--- a/apps/readest-app/src/__tests__/foliate-pdf-redundant-render.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-pdf-redundant-render.test.ts
@@ -1,0 +1,193 @@
+// readest/readest issue #6071: a redundant PDF re-render detaches the live TTS ranges.
+//
+// Every PDF render tears the text layer down (`container.replaceChildren()`) and
+// builds it again. fixed-layout's `#observer = new ResizeObserver(() => this.#render())`
+// re-renders on any layout change -- including the one a page turn itself causes --
+// and discards the render promises, so a second render lands ~130ms after the first
+// with nothing about the output changed.
+//
+// By then TTSController has already built its `TTS` over the first render's text
+// layer and materialised the sentence `Range`s. The second `replaceChildren()`
+// detaches every node those ranges point at, so the blocks yield empty text: TTS
+// skips paragraphs, nothing highlights, and a page whose blocks are all empty makes
+// the controller advance -- the reported "one paragraph per page" loop.
+//
+// Traced on a Xiaomi 2211133C (Android 16, Readest 0.12.6): every page was wiped
+// exactly twice, ~130ms apart, at an identical scale and host box.
+//
+// `render` must therefore skip the rebuild when nothing that affects its output
+// (the page, the zoom, the page colours, the OS font scale) has changed.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Text of the page the fake pdf.js text layer builds, one span per entry.
+const PAGE_TEXT = ['Magnus Pym got out of his elderly country taxicab. ', 'No one to flap about.'];
+
+// Counts how many times a text layer was actually built.
+let textLayerBuilds = 0;
+
+vi.mock('@pdfjs/pdf.min.mjs', () => {
+  class PDFDataRangeTransport {
+    requestDataRange!: (begin: number, end: number) => void;
+    onDataRange = vi.fn();
+    constructor(
+      public length: number,
+      public initialData: unknown,
+    ) {}
+  }
+
+  // Stands in for pdfjsLib.TextLayer: fills the container the way the real one
+  // does, so the test can hold a node from it and check it stays connected.
+  class TextLayer {
+    #container: HTMLElement;
+    constructor({ container }: { container: HTMLElement }) {
+      this.#container = container;
+    }
+    async render() {
+      textLayerBuilds++;
+      for (const str of PAGE_TEXT) {
+        const span = this.#container.ownerDocument.createElement('span');
+        span.textContent = str;
+        this.#container.append(span);
+      }
+    }
+  }
+
+  class AnnotationLayer {
+    async render() {}
+  }
+
+  const makePage = () => ({
+    getViewport: ({ scale }: { scale: number }) => ({ width: 600 * scale, height: 800 * scale }),
+    render: () => ({ promise: Promise.resolve(), cancel: vi.fn() }),
+    streamTextContent: vi.fn(async () => ({})),
+    getTextContent: vi.fn(async () => ({ items: [] })),
+    getAnnotations: vi.fn(async () => []),
+    cleanup: vi.fn(),
+  });
+
+  const getDocument = vi.fn(() => ({
+    promise: Promise.resolve({
+      numPages: 3,
+      getPage: vi.fn(async () => makePage()),
+      getMetadata: vi.fn(async () => ({ metadata: undefined, info: {} })),
+      getViewerPreferences: vi.fn(async () => null),
+      getOutline: vi.fn(async () => null),
+      getPageLabels: vi.fn(async () => null),
+      getDestination: vi.fn(),
+      getPageIndex: vi.fn(),
+      destroy: vi.fn(),
+    }),
+    destroy: vi.fn(),
+  }));
+
+  (globalThis as unknown as { pdfjsLib: unknown }).pdfjsLib = {
+    GlobalWorkerOptions: {},
+    PDFDataRangeTransport,
+    getDocument,
+    TextLayer,
+    AnnotationLayer,
+  };
+  return {};
+});
+
+const fakeFile = {
+  size: 1,
+  slice: () => ({ arrayBuffer: async () => new ArrayBuffer(0) }),
+} as unknown as File;
+
+type OnZoom = (opts: {
+  doc: Document;
+  scale: number;
+  pageColors?: { background: string; foreground: string };
+}) => Promise<void> | void;
+
+interface PdfBook {
+  sections: { load: () => Promise<{ onZoom: OnZoom }> }[];
+}
+
+// The DOM `renderPage`'s blob document gives each page's iframe. It has to be a
+// real iframe document: `render` bails on a document with no `defaultView`.
+const frames: HTMLIFrameElement[] = [];
+const makePageDocument = () => {
+  const frame = document.createElement('iframe');
+  document.body.append(frame);
+  frames.push(frame);
+  const doc = frame.contentDocument!;
+  for (const [tag, attr, value] of [
+    ['div', 'id', 'canvas'],
+    ['div', 'class', 'textLayer'],
+    ['div', 'class', 'annotationLayer'],
+  ] as const) {
+    const el = doc.createElement(tag);
+    el.setAttribute(attr, value);
+    doc.body.append(el);
+  }
+  return doc;
+};
+
+const openFirstPage = async () => {
+  const { makePDF } = await import('foliate-js/pdf.js');
+  const book = (await makePDF(fakeFile)) as unknown as PdfBook;
+  const { onZoom } = await book.sections[0]!.load();
+  return { onZoom, doc: makePageDocument() };
+};
+
+beforeEach(() => {
+  textLayerBuilds = 0;
+  // jsdom has no 2d context; `render` only hands it to page.render(), which the
+  // fake pdf.js ignores. Stub it so the run stays free of jsdom "Not implemented".
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+    {} as unknown as CanvasRenderingContext2D,
+  );
+  // renderPage fetches the pdf.js viewer stylesheets before building the blob.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ text: async () => '' })),
+  );
+  vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:page');
+  vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  for (const frame of frames.splice(0)) frame.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('PDF re-render (#6071)', () => {
+  it('leaves the text layer alone when nothing affecting the render changed', async () => {
+    const { onZoom, doc } = await openFirstPage();
+
+    await onZoom({ doc, scale: 0.9424859427009213 });
+    const spoken = doc.querySelector('.textLayer')!.firstChild!;
+    expect(spoken.textContent).toBe(PAGE_TEXT[0]);
+
+    // The ResizeObserver's second render, same page, same scale, same colours.
+    await onZoom({ doc, scale: 0.9424859427009213 });
+
+    // A TTS Range anchored in the first render must survive: a detached node
+    // yields empty text, which is what makes TTS skip the paragraph.
+    expect(spoken.isConnected).toBe(true);
+    expect(textLayerBuilds).toBe(1);
+  });
+
+  it('rebuilds the text layer when the zoom changes', async () => {
+    const { onZoom, doc } = await openFirstPage();
+
+    await onZoom({ doc, scale: 1 });
+    await onZoom({ doc, scale: 2 });
+
+    expect(textLayerBuilds).toBe(2);
+    expect(doc.querySelector('.textLayer')!.textContent).toContain(PAGE_TEXT[0]!.trim());
+  });
+
+  it('rebuilds the text layer when the page colours change', async () => {
+    const { onZoom, doc } = await openFirstPage();
+
+    await onZoom({ doc, scale: 1, pageColors: { background: '#fff', foreground: '#000' } });
+    await onZoom({ doc, scale: 1, pageColors: { background: '#000', foreground: '#fff' } });
+
+    expect(textLayerBuilds).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #6071. Depends on readest/foliate-js#91 (pinned here at `8481b9a`; needs a re-pin once that merges).

## The bug

Read Aloud on a PDF skipped most paragraphs, highlighted nothing, and once a page came back fully empty it read one paragraph, turned the page, and looped that way to the end of the book. Reported on iOS; it is shared web code and reproduces everywhere.

## Root cause

Each PDF page is rendered **twice** per page turn:

1. The awaited render, from `forward()` → `#initTTSForSection` → `onSectionChange` → `renderer.goTo` → `goToSpread` → `#render` → pdf `render()`.
2. `#initTTSForSection` then builds `new TTS(doc, …)` over that text layer and materialises its sentence `Range`s.
3. ~130 ms later `fixed-layout.js`'s `#observer = new ResizeObserver(() => this.#render())` fires — the page turn changed layout — and re-renders the same page. It discards the `renderPromises` array that `#render()` returns for exactly this purpose (`fixed-layout.js:808-809` awaits it properly).
4. `pdf.js`'s `container.replaceChildren()` runs again and detaches every node those ranges point at.

The blocks then yield empty text, which `TTSController.ts:1498-1520` skips; `#nossmlCnt` resets on every non-empty block (line 1522), so the 10-strike stop at line 1500 never trips and it runs to the end of the book. Dead ranges also explain the missing highlight — there is nothing left to anchor to.

## The fix

foliate-js skips a render when the page, zoom, page colours and OS font scale are all unchanged (readest/foliate-js#91). Fixing it there rather than in the `ResizeObserver` protects the text layer from *every* redundant render trigger, and skips the rasterisation too.

## Verification

- **New unit test** — a node captured from the first render must still be `isConnected` after an identical second `onZoom`. Red before the fix, green after, plus guard-rails that a zoom change and a `pageColors` change still rebuild. Needs a real iframe document: `render` bails on `document.implementation.createHTMLDocument` because `defaultView` is null.
- **Browser A/B on the real bundle** — unfixed, every page wiped twice with identical content (`had=2368` → `had=2368`, ~150 ms apart); fixed, once per page, and a node captured at render time survived 4 consecutive page turns.
- **Xiaomi 2211133C (Android 16)**, rebuilt and installed, replaying the reporter's own PDF — 310 non-empty blocks, **zero** empty, a clean page turn, word highlight tracking down the page. The old build gave 4 blocks then empties.
- `pnpm test` (10,889 pass) and `pnpm lint` clean.

## Found but not fixed here

`fixed-layout.js` implements no `primaryIndex` (`grep -c` → 0) while `paginator.js:1689` does, and `apps/readest-app/src/types/view.ts:49` declares it non-optional, so TypeScript never flags the `undefined`. Both TTS consumers silently fall back to `contents[0]` (`TTSController.ts:536-537`, `useTTSControl.ts:484`), and `getContents()` returns both pages of a spread. Harmless at `spread: none`; on a two-page spread `contents[0]` is the wrong page and `useTTSControl.ts:492`/`:508` would fire `view.goTo(cfi)` on every sentence mark. Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for PDF rendering to verify that unchanged content preserves its existing text layer.
  * Added coverage confirming that text layers are rebuilt when zoom or page-color settings change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->