### PR TITLE
fix(nix): let the linker resolve libcef.so's own dependencies

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -223,6 +223,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     gst_all_1.gst-plugins-bad
   ];
 
+  # ld resolves the DT_NEEDED entries of a library it links against through
+  # -rpath-link and that library's own RUNPATH, never through the -L search
+  # path. libcef.so is a Chromium prebuilt whose RUNPATH is just `$ORIGIN`,
+  # so the final link cannot find libnss3.so, libnspr4.so, libdbus-1.so.3,
+  # libcups.so.2, libudev.so.1 or libasound.so.2, and fails with "undefined
+  # reference to `PK11_SignatureLen@NSS_3.2'" and friends. Nix libraries carry
+  # a RUNPATH and resolve on their own; point the linker at the buildInputs
+  # for the ones libcef.so needs.
+  NIX_LDFLAGS = "-rpath-link=${lib.makeLibraryPath finalAttrs.buildInputs}";
+
   preBuild = lib.optionalString stdenv.hostPlatform.isLinux ''
     # Lay the CEF distribution out the way download-cef caches it (Release/
     # and Resources/ flattened, plus archive.json) and point cef-dll-sys at


### PR DESCRIPTION
The `Build with Nix` run on main ([34e4ebee](https://github.com/readest/readest/actions/runs/34006430861/job/101414377223)) fails at the final link:

```
ld.bfd: warning: libnspr4.so, needed by /build/cef/libcef.so, not found (try using -rpath or -rpath-link)
...
ld.bfd: /build/cef/libcef.so: undefined reference to `PK11_SignatureLen@NSS_3.2'
ld.bfd: /nix/store/...-libgudev-238/lib/libgudev-1.0.so.0: undefined reference to `udev_enumerate_add_match_property@LIBUDEV_183'
```

## Cause

`ld` resolves the `DT_NEEDED` entries of a library it links against through `-rpath-link` and through that library's own `RUNPATH` — never through the `-L` search path. Nix's libraries carry a `RUNPATH`, so they resolve themselves; `libcef.so` is a Chromium prebuilt whose `RUNPATH` is only `$ORIGIN`, so `libnspr4.so`, `libnss3.so`, `libnssutil3.so`, `libsmime3.so`, `libdbus-1.so.3`, `libcups.so.2`, `libudev.so.1` and `libasound.so.2` are never found even though all of them are in `buildInputs`. The first miss also poisons every other library needing the same soname, which is why `libgudev` and `libatspi` report undefined `udev_*`/`dbus_*` references.

## Fix

Point the linker at the `buildInputs` library directories with `-rpath-link`. Link-time only: nothing about the produced artifact changes, `autoPatchelfHook` still sets the runtime `RUNPATH`s.

## Verification

`nix-build` cannot run on a PR (nix-build.yml is `push: [main]` only), so the link was reproduced in a nix build against the real `libcef.so`, with the same `buildInputs` and a link line mirroring the real one (`-lcef` plus the gtk stack that `glib-sys`/`gtk-sys` link directly):

| variant | result |
| --- | --- |
| no flag (control) | fails with the same missing sonames and undefined references as CI |
| `-rpath-link=${lib.makeLibraryPath buildInputs}` | links cleanly |

Running `autoPatchelf` on `libcef.so` was tested as an alternative; it also works, which additionally confirms that every `libcef.so` dependency is satisfiable from the declared `buildInputs`, so the fixup phase has what it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFQr7zxYn8L8vitR5Ef1q8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build failures caused by unresolved native library references when packaging the application with Nix.
  * Improved linking for required system libraries during the final build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->