### PR TITLE
fix: serialize TTS cache compaction before shutdown

### DIFF
--- a/apps/readest-app/src/__tests__/services/tts-book-cache-store.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-book-cache-store.test.ts
@@ -115,6 +115,35 @@ describe('BookTTSCacheStore', () => {
     await expect(store.close()).resolves.toBeUndefined();
   });
 
+  test('close waits for an active compaction before closing the database', async () => {
+    const store = new BookTTSCacheStore(appService, () => 'hash123', 1024 * 1024);
+    await store.registerSectionMarks(7, ['0:a']);
+    await store.put('k1', entry());
+    await store.recordMarkKey(7, 0, 'k1');
+    const writing = Promise.withResolvers<void>();
+    const resume = Promise.withResolvers<void>();
+    const write = packState.fs.write.getMockImplementation()!;
+    packState.fs.write.mockImplementationOnce(async (name, data) => {
+      writing.resolve();
+      await resume.promise;
+      await write(name, data);
+    });
+    const close = vi.spyOn(db, 'close');
+    const compacting = store.compact();
+    await writing.promise;
+    const closing = store.close();
+    // Let the close path run while the first pack write remains suspended.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const closedEarly = close.mock.calls.length > 0;
+    resume.resolve();
+    const results = await Promise.allSettled([compacting, closing]);
+
+    expect(closedEarly).toBe(false);
+    expect(results.map((result) => result.status)).toEqual(['fulfilled', 'fulfilled']);
+    expect(close).toHaveBeenCalledOnce();
+    expect([...packState.files.keys()].filter((name) => name.endsWith('.mp3'))).toHaveLength(1);
+  });
+
   test('marks a book cache while an explicit download is pinned and clears the marker on cancel', async () => {
     const store = new BookTTSCacheStore(appService, () => 'hash123', 1024 * 1024);
     const sequence: string[] = [];

--- a/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
@@ -90,6 +90,43 @@ describe('SqliteTTSCacheStore pack compaction', () => {
     expect(bytes[80]).toBe(3);
   });
 
+  test('a queued compaction retries after a preceding database query fails', async () => {
+    await cacheSection(3, ['m1'], ['k1']);
+    const error = new Error('Database query failed');
+    vi.spyOn(db, 'select').mockRejectedValueOnce(error);
+
+    const results = await Promise.allSettled([store.compact(), store.compact()]);
+
+    expect(results).toEqual([
+      { status: 'rejected', reason: error },
+      { status: 'fulfilled', value: 1 },
+    ]);
+    expect((await packFs.list()).filter((name) => name.endsWith('.mp3'))).toHaveLength(1);
+    expect(await store.get('k1')).toMatchObject(sentence(1));
+  });
+
+  test('queued compaction includes sections completed during an earlier run', async () => {
+    await cacheSection(3, ['m1'], ['k1']);
+    const writing = Promise.withResolvers<void>();
+    const resume = Promise.withResolvers<void>();
+    const write = packFs.write.bind(packFs);
+    vi.spyOn(packFs, 'write').mockImplementationOnce(async (name, data) => {
+      writing.resolve();
+      await resume.promise;
+      await write(name, data);
+    });
+    const first = store.compact();
+    await writing.promise;
+    await cacheSection(4, ['m2'], ['k2']);
+    const second = store.compact();
+    resume.resolve();
+
+    expect(await Promise.all([first, second])).toEqual([1, 1]);
+    expect((await packFs.list()).filter((name) => name.endsWith('.mp3'))).toHaveLength(2);
+    expect(await store.get('k1')).toMatchObject(sentence(1));
+    expect(await store.get('k2')).toMatchObject(sentence(1));
+  });
+
   test('a section sharing a sentence key with an already-packed section still packs (regression)', async () => {
     // Section A packs first, adopting the shared key k1 into its pack. From
     // then on k1's entry is pack-backed (audio NULL pointing at pack A).

--- a/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
+++ b/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
@@ -176,6 +176,7 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
   #now: () => number;
   #packFs: TTSPackFs | null;
   #ready: Promise<void> | null = null;
+  #compaction: Promise<number> = Promise.resolve(0);
   #pendingTouches = new Map<string, number>();
   #pendingPackTouches = new Map<number, number>();
 
@@ -550,7 +551,16 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
 
   // Merge every fully cached section into one pack file. Returns the number
   // of packs created. Idle-time work: callers debounce it.
-  async compact(): Promise<number> {
+  compact(): Promise<number> {
+    // Downloads, the idle timer, and close() can all request compaction.
+    // Serialize their file writes/transactions so close waits for active work
+    // and a failed overlapping run cannot remove another run's pack file.
+    const pending = this.#compaction.catch(() => 0).then(() => this.#compact());
+    this.#compaction = pending;
+    return pending;
+  }
+
+  async #compact(): Promise<number> {
     if (!this.#packFs) return 0;
     await this.#ensureSchema();
     const completable = await this.#db.select<


### PR DESCRIPTION
An idle or download cache compaction can still be writing a pack when Read Aloud shutdown starts another compaction. Both runs target the same files and database; shutdown can close the connection before the first run finishes, and failed cleanup can remove a completed pack. This matches the overlapping transaction/close errors in [READEST-13W](https://readest.sentry.io/issues/READEST-13W).

Queue compactions within each SqliteTTSCacheStore. Close-time compaction waits behind existing work, queued runs recheck for newly completed sections, and a rejected run does not block later requests. Application code only, with no library patches.

The regression test reproduced a database closing while a pack write was suspended, followed by a database-not-open error. All 58 targeted cache tests pass, including shutdown ordering, failure recovery, and chapters completed during a previous run. Formatting, TypeScript/Biome, and the full unit suite passed (10,950 tests; 16 skipped). Independent review found no actionable issues.

This fixes the overlapping-compaction path, not every possible database lifetime race across separate cache instances. Sentry release verification remains pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text-to-speech cache reliability by preventing overlapping maintenance operations.
  - Ensured pending cache updates finish before the cache is closed.
  - Improved recovery when a cache maintenance operation encounters a temporary database error.
  - Ensured updates completed during an ongoing maintenance operation are included in the next pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->