### PR TITLE
feat(nix): build the Linux package on the CEF runtime

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -14,35 +14,97 @@
 , openssl
 , glib-networking
 , autoPatchelfHook
+, autoAddDriverRunpath
 , lib
 , moreutils
 , jq
 , gst_all_1
+, fetchurl
+, runCommand
+  # Runtime dependencies of the CEF distribution (libcef.so and the ANGLE
+  # libraries), resolved by autoPatchelfHook.
+, nss
+, nspr
+, at-spi2-core
+, dbus
+, cups
+, expat
+, alsa-lib
+, libgbm
+, libxkbcommon
+, udev
+, libx11
+, libxcomposite
+, libxdamage
+, libxext
+, libxfixes
+, libxrandr
+, libxcb
+, libxcursor
+, libxi
 ,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   inherit version;
   pname = "readest";
-  src = lib.fileset.toSource {
-    root = ../.;
-    fileset = lib.fileset.intersection
-      (lib.fileset.gitTracked ../.)
-      (lib.fileset.unions [
-        ../apps/readest-app
-        ../apps/readest-app/src-tauri/plugins/tauri-plugin-turso
-        ../apps/readest-app/src-tauri/plugins/tauri-plugin-webview-upgrade
+  src =
+    let
+      tree = lib.fileset.toSource {
+        root = ../.;
+        fileset = lib.fileset.intersection
+          (lib.fileset.gitTracked ../.)
+          (lib.fileset.unions [
+            ../apps/readest-app
+            ../apps/readest-app/src-tauri/plugins/tauri-plugin-turso
+            ../apps/readest-app/src-tauri/plugins/tauri-plugin-webview-upgrade
 
-        ../packages
-        ../patches
+            ../packages
+            ../patches
 
-        ../package.json
-        ../pnpm-lock.yaml
-        ../pnpm-workspace.yaml
+            ../package.json
+            ../pnpm-lock.yaml
+            ../pnpm-workspace.yaml
 
-        ../Cargo.toml
-        ../Cargo.lock
-      ]);
-  };
+            ../Cargo.toml
+            ../Cargo.lock
+            ../Cargo.cef.lock
+          ]);
+      };
+    in
+    # Linux builds on the CEF runtime, like `pnpm tauri build` on Linux
+    # (apps/readest-app/scripts/tauri.mjs): the CEF dependency graph is pinned
+    # in Cargo.cef.lock, and src-tauri/.cargo/cef.toml holds the Linux-only
+    # `[patch.crates-io]` that takes tauri and its plugins from the feat/cef
+    # branches. Cargo only reads a file named config.toml, so both are put in
+    # place here, where cargoDeps (fetchCargoVendor) and the build see them.
+    runCommand "readest-source" { } ''
+      cp -r ${tree} $out
+      chmod -R u+w $out
+      cp $out/Cargo.cef.lock $out/Cargo.lock
+      cp $out/apps/readest-app/src-tauri/.cargo/cef.toml \
+        $out/apps/readest-app/src-tauri/.cargo/config.toml
+    '';
+
+  # The CEF binary distribution the `cef` crate would otherwise download at
+  # build time. Its version has to match cef-dll-sys in Cargo.cef.lock.
+  cefDist = {
+    x86_64-linux = fetchurl {
+      url = "https://cef-builds.spotifycdn.com/cef_binary_151.3.24%2Bg2384915%2Bchromium-151.0.7922.174_linux64_minimal.tar.bz2";
+      hash = "sha256-21PEP9rOi37krw8AUSARbWlzqp2Ot3AsBhe635voaE4=";
+      passthru = {
+        archiveName = "cef_binary_151.3.24+g2384915+chromium-151.0.7922.174_linux64_minimal.tar.bz2";
+        sha1 = "b1e99d3e3ff4213f99f7cda0211db89454398811";
+      };
+    };
+    aarch64-linux = fetchurl {
+      url = "https://cef-builds.spotifycdn.com/cef_binary_151.3.24%2Bg2384915%2Bchromium-151.0.7922.174_linuxarm64_minimal.tar.bz2";
+      hash = "sha256-R5ZbnDallYvdbW/bP+M2DzjRfWWRTvY2q63hSIHNxZs=";
+      passthru = {
+        archiveName = "cef_binary_151.3.24+g2384915+chromium-151.0.7922.174_linuxarm64_minimal.tar.bz2";
+        sha1 = "95acd2a46975e2c60afa6b427ec50c0a3be6236f";
+      };
+    };
+  }.${stdenv.hostPlatform.system} or null;
   postUnpack = ''
     # pnpm.configHook has to write to ../.., as our sourceRoot is set to
     # apps/readest-app
