### PR TITLE
fix(tts): read aloud only the selection on Ctrl/Cmd+R

### DIFF
--- a/apps/readest-app/src/__tests__/components/annotator/AnnotatorShortcuts.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotatorShortcuts.test.tsx
@@ -15,6 +15,7 @@ const h = vi.hoisted(() => ({
   },
   saveConfig: vi.fn(),
   updateBooknotes: vi.fn(),
+  view: null as unknown,
 }));
 
 const settings = {
@@ -80,7 +81,7 @@ vi.mock('@/store/bookDataStore', () => {
 
 vi.mock('@/store/readerStore', () => {
   const state = {
-    getView: () => null,
+    getView: () => h.view,
     getViewsById: () => [],
     getViewSettings: () => h.viewSettings,
   };
@@ -193,9 +194,39 @@ const selectPopupText = async (cfi?: string) => {
   });
 };
 
+// A main-view (non-popup) selection, the state Ctrl/Cmd+R acts on. The
+// `wordlens-dictionary` route is the one selection source that survives this
+// harness's mocks -- `footnote-selection` always stamps `popup: true`, and
+// `onReadAloudSelection` deliberately bails on popup ranges.
+const selectMainViewText = async (text = 'the river rounded a steep shoulder of land') => {
+  const paragraph = document.createElement('p');
+  paragraph.textContent = text;
+  document.body.append(paragraph);
+  h.view = {
+    renderer: {
+      getContents: () => [{ doc: document, index: 0 }],
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    getCFI: () => 'epubcfi(/6/2!/4/2)',
+    deselect: vi.fn(),
+  };
+  await act(async () => {
+    await eventDispatcher.dispatch('wordlens-dictionary', {
+      bookKey: 'book-1',
+      element: paragraph,
+      word: text,
+    });
+  });
+  return paragraph;
+};
+
 describe('Annotator popup shortcuts', () => {
   beforeEach(() => {
     h.actions = null;
+    h.view = null;
     h.config.booknotes = [];
     h.viewSettings.copyToNotebook = false;
     h.updateBooknotes.mockImplementation(() => h.config);
@@ -237,6 +268,32 @@ describe('Annotator popup shortcuts', () => {
 
     expect(handled).toBe(true);
     expect(h.updateBooknotes).toHaveBeenCalledOnce();
+  });
+
+  // #5011: Ctrl/Cmd+R is documented as "Readest reads the selection and stops",
+  // but the handler called handleSpeakText() without an argument, so `oneTime`
+  // fell back to false. useTTSControl then took the startFromRange branch,
+  // which begins at the top of the containing block and carries on through the
+  // book -- reading from the start of the paragraph and past the selection.
+  test('onReadAloudSelection speaks only the selection', async () => {
+    render(<Annotator bookKey='book-1' contentInsets={{ top: 0, right: 0, bottom: 0, left: 0 }} />);
+    await selectMainViewText();
+
+    const speaks: { oneTime?: boolean; range?: Range }[] = [];
+    const capture = (event: CustomEvent) => {
+      speaks.push(event.detail);
+    };
+    eventDispatcher.on('tts-speak', capture);
+
+    let handled: boolean | undefined;
+    await act(async () => {
+      handled = h.actions?.['onReadAloudSelection']?.();
+    });
+    eventDispatcher.off('tts-speak', capture);
+
+    expect(handled).toBe(true);
+    expect(speaks).toHaveLength(1);
+    expect(speaks[0]!.oneTime).toBe(true);
   });
 
   test('stores copied excerpts without inserting them into the Notebook editor', async () => {

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -1630,7 +1630,11 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     setShowDeepLPopup(true);
   };
 
-  const handleSpeakText = async (oneTime = false) => {
+  // `oneTime` is required rather than defaulted: it decides whether this reads
+  // the selection and stops or starts an open-ended session from it, and every
+  // entry point here means the former. Defaulting it silently turned Ctrl/Cmd+R
+  // into "start the book from this paragraph" (#5011).
+  const handleSpeakText = async (oneTime: boolean) => {
     if (!selection || !selection.text) return;
     // TTS walks the main view's documents; a popup-window range can't seed it
     // (the toolbar button is disabled, this guards the keyboard shortcut).
@@ -1718,7 +1722,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
       },
       onReadAloudSelection: () => {
         if (!selection?.text || selection.popup) return false;
-        handleSpeakText();
+        handleSpeakText(true);
         return true;
       },
       onProofreadSelection: () => {
@@ -2322,7 +2326,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
         return {
           tooltipText: _(label),
           Icon,
-          onClick: handleSpeakText,
+          onClick: () => handleSpeakText(true),
           disabled: !!selection?.popup,
         };
       case 'proofread':


### PR DESCRIPTION
Closes #5011 (the primary report). See "Not covered here" below for the two other symptoms in that thread.

## The bug

The docs say:

> You can also read aloud a selection only — select text in the reader and press Ctrl+R / Cmd+R. Readest reads the selection and stops.

It doesn't. It starts reading at the top of the paragraph containing the selection and carries on through the book — an ordinary TTS session, as the reporter put it.

## Root cause

`Annotator.tsx` declared `handleSpeakText = async (oneTime = false)`, and the shortcut handler called it with no argument:

```ts
onReadAloudSelection: () => {
  if (!selection?.text || selection.popup) return false;
  handleSpeakText();          // oneTime → false
  return true;
},
```

`useTTSControl` gates the selection-only path on that flag (`const speakSelection = oneTime && !!ttsSpeakRange`), so with `false` it fell through to `ttsController.startFromRange(ttsFromRange)` — start a session at the range's block and keep going.

The selection toolbar's own button (`onClick: handleSpeakText`) was relying on the same default and only behaved correctly by accident: React hands a click handler the `MouseEvent`, which is truthy.

## Fix

Pass `oneTime` explicitly, and make the parameter required so no caller can silently fall into session mode again. The toolbar button now says what it means rather than depending on the event object being truthy.

## Verification

Verified on a **Xiaomi 2211133C** (Android 16) against the shipped build, driving the shortcut over CDP with a live selection:

Before — selection was the single word `"Nothing"`:

```json
{ "oneTime": false, "hasRange": true, "rangeText": "Nothing" }
```

Six seconds later the TTS highlight had moved **two paragraphs past** the selection, onto "know" in a later paragraph — it never stopped at the selection.

After, in the browser against the same code path:

```json
{ "oneTime": true, "rangeText": "ezed\n again. He was no longer dripping but" }
```

which routes to `genSSMLRaw(range.toString().trim())` and `speak(ssml, true, …)` — spoken once, then the session stops.

**New regression test** (`AnnotatorShortcuts.test.tsx`): drives `onReadAloudSelection` with a main-view selection and asserts the dispatched `tts-speak` carries `oneTime: true`. It fails on `expected false to be true` without the fix. The harness's `getView` had to become configurable — `footnote-selection`, the only selection helper there, always stamps `popup: true`, which this handler deliberately refuses.

`pnpm lint` clean.

## Not covered here

The issue thread contains two further symptoms that are **not** this bug and are not fixed by this PR:

1. **"iOS Quick Action reads only the first word of a multi-word selection."** That path already passed `oneTime: true` (the mobile toolbar's `'tts'` case), and `oneTime` speaks the whole SSML — it only suppresses auto-advance. So the truncation is elsewhere, most likely in the native iOS client. Not reproducible on the stack I have.
2. **The commenter's Linux Flatpak report** ("one word then silence" with Edge TTS on desktop, while the web app is fine). That is a desktop Edge-TTS transport problem, closer to #5230 than to this. Worth splitting into its own issue.

Also noted while in this code: `genSSMLRaw` interpolates the selected text into SSML **without XML-escaping**, so a selection containing `&` or `<` produces malformed SSML. Left alone here to keep this change to the reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Read-aloud selection now speaks only the selected text and does not continue beyond the selection.
  - Text-to-speech actions consistently treat each requested read-aloud operation as a one-time playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->