### PR TITLE
fix: continue library sync after cover download failures

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/useBooksSync-routing.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/useBooksSync-routing.test.tsx
@@ -25,7 +25,7 @@ import type { Book } from '@/types/book';
 const appService = vi.hoisted(() => ({
   saveLibraryBooks: vi.fn(async () => {}),
   generateCoverImageUrl: vi.fn(async () => 'blob:cover'),
-  downloadBookCovers: vi.fn(async () => {}),
+  downloadBookCovers: vi.fn(async (_books: Book[]) => {}),
 }));
 
 const syncState = vi.hoisted(() => ({
@@ -96,11 +96,74 @@ const { eventDispatcher } = await import('@/utils/event');
 
 beforeEach(() => {
   vi.clearAllMocks();
+  appService.downloadBookCovers.mockReset().mockResolvedValue(undefined);
   syncState.syncedBooks = null;
   syncState.lastSyncedAtBooks = 0;
   routing.readestEnabled = true;
   routing.backends = [];
   useLibraryStore.setState({ library: [], libraryLoaded: true, isSyncing: false });
+});
+
+describe('useBooksSync cover download failures', () => {
+  const makeBook = (overrides: Partial<Book> = {}): Book =>
+    ({
+      hash: 'book-1',
+      title: 'Book',
+      author: 'Author',
+      format: 'EPUB',
+      createdAt: 100,
+      updatedAt: 100,
+      uploadedAt: 100,
+      ...overrides,
+    }) as Book;
+
+  it('merges metadata despite a failed cover refresh and retries the cover on the next sync', async () => {
+    useLibraryStore.setState({
+      library: [
+        makeBook({
+          coverHash: 'old-cover',
+          coverUpdatedAt: 100,
+          coverDownloadedAt: 100,
+        }),
+      ],
+    });
+    const cloudBook = makeBook({
+      title: 'Updated title',
+      updatedAt: 200,
+      coverHash: 'new-cover',
+      coverUpdatedAt: 200,
+    });
+    syncState.syncedBooks = [cloudBook];
+    appService.downloadBookCovers.mockRejectedValueOnce(new Error('Cover URLs unavailable'));
+    const { rerender } = renderHook(() => useBooksSync());
+
+    await waitFor(() => expect(useLibraryStore.getState().library[0]?.title).toBe('Updated title'));
+    expect(useLibraryStore.getState().library[0]?.coverDownloadedAt).toBeFalsy();
+    expect(appService.saveLibraryBooks).toHaveBeenCalled();
+
+    appService.downloadBookCovers.mockImplementationOnce(async (books) => {
+      for (const book of books) book.coverDownloadedAt = 300;
+    });
+    syncState.syncedBooks = [{ ...cloudBook }];
+    rerender();
+    await waitFor(() => expect(useLibraryStore.getState().library[0]?.coverDownloadedAt).toBe(300));
+    expect(appService.downloadBookCovers).toHaveBeenCalledTimes(2);
+  });
+
+  it('adds new books and continues later batches when a cover batch fails', async () => {
+    syncState.syncedBooks = Array.from({ length: 11 }, (_, index) =>
+      makeBook({ hash: `book-${index + 1}` }),
+    );
+    appService.downloadBookCovers.mockRejectedValueOnce(new Error('Cover URLs unavailable'));
+    renderHook(() => useBooksSync());
+
+    await waitFor(() => expect(useLibraryStore.getState().library).toHaveLength(11));
+    expect(useLibraryStore.getState().library[0]?.hash).toBe('book-1');
+    expect(useLibraryStore.getState().library[0]?.coverDownloadedAt).toBeFalsy();
+    expect(useLibraryStore.getState().isSyncing).toBe(false);
+    expect(appService.saveLibraryBooks).toHaveBeenCalled();
+    expect(appService.downloadBookCovers).toHaveBeenCalledTimes(2);
+  });
 });
 
 afterEach(() => {

--- a/apps/readest-app/src/app/library/hooks/useBooksSync.ts
+++ b/apps/readest-app/src/app/library/hooks/useBooksSync.ts
@@ -308,7 +308,12 @@ export const useBooksSync = () => {
     const oldBooksBatchSize = 100;
     for (let i = 0; i < oldBooksNeedsDownload.length; i += oldBooksBatchSize) {
       const batch = oldBooksNeedsDownload.slice(i, i + oldBooksBatchSize);
-      await appService?.downloadBookCovers(batch);
+      await appService?.downloadBookCovers(batch).catch((error) => {
+        console.warn('Cover refresh failed; continuing library sync:', error);
+        // The merge adopts the remote cover hash below. Keep failed covers
+        // eligible for retry even after their metadata clocks match.
+        for (const book of batch) book.coverDownloadedAt = null;
+      });
     }
 
     const updatedLibrary = await Promise.all(liveLibrary.map(processOldBook));
@@ -353,7 +358,9 @@ export const useBooksSync = () => {
       const batchSize = 10;
       for (let i = 0; i < newBooks.length; i += batchSize) {
         const batch = newBooks.slice(i, i + batchSize);
-        await appService?.downloadBookCovers(batch);
+        await appService?.downloadBookCovers(batch).catch((error) => {
+          console.warn('Cover download failed; continuing library sync:', error);
+        });
         await Promise.all(batch.map(processNewBook));
         const progress = Math.min((i + batchSize) / newBooks.length, 1);
         setSyncProgress(progress);


### PR DESCRIPTION
A failed request for cover download URLs aborted library reconciliation: existing-book updates rejected outside the error handler, while new books never reached the library when their cover batch failed. [READEST-3Y](https://readest.sentry.io/issues/READEST-3Y) records this after a network failure during sync.

Handle cover-batch failures separately so metadata updates, new-book adoption, and later batches continue. Mark failed existing-cover refreshes as pending so they are retried when a later sync includes those books again, even after adopting the remote cover hash and timestamp. This changes application code only.

Both new regression tests failed before the fix, including an unhandled rejection. All 25 targeted tests pass, covering metadata reconciliation, retry on the next sync, and continued adoption across multiple batches. Pre-push checks passed: formatting, lint/type checking, and the full suite (10,952 tests passed; 16 skipped). Independent review found no actionable issues.

The network failure itself remains possible; this fixes its effect on library sync. Sentry release verification remains pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Library synchronization now continues when book cover downloads fail.
  - Failed cover refreshes remain eligible for retry during a later sync.
  - New books are added successfully even if their cover downloads cannot be completed.
  - Subsequent synchronization batches continue processing after a cover download failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->