@@ -72,9 +134,27 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoRoot = "../..";
-  cargoHash = "sha256-5uavqv6Vx5YxfxUUIQ+A5kijBmOPamC+aBx8nPjlMrY=";
+  cargoHash = "sha256-JxKp18/+AyXKw7tJBJKYoRNroj+nbZKfo33O6ZZr15s=";
 
   buildAndTestSubdir = "src-tauri";
+
+  # The CEF runtime instead of wry (see src-tauri/Cargo.toml).
+  buildFeatures = [ "cef" ];
+  buildNoDefaultFeatures = true;
+  # The test binaries link libcef.so, which the build sandbox cannot load; the
+  # Rust unit tests run in the pull-request workflow (`pnpm test:rust`).
+  doCheck = false;
+
+  # winit's X11 backend dlopens Xlib, Xcursor, Xi, Xrandr and xkbcommon at run
+  # time (x11-dl, xkbcommon-dl), which autoPatchelf cannot see; put them on
+  # the RUNPATH so dlopen finds them.
+  runtimeDependencies = [
+    libx11
+    libxcursor
+    libxi
+    libxrandr
+    libxkbcommon
+  ];
 
   postPatch = ''
     substituteInPlace src-tauri/tauri.conf.json \
@@ -105,6 +185,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pkg-config
     wrapGAppsHook3
     autoPatchelfHook
+    # Chromium's GPU process dlopens the system GL/Vulkan drivers; on NixOS
+    # they live in /run/opengl-driver/lib, which this adds to the RUNPATHs.
+    autoAddDriverRunpath
     moreutils
     jq
   ];
