### PR TITLE
fix(epub): match `[xml|lang]` and `:lang()` on `xml:lang` attributes

### DIFF
--- a/apps/readest-app/src/__tests__/utils/style-dom.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-dom.test.ts
@@ -701,14 +701,23 @@ describe('applyNamespacedAttributes', () => {
     expect(doc.querySelector('a')!.getAttributeNS(OPS, 'type')).toBe('noteref');
   });
 
-  it('leaves the reserved xml and xmlns names untouched', () => {
-    const doc = parseAsSrcdoc('<div xml:lang="en">x</div>');
+  // The `xml` prefix is bound by the XML spec itself and never declared with
+  // `xmlns:xml`, so a book's `@namespace xml` + `[xml|lang="en"]` rule needs
+  // the implicit binding restored the same way.
+  it('binds the implicit xml prefix so [xml|lang] selectors can match', () => {
+    const doc = parseAsSrcdoc('<div xml:lang="en">x</div>', '');
+    applyNamespacedAttributes(doc);
+    const div = doc.querySelector('div')!;
+    expect(div.getAttributeNS('http://www.w3.org/XML/1998/namespace', 'lang')).toBe('en');
+    expect(div.getAttribute('xml:lang')).toBe('en');
+  });
+
+  it('leaves xmlns declarations untouched', () => {
+    const doc = parseAsSrcdoc('<div>x</div>');
     applyNamespacedAttributes(doc);
     const html = doc.documentElement;
-    const div = doc.querySelector('div')!;
-    expect(div.getAttributeNS('http://www.w3.org/XML/1998/namespace', 'lang')).toBeNull();
-    expect(div.getAttribute('xml:lang')).toBe('en');
     expect(html.getAttribute('xmlns:epub')).toBe(OPS);
+    expect(html.getAttributeNS('http://www.w3.org/2000/xmlns/', 'epub')).toBeNull();
   });
 
   it('does not let a declaration reach a sibling that is out of its scope', () => {

--- a/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
@@ -436,6 +436,9 @@ describe('getLayoutStyles branches (via getStyles)', () => {
     expect(css).not.toContain('text-indent: 2em');
     expect(css).not.toContain('hyphens: auto');
     expect(css).not.toContain('-webkit-hyphens: auto');
+    // the body line-height reset exists to make room for our paragraph rules;
+    // with the book's layout in charge its `body { line-height }` must inherit
+    expect(css).not.toContain('line-height: unset');
     // non-paragraph layout rules must still be emitted
     expect(css).toContain('@namespace epub');
     expect(css).toContain('--margin-top: 50px');
@@ -465,6 +468,7 @@ describe('getLayoutStyles branches (via getStyles)', () => {
     expect(css).toContain('letter-spacing: 2px');
     expect(css).toContain('text-indent: 2em');
     expect(css).toContain('hyphens: auto');
+    expect(css).toContain('line-height: unset');
   });
 });
 

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1365,6 +1365,7 @@ export const applyScrollModeClass = (document: Document, isScrollMode: boolean) 
 // A prefixed attribute name, e.g. the `epub:type` of `epub:type="chapter"`.
 const PREFIXED_ATTR_REGEX = /^([A-Za-z_][\w.-]*):([A-Za-z_][\w.-]*)$/;
 const EPUB_OPS_NAMESPACE = 'http://www.idpf.org/2007/ops';
+const XML_NAMESPACE = 'http://www.w3.org/XML/1998/namespace';
 
 /**
  * Re-attach the namespaces an XHTML section declared to its prefixed
@@ -1402,8 +1403,12 @@ export const applyNamespacedAttributes = (document: Document) => {
       // document, so the declaration on the original <html> may be gone.
       // `epub` has one fixed namespace in EPUB, which is enough to restore the
       // selectors used by the book's stylesheet (including noteref markers).
+      // `xml` is bound by XML itself and is never declared, so `xml:lang`
+      // needs the same treatment for a book's `[xml|lang="en"]` rule to match.
       const uri =
-        lookupNamespace(element, prefix) ?? (prefix === 'epub' ? EPUB_OPS_NAMESPACE : null);
+        prefix === 'xml'
+          ? XML_NAMESPACE
+          : (lookupNamespace(element, prefix) ?? (prefix === 'epub' ? EPUB_OPS_NAMESPACE : null));
       if (uri && !element.hasAttributeNS(uri, localName!)) {
         element.setAttributeNS(uri, name, value);
       }

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -469,10 +469,6 @@ const getPageLayoutStyles = (
   }
 
   /* Now begins really dirty hacks to fix some badly designed epubs */
-  body {
-    line-height: unset;
-  }
-
   .duokan-footnote-content,
   .duokan-footnote-item {
     display: none;
@@ -591,6 +587,13 @@ const getParagraphLayoutStyles = (
   [align="right"] { text-align: right; }
   [align="center"] { text-align: center; }
   [align="justify"] { text-align: justify; }
+  /* Some badly designed EPUBs put their line-height on body; drop it so the
+     Line Spacing setting below, not an inherited value, spaces the text. It
+     lives in this chunk so Use Book Layout lets the book's body value
+     inherit (#6088). */
+  body {
+    line-height: unset;
+  }
   :is(hgroup, header) p {
       text-align: unset;
       hyphens: unset;


### PR DESCRIPTION
Closes #6088

A Sigil test book from the reporter binds the `xml` prefix and styles by `xml:lang`:

```css
@namespace xml "http://www.w3.org/XML/1998/namespace";
[xml|lang="en"] { color: red; }
```

With `<p xml:lang="en">` the paragraph stayed in the theme text color.

### Why

Sections reach the iframe through `iframe.srcdoc`, which is always parsed as HTML, so a prefixed attribute lands in the null namespace under its literal name (#6038). `applyNamespacedAttributes` re-attached a namespace only for prefixes the document declared with `xmlns:*`, plus a fixed `epub` fallback. The `xml` prefix is bound by the XML spec itself and is never declared with `xmlns:xml`, so it was skipped and both `[xml|lang]` and `:lang()` saw nothing.

The first commit binds `xml` to `http://www.w3.org/XML/1998/namespace` in the same place. The original attribute stays put, so `getAttribute('xml:lang')` callers are unaffected.

Side benefit: `:lang()` now matches content tagged only with `xml:lang`, which is what EPUB 3 XHTML commonly uses. That covers a book's own language-dependent rules and our `:lang(zh), :lang(ja), :lang(ko)` widows/orphans rule, and it feeds hyphenation.

Verified in the web dev build (Chromium), reading the section iframe through the open shadow roots:

| | `getComputedStyle(p).color` | `p.matches(':lang(en)')` | `p.getAttributeNS(XML_NS, 'lang')` |
| --- | --- | --- | --- |
| before | `rgb(23, 23, 23)` | `false` | `null` |
| after | `rgb(255, 0, 0)` | `true` | `"en"` |

### Second commit: Use Book Layout vs `body { line-height }`

The same reporter sent a book with `body { color: red; line-height: 3 }`. `body { line-height: unset }` is a deliberate reset so the Line Spacing setting reaches the text, but it sat in the always-on page-layout chunk while **Use Book Layout** only drops the paragraph-layout chunk. So even with the toggle on, such a book rendered at `line-height: normal`.

The reset moves next to the paragraph rules it exists for. With Use Book Layout on, paragraphs inherit the book's value (48px at a 16px font); with it off nothing changes (22.4px).

Body-level `color` is deliberately left alone. Readest's stylesheet is appended after the book's, so `html, body { color }` wins on equal specificity, and a book's `body { color: #333 }` overriding the theme would make dark mode unreadable. A book that targets elements directly, or uses `!important`, still wins.

### Tests

`applyNamespacedAttributes` now has a case asserting the `xml` binding (replacing one that asserted the old skip), and the `getStyles` layout tests assert `line-height: unset` is present with Use Book Layout off and absent with it on.

`pnpm test`, `pnpm lint` and `pnpm format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved XML namespace attribute handling so selectors such as `[xml|lang]` match correctly.
  - Fixed line-height behavior in book layouts by preventing unintended resets while preserving standard styling elsewhere.
- **Tests**
  - Added regression coverage for XML namespace selectors and layout-specific line-height behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->