### PR TITLE
feat(linux): debug the CEF build over CDP, and three fixes it found

### DIFF
--- a/apps/readest-app/docs/testing.md
+++ b/apps/readest-app/docs/testing.md
@@ -153,6 +153,54 @@ pnpm test:e2e
 - **Connects to:** port 4445 (embedded WebDriver server)
 - **Use for:** UI interaction tests, window management, navigation flows.
 
+## Debugging the Linux CEF Build (CDP)
+
+The Linux CEF runtime is Chromium, so the app window is a normal Chrome DevTools
+Protocol target — the same interface Chrome, Playwright and Puppeteer speak. This
+is the only way to inspect the running desktop app on Linux (WebKitWebDriver, used
+by `pnpm tauri:dev:test`, drives the wry runtime instead).
+
+```bash
+# Terminal 1: dev build with the CDP endpoint on 127.0.0.1:9222
+pnpm tauri:dev:cdp
+
+# Terminal 2
+pnpm cdp targets                                     # list debuggable targets
+pnpm cdp eval 'document.title'                       # run JS in the app window
+pnpm cdp eval 'window.__TAURI_INTERNALS__.invoke("plugin:app|version")'
+pnpm cdp click 'button[aria-label="Import Books"]'   # real pointer events
+pnpm cdp screenshot /tmp/library.png
+pnpm cdp logs 30                                     # tail the app console
+```
+
+`pnpm tauri:dev:cdp` is `pnpm tauri dev` with `READEST_CDP_PORT=9222`. Any CEF
+build honours that variable — a packaged `.deb`, the Flatpak, or `tauri build`
+output — so the same tooling works against release binaries:
+
+```bash
+READEST_CDP_PORT=9222 readest
+CDP_PORT=9222 pnpm cdp targets
+```
+
+`scripts/cdp.mjs` is dependency-free (node's global `fetch` and `WebSocket`); the
+endpoint listens on loopback only. For anything richer, connect a real client to
+the same port — `chrome://inspect` in a local Chrome, or
+`chromium.connectOverCDP('http://127.0.0.1:9222')`.
+
+### Limits
+
+- **The IPC bridge cannot be stubbed.** `window.__TAURI_INTERNALS__.invoke` is
+  defined non-writable and non-configurable, so assigning over it from `eval`
+  fails silently and the real command still runs. You can *call* it, not fake it.
+- **Native dialogs are outside the page.** The file picker is an XDG portal
+  window (`org.gnome.Nautilus` on GNOME), not a CEF surface, so CDP cannot see or
+  click it. Driving an import end-to-end needs X11 input (XTEST via python-xlib:
+  focus the chooser, `Ctrl+L`, type the path, `Return` to select, `Return` to
+  open) — or skip the picker and dispatch the app's own `import-book-files` event.
+- **Passing `--remote-debugging-port` on argv works too**, but `tauri-plugin-cli`
+  parses the same argv for open-with paths and warns on every launch. Prefer the
+  env var.
+
 ## Test File Naming
 
 | Suffix              | Runner              | Environment           |

--- a/apps/readest-app/package.json
+++ b/apps/readest-app/package.json
@@ -45,6 +45,8 @@
     "tauri:dev:test": "dotenv -e .env.tauri -- tauri dev --features webdriver",
     "tauri:build:test": "dotenv -e .env.tauri -- tauri build --debug --features webdriver",
     "tauri": "node scripts/tauri.mjs",
+    "tauri:dev:cdp": "READEST_CDP_PORT=9222 node scripts/tauri.mjs dev",
+    "cdp": "node scripts/cdp.mjs",
     "fmt:check": "cargo fmt -p Readest --check",
     "clippy:check": "cargo clippy -p Readest --no-deps -- -D warnings",
     "test:rust": "cargo test -p Readest --lib",

--- a/apps/readest-app/scripts/cdp.mjs
+++ b/apps/readest-app/scripts/cdp.mjs
@@ -61,11 +61,19 @@ const connect = async () => {
   const send = (method, params = {}) =>
     new Promise((resolve, reject) => {
       const id = ++lastId;
-      pending.set(id, (m) =>
-        m.error ? reject(new Error(`${method}: ${JSON.stringify(m.error)}`)) : resolve(m.result),
-      );
+      // A pending timer keeps node's event loop alive, so it has to be cleared
+      // once the reply lands: otherwise the command prints its answer and then
+      // sits there for the rest of the 30s before the process can exit.
+      const timeout = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`${method}: timed out`));
+      }, 30000);
+      pending.set(id, (m) => {
+        clearTimeout(timeout);
+        if (m.error) reject(new Error(`${method}: ${JSON.stringify(m.error)}`));
+        else resolve(m.result);
+      });
       ws.send(JSON.stringify({ id, method, params }));