@@ -115,6 +198,24 @@ rustPlatform.buildRustPackage (finalAttrs: {
     librsvg
     openssl
     glib-networking
+    # libcef.so
+    nss
+    nspr
+    at-spi2-core
+    dbus
+    cups
+    expat
+    alsa-lib
+    libgbm
+    libxkbcommon
+    udev
+    libx11
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrandr
+    libxcb
     # TTS
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
@@ -122,7 +223,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
     gst_all_1.gst-plugins-bad
   ];
 
-  preBuild = ''
+  preBuild = lib.optionalString stdenv.hostPlatform.isLinux ''
+    # Lay the CEF distribution out the way download-cef caches it (Release/
+    # and Resources/ flattened, plus archive.json) and point cef-dll-sys at
+    # it so it links against it instead of downloading.
+    export CEF_PATH="$NIX_BUILD_TOP/cef"
+    mkdir -p "$CEF_PATH"
+    tar -xjf ${finalAttrs.cefDist} --strip-components=1 -C "$CEF_PATH"
+    mv "$CEF_PATH"/Release/* "$CEF_PATH"/Resources/* "$CEF_PATH"/
+    printf '{"type": "minimal", "name": "%s", "sha1": "%s"}\n' \
+      "${finalAttrs.cefDist.archiveName}" "${finalAttrs.cefDist.sha1}" > "$CEF_PATH/archive.json"
+  '' + ''
     # set up pdfjs and simplecc
     pnpm setup-vendors
 
@@ -134,6 +245,35 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # >   Error Unable to find your web assets, did you forget to build your web app?
     #     Your frontendDist is set to "../out" (which is `/build/source/apps/readest-app/out`).
     pnpm --filter @readest/readest-app build
+  '';
+
+  # The deb the nixpkgs tauri CLI bundles carries only the executable; ship
+  # the CEF runtime next to it the way the CEF tauri CLI does for the deb
+  # (usr/share/Readest), since libcef.so is found through $ORIGIN.
+  postInstall = ''
+    # Several plugins still enable tauri's default `wry` feature, so the wry
+    # runtime is compiled in even though nothing uses it under CEF. Distro
+    # toolchains link with --as-needed and drop the unreferenced WebKitGTK
+    # libraries; rustc links through its bundled lld here, so the wrapper's
+    # flags never apply and they stay NEEDED. That is fatal: Nix's WebKitGTK
+    # uses bmalloc, whose static initializer starts a scavenger thread in every
+    # process, and Chromium's zygote refuses to run multi-threaded. Drop them,
+    # after checking that nothing in the executable refers to them.
+    if $NM -D --undefined-only $out/bin/readest | grep -Eq ' (webkit_|jsc_|JS[A-Z]|soup_)'; then
+      echo "readest references WebKitGTK/libsoup symbols; cannot drop the libraries" >&2
+      exit 1
+    fi
+    patchelf --remove-needed libwebkit2gtk-4.1.so.0 --remove-needed libjavascriptcoregtk-4.1.so.0 \
+      --remove-needed libsoup-3.0.so.0 $out/bin/readest
+    mkdir -p $out/lib/readest
+    mv $out/bin/readest $out/lib/readest/readest
+    ln -s ../lib/readest/readest $out/bin/readest
+    for file in libcef.so libEGL.so libGLESv2.so libvk_swiftshader.so libvulkan.so.1 \
+      vk_swiftshader_icd.json chrome_100_percent.pak chrome_200_percent.pak \
+      resources.pak icudtl.dat v8_context_snapshot.bin; do
+      cp "$CEF_PATH/$file" $out/lib/readest/
+    done
+    cp -r "$CEF_PATH/locales" $out/lib/readest/
   '';
 
   tursoPluginDeps = fetchPnpmDeps {


### PR DESCRIPTION
## Summary

Makes the Nix package (`nix run github:readest/readest`) build the same CEF runtime that the deb, rpm, AppImage and Flatpak now ship, instead of WebKitGTK.

- The source derivation swaps `Cargo.cef.lock` in as `Cargo.lock` and installs `src-tauri/.cargo/cef.toml` as the cargo config, so `fetchCargoVendor` and the build resolve the feat/cef graph from the readest forks.
- The CEF binary distribution (151.3.24, minimal) is a `fetchurl` source flattened like download-cef's cache and passed through `CEF_PATH`; nothing is downloaded at build time.
- Build with `--no-default-features --features cef`; the CEF runtime files live next to the executable in `lib/readest` (libcef.so is found via `$ORIGIN`), `bin/readest` is a symlink.
- winit's dlopen'ed X11/xkbcommon libraries are added as `runtimeDependencies`; `autoAddDriverRunpath` lets the GPU process find GL drivers on NixOS.
- Nix's linker keeps unreferenced `libwebkit2gtk`/`libjavascriptcoregtk`/`libsoup` as NEEDED (plugins still enable tauri's `wry` feature, and rustc links through its bundled lld, so `--as-needed` never applies). That is fatal here: Nix's WebKitGTK is built with bmalloc, whose static initializer starts a thread in every process, so Chromium's zygote fails its single-threaded CHECK and every GPU process launch fails. The libraries are removed with patchelf after checking the executable references none of their symbols.
- `doCheck = false`: test binaries link libcef.so, which the sandbox cannot load; `pnpm test:rust` covers the Rust unit tests in CI.

## Test plan

- [x] `nix build .#default` (via nix-portable, pinned nixpkgs) succeeds; auto-patchelf reports no missing dependencies
- [x] The output starts, keeps its GPU process and renders the library (run in a bwrap root with `/nix` mounted, on Xvfb)
- [ ] `nix-deps-check` confirms the new `cargoHash`
- [ ] Someone on NixOS confirms GL works through `/run/opengl-driver/lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for building and packaging the Linux CEF variant.
  - Included the required CEF libraries, resources, and runtime components alongside the application.
  - Added support for both x86_64 and aarch64 Linux builds.

- **Improvements**
  - Streamlined the packaged application by removing unnecessary graphical toolkit dependencies while preserving runtime functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->