-      setTimeout(() => reject(new Error(`${method}: timed out`)), 30000);
     });
   const evaluate = async (expression) => {
     const { result, exceptionDetails } = await send('Runtime.evaluate', {

--- a/apps/readest-app/scripts/cdp.mjs
+++ b/apps/readest-app/scripts/cdp.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// Talk to the running app over the Chrome DevTools Protocol.
+//
+// Only the Linux CEF build exposes a CDP endpoint, and only when it was started
+// with a port: `pnpm tauri:dev:cdp`, or `READEST_CDP_PORT=9222` on any CEF
+// build (see docs/testing.md). Everything here is plain node — the global
+// `fetch` and `WebSocket` are all a CDP client needs.
+//
+//   pnpm cdp targets
+//   pnpm cdp eval 'document.title'
+//   pnpm cdp eval 'window.__TAURI_INTERNALS__.invoke("plugin:app|version")'
+//   pnpm cdp click 'button[aria-label="Import Books"]'
+//   pnpm cdp screenshot /tmp/library.png
+//   pnpm cdp logs 30
+//
+// CDP_PORT overrides the default 9222.
+const PORT = process.env['CDP_PORT'] ?? '9222';
+const BASE = `http://127.0.0.1:${PORT}`;
+
+const die = (message) => {
+  console.error(message);
+  process.exit(1);
+};
+
+const listTargets = async () => {
+  try {
+    return await (await fetch(`${BASE}/json/list`)).json();
+  } catch {
+    return die(
+      `No CDP endpoint on ${BASE}. Start the app with \`pnpm tauri:dev:cdp\` ` +
+        '(or READEST_CDP_PORT=<port> on a CEF build).',
+    );
+  }
+};
+
+// The app window is the only http(s) target; chrome:// targets are CEF's own UI.
+const appTarget = async () => {
+  const targets = await listTargets();
+  const page = targets.find((t) => t.type === 'page' && /^https?:/.test(t.url));
+  return page ?? die('No app page target found. Is the window open?');
+};
+
+const connect = async () => {
+  const ws = new WebSocket((await appTarget()).webSocketDebuggerUrl);
+  await new Promise((resolve, reject) => {
+    ws.addEventListener('open', resolve);
+    ws.addEventListener('error', () => reject(new Error('websocket failed')));
+  });
+  let lastId = 0;
+  const pending = new Map();
+  const listeners = new Set();
+  ws.addEventListener('message', (message) => {
+    const data = JSON.parse(message.data);
+    if (data.id && pending.has(data.id)) {
+      pending.get(data.id)(data);
+      pending.delete(data.id);
+    } else if (data.method) {
+      for (const listener of listeners) listener(data);
+    }
+  });
+  const send = (method, params = {}) =>
+    new Promise((resolve, reject) => {
+      const id = ++lastId;
+      pending.set(id, (m) =>
+        m.error ? reject(new Error(`${method}: ${JSON.stringify(m.error)}`)) : resolve(m.result),
+      );
+      ws.send(JSON.stringify({ id, method, params }));
+      setTimeout(() => reject(new Error(`${method}: timed out`)), 30000);
+    });
+  const evaluate = async (expression) => {
+    const { result, exceptionDetails } = await send('Runtime.evaluate', {
+      expression,
+      returnByValue: true,
+      awaitPromise: true,
+    });
+    if (exceptionDetails) {
+      throw new Error(exceptionDetails.exception?.description ?? exceptionDetails.text);
+    }
+    return result.value;
+  };
+  return { send, evaluate, on: (fn) => listeners.add(fn), close: () => ws.close() };
+};
+
+const [command, ...args] = process.argv.slice(2);
+
+switch (command) {
+  case 'targets': {
+    for (const t of await listTargets()) console.log(`${t.type}\t${t.url}\t${t.title}`);
+    break;
+  }
+
+  case 'eval': {
+    if (!args[0]) die("usage: pnpm cdp eval '<javascript>'");
+    const cdp = await connect();
+    const value = await cdp.evaluate(args[0]);
+    console.log(typeof value === 'string' ? value : JSON.stringify(value, null, 2));
+    cdp.close();
+    break;
+  }
+
+  // A real mouse press at the element's center: menus and dropdowns that key off
+  // pointer events ignore an `element.click()` from `eval`.
+  case 'click': {
+    if (!args[0]) die("usage: pnpm cdp click '<css selector>'");
+    const cdp = await connect();
+    const box = await cdp.evaluate(`(() => {
+      const el = document.querySelector(${JSON.stringify(args[0])});
+      if (!el) return null;
+      el.scrollIntoView({ block: 'center' });
+      const r = el.getBoundingClientRect();
+      return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+    })()`);
+    if (!box) die(`No element matches ${args[0]}`);
+    for (const type of ['mouseMoved', 'mousePressed', 'mouseReleased']) {
+      await cdp.send('Input.dispatchMouseEvent', {
+        type,
+        x: box.x,
+        y: box.y,
+        button: 'left',
+        clickCount: type === 'mouseMoved' ? 0 : 1,
+        buttons: type === 'mousePressed' ? 1 : 0,
+      });
+    }
+    console.log(`clicked ${args[0]}`);
+    cdp.close();
+    break;
+  }
+
+  case 'screenshot': {
+    const out = args[0] ?? 'cdp-screenshot.png';
+    const cdp = await connect();
+    const { data } = await cdp.send('Page.captureScreenshot', { format: 'png' });
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(out, Buffer.from(data, 'base64'));
+    console.log(out);
+    cdp.close();
+    break;
+  }
+
+  // Console output of the running app, including whatever it logged before we
+  // attached (Runtime.enable replays the buffer).
+  case 'logs': {
+    const seconds = Number(args[0] ?? 10);
+    const cdp = await connect();
+    cdp.on(({ method, params }) => {
+      if (method === 'Runtime.consoleAPICalled') {
+        const text = params.args
+          .map((a) => a.value ?? a.description ?? a.unserializableValue ?? '')
+          .join(' ');
+        console.log(`[${params.type}] ${text}`);
+      } else if (method === 'Runtime.exceptionThrown') {
+        console.log(`[error] ${params.exceptionDetails.exception?.description ?? ''}`);
+      }
+    });
+    await cdp.send('Runtime.enable');
+    setTimeout(() => {
+      cdp.close();
+      process.exit(0);
+    }, seconds * 1000);
+    break;
+  }
+
+  default:
+    die('usage: pnpm cdp <targets|eval|click|screenshot|logs> [args]');
+}

--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -256,6 +256,32 @@ fn get_executable_dir() -> String {
         .unwrap_or_default()
 }
 
+/// Logical size of the main window the first time the app runs. Later launches
+/// restore whatever the user left behind (`tauri_plugin_window_state`), so this
+/// is a starting point, not a preference. macOS has always opened at this size;
+/// Windows and Linux used to open at 800x600, which is cramped for the library
+/// grid and a two-page spread. It clears a 1080p work area whole.
+#[cfg(desktop)]
+const DEFAULT_WINDOW_SIZE: (f64, f64) = (1280.0, 800.0);
+
+// The first-launch window size, shrunk to fit `work_area` — the monitor minus
+// its taskbar/panels, in logical pixels — when the default is too big for it.
+// A fixed 1280x800 hangs off the bottom of a 1366x768 laptop screen, and a
+// window that opens partly off-screen can be impossible to resize back.
+// `None` (no monitor reported, or one reporting an empty work area) keeps the
+// default: a window that is too large stays reachable, one sized from a bogus
+// zero-height screen does not.
+#[cfg(desktop)]
+fn default_window_size(work_area: Option<(f64, f64)>) -> (f64, f64) {
+    let Some((width, height)) = work_area.filter(|(w, h)| *w > 0.0 && *h > 0.0) else {
+        return DEFAULT_WINDOW_SIZE;
+    };
+    (
+        DEFAULT_WINDOW_SIZE.0.min(width * 0.9),
+        DEFAULT_WINDOW_SIZE.1.min(height * 0.9),
+    )
+}
+
 // Pure decision for whether the in-app updater should be hidden. Kept
 // dependency-free so it can be unit tested for every platform combination.
 //
@@ -713,10 +739,18 @@ pub fn run() {
                     true
                 });
 
-            #[cfg(target_os = "macos")]
-            let win_builder = win_builder.inner_size(1280.0, 800.0).resizable(true);
-            #[cfg(all(not(target_os = "macos"), desktop))]
-            let win_builder = win_builder.inner_size(800.0, 600.0).resizable(true);
+            #[cfg(desktop)]
+            let win_builder = {
+                let work_area = app.primary_monitor().ok().flatten().map(|monitor| {
+                    let size = monitor
+                        .work_area()
+                        .size
+                        .to_logical::<f64>(monitor.scale_factor());
+                    (size.width, size.height)
+                });
+                let (width, height) = default_window_size(work_area);
+                win_builder.inner_size(width, height).resizable(true)
+            };
 
             // The overlay title bar draws its title over the app's own header,
             // so `macos::window::init()` hides the title text and the window
@@ -852,7 +886,38 @@ pub fn run() {
 
 #[cfg(all(test, desktop))]
 mod tests {
-    use super::compute_updater_disabled;
+    use super::{compute_updater_disabled, default_window_size, DEFAULT_WINDOW_SIZE};
+
+    #[test]
+    fn monitor_with_room_keeps_the_shipped_default() {
+        // 1080p minus a taskbar is the everyday case, and the default is picked
+        // to fit it whole; anything larger fits too.
+        assert_eq!(
+            default_window_size(Some((1920.0, 1040.0))),
+            DEFAULT_WINDOW_SIZE
+        );
+        assert_eq!(
+            default_window_size(Some((2560.0, 1400.0))),
+            DEFAULT_WINDOW_SIZE
+        );
+    }
+
+    #[test]
+    fn small_laptop_screen_shrinks_the_window() {
+        // 1366x768 is the screen the old 800x600 default was sized for, and the
+        // one a fixed 1280x800 would hang off the bottom of.
+        let (width, height) = default_window_size(Some((1366.0, 728.0)));
+        assert!((width - 1229.4).abs() < 0.01, "width {width}");
+        assert!((height - 655.2).abs() < 0.01, "height {height}");
+    }
+
+    #[test]
+    fn unknown_or_empty_work_area_falls_back_to_the_default() {
+        // No monitor reported, or one reporting nothing usable (a display that
+        // is off, or a compositor that has not laid out the screen yet).
+        assert_eq!(default_window_size(None), DEFAULT_WINDOW_SIZE);
+        assert_eq!(default_window_size(Some((0.0, 0.0))), DEFAULT_WINDOW_SIZE);
+    }
 
     #[test]
     fn env_opt_out_disables_on_any_desktop() {

--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -410,6 +410,21 @@ pub fn run() {
 
     let builder = tauri::Builder::<AppRuntime>::new();
 
+    // `READEST_CDP_PORT=9222` hands the port to CEF as `--remote-debugging-port`,
+    // so a debugger or test driver can attach over the Chrome DevTools Protocol
+    // on 127.0.0.1 (see docs/testing.md). CEF also honours the switch straight
+    // off argv, but tauri-plugin-cli parses the same argv for open-with paths and
+    // warns about the unknown argument on every launch, so the env var is the
+    // supported way in.
+    #[cfg(all(feature = "cef", target_os = "linux"))]
+    let builder = match std::env::var("READEST_CDP_PORT") {
+        Ok(port) if !port.is_empty() => builder.runtime_init_attrs(
+            tauri::CefRuntimeAttributes::default()
+                .command_line_arg("remote-debugging-port", Some(port)),
+        ),
+        _ => builder,
+    };
+
     let builder = builder
         .plugin(
             tauri_plugin_log::Builder::new()

--- a/apps/readest-app/src/app/library/components/OPDSDialog.tsx
+++ b/apps/readest-app/src/app/library/components/OPDSDialog.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx';
 import { useEnv } from '@/context/EnvContext';
-import { CatalogManager } from '@/app/opds/components/CatalogManager';
+import { CatalogManager, CATALOG_DIALOG_BOX_CLASS } from '@/app/opds/components/CatalogManager';
 import { useTranslation } from '@/hooks/useTranslation';
 import Dialog from '@/components/Dialog';
 
@@ -17,7 +17,7 @@ export function CatalogDialog({ onClose }: CatalogDialogProps) {
       title={appService?.isOnlineCatalogsAccessible ? _('Online Library') : _('OPDS Catalogs')}
       onClose={onClose}
       bgClassName={'sm:bg-black/75!'}
-      boxClassName='sm:min-w-[520px] sm:w-3/4 sm:h-[85%] sm:max-w-(--breakpoint-sm)!'
+      boxClassName={CATALOG_DIALOG_BOX_CLASS}
     >
       <div className={clsx('bg-base-100 relative flex flex-col overflow-y-auto pb-4')}>
         <CatalogManager />

--- a/apps/readest-app/src/app/opds/components/CatalogManager.tsx
+++ b/apps/readest-app/src/app/opds/components/CatalogManager.tsx
@@ -342,6 +342,17 @@ interface CatalogManagerProps {
   inSubPage?: boolean;
 }
 
+/**
+ * Box size shared by the catalog manager dialog (`OPDSDialog`) and the
+ * Add/Edit Catalog form it opens on top of itself. The form used to take
+ * daisyUI's `modal-box` default — narrower than the manager behind it, and
+ * tall enough to run off the bottom of a 1280x800 window — so both windows now
+ * size from this one string. `sm:`-only: below that breakpoint each dialog
+ * keeps its own full-width mobile treatment.
+ */
+export const CATALOG_DIALOG_BOX_CLASS =
+  'sm:min-w-[520px] sm:w-3/4 sm:h-[85%] sm:max-w-(--breakpoint-sm)!';
+
 export function CatalogManager({ inSubPage = false }: CatalogManagerProps = {}) {
   const _ = useTranslation();
   const router = useRouter();
@@ -772,7 +783,9 @@ export function CatalogManager({ inSubPage = false }: CatalogManagerProps = {}) 
       {showAddDialog && (
         <ModalPortal>
           <dialog className='modal modal-open'>
-            <div className='modal-box'>
+            <div
+              className={clsx('modal-box sm:max-h-full sm:max-w-full', CATALOG_DIALOG_BOX_CLASS)}
+            >
               <h3 className='mb-4 text-lg font-semibold tracking-tight'>
                 {editingCatalogId ? _('Edit OPDS Catalog') : _('Add OPDS Catalog')}
               </h3>

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -1004,6 +1004,24 @@
     display: none;
   }
 
+  /* Virtuoso owns the scroller inside every OverlayScrollbars root we set up
+     (bookshelf, TOC, book notes) and gives it `overflow-y: auto` inline, so the
+     platform scrollbar paints for as long as OverlayScrollbars' deferred init
+     takes — then vanishes when OS marks the same element
+     `data-overlayscrollbars-viewport="scrollbarHidden ..."`, widening the
+     content by the scrollbar's width and shifting the whole grid. OS ships
+     hiding rules for `[data-overlayscrollbars-initialize]`, but that attribute
+     sits on the root we hand it, never on the child that actually scrolls.
+     Hide it there too, until OS takes the root over. */
+  [data-overlayscrollbars-initialize]:not([data-overlayscrollbars]) [data-virtuoso-scroller] {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  [data-overlayscrollbars-initialize]:not([data-overlayscrollbars])
+    [data-virtuoso-scroller]::-webkit-scrollbar {
+    display: none;
+  }
+
   [data-eink='true'] input.search-input,
   [data-eink='true'] input.search-input:focus {
     border-width: 1px !important;


### PR DESCRIPTION
The Linux CEF runtime is Chromium, so the app window is a plain Chrome DevTools Protocol target. This wires that up as a supported workflow, then fixes the three things I found by pointing it at the running app.

## The tooling

```bash
pnpm tauri:dev:cdp      # dev build with CDP on 127.0.0.1:9222
pnpm cdp targets
pnpm cdp eval 'document.title'
pnpm cdp eval 'window.__TAURI_INTERNALS__.invoke("plugin:app|version")'
pnpm cdp click 'button[aria-label="Import Books"]'
pnpm cdp screenshot /tmp/library.png
pnpm cdp logs 30
```

`READEST_CDP_PORT=<port>` hands the port to CEF as `--remote-debugging-port` through the runtime's command-line args, so it works on any CEF build — a packaged `.deb`, the Flatpak, `tauri build` output — not just `tauri dev`. CEF honours the switch straight off argv too, but `tauri-plugin-cli` parses the same argv for open-with paths and warns about the unknown argument on every launch, so the env var is the supported way in. `scripts/cdp.mjs` needs no dependencies (node's global `fetch` and `WebSocket`), and the endpoint listens on loopback only.

This is the only way to inspect the running desktop app on Linux: `pnpm tauri:dev:test` drives WebKitWebDriver, which speaks to the wry runtime, not CEF. `docs/testing.md` covers it, including two limits worth knowing — `window.__TAURI_INTERNALS__.invoke` is non-writable so the IPC cannot be stubbed from the page, and native file dialogs are XDG-portal windows outside CEF entirely.

## The fixes

**Desktop window opens at 1280x800.** macOS always did; Windows and Linux opened at 800x600, cramped for the library grid and a two-page spread. Clamped to 90% of the monitor work area so it cannot open partly off-screen on a 1366x768 laptop. First launch only — later ones restore the saved geometry.

**Add Catalog dialog matches the catalog manager.** It took daisyUI's bare `modal-box` default: 512x889 against the 640x756 manager it opens on top of, so it sat narrower than the window behind it and ran 89px off the bottom of a 1280x800 window, putting Cancel / Add Catalog out of reach. Both now size from one exported class string.

**No more native scrollbar flash on the library.** Reloading showed the platform scrollbar for ~1.8s, then lost it, shifting the grid 15px. Virtuoso owns the scroller inside the OverlayScrollbars root and gives it `overflow-y: auto` inline; OverlayScrollbars' own pre-init hiding rules only cover the root element we hand it, never that child. The CSS extends the same convention to the scroller, scoped to the pre-init window, and covers the reader sidebar's TOC and book-note lists too.

## Verification

`pnpm test` (907 files / 10950 tests), `pnpm lint`, `pnpm format:check`, `pnpm test:rust` (131 tests, 3 new for the window-size clamp), `pnpm fmt:check`, `pnpm clippy:check` — all green.

Measured against the running app over CDP:

| | before | after |
|---|---|---|
| scroller gutter on reload | 0 → **15** → 0 | 0 throughout |
| add-catalog box vs manager | 512x889 vs 640x756 | 640x756, same origin |
| first-launch window | 800x600 | 1280x800 |

The scrollbar fix was A/B'd by disabling the rule and re-measuring on live reloads; a screencast of the reload confirms no scrollbar is painted at the right edge.

Note: two specs (`native-app-service-gallery`, `native-app-service-share`) intermittently hit their 5s timeout in a full-parallelism local run — they `await import('@/services/nativeAppService')` inside the test body and lose the race against on-demand transforms. They pass in isolation and under CI's `--maxWorkers=4`. Pre-existing, untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added developer tooling for inspecting, evaluating, clicking, capturing screenshots, and viewing logs in the Linux desktop app through Chrome DevTools Protocol.
  - Added documentation and commands for launching and connecting to the debugging endpoint.

- **Improvements**
  - Desktop windows now adapt to smaller screens while maintaining a practical default size.
  - Catalog and Add/Edit Catalog dialogs now use consistent sizing.
  - Prevented temporary scrollbar flicker and content shifting while lists initialize.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->