### PR TITLE
feat(ui): dismiss bottom sheets by swiping down from anywhere

### DIFF
--- a/apps/readest-app/src/__tests__/components/dialog-swipe-dismiss.test.tsx
+++ b/apps/readest-app/src/__tests__/components/dialog-swipe-dismiss.test.tsx
@@ -123,6 +123,30 @@ describe('Dialog swipe-to-dismiss', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  // The system can take the touch away after the swipe has already become a
+  // drag — an edge-swipe back gesture, the notification shade. That is not a
+  // decision to dismiss, and it must not leave the drag half-finished: the
+  // viewport-wide shield useDrag installs would swallow every later tap.
+  it('restores the sheet when the system cancels a swipe already under way', () => {
+    const onClose = vi.fn();
+    render(<Sheet onClose={onClose} />);
+    const modal = document.querySelector('.modal-box') as HTMLElement;
+
+    const entry = screen.getByTestId('entry');
+    entry.dispatchEvent(touchEvent('touchstart', 100, 300));
+    entry.dispatchEvent(touchEvent('touchmove', 100, 320));
+    window.dispatchEvent(touchEvent('touchmove', 100, 700));
+    expect(document.querySelector('.drag-shield')).not.toBeNull();
+
+    window.dispatchEvent(touchEvent('touchcancel', 100, 700));
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(document.querySelector('.drag-shield')).toBeNull();
+    // Back to its resting snap, not left wherever the finger was.
+    expect(modal.style.height).toBe('75%');
+    expect(modal.style.transform).toBe('');
+  });
+
   it('does not dismiss on a desktop-sized viewport', () => {
     setViewport(1440, 900);
     const onClose = vi.fn();

--- a/apps/readest-app/src/__tests__/components/dialog-swipe-dismiss.test.tsx
+++ b/apps/readest-app/src/__tests__/components/dialog-swipe-dismiss.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * A bottom sheet must be dismissible with a downward swipe that starts anywhere
+ * on it, not only on the 24px drag handle at its top edge (#6089): after reading
+ * a dictionary entry the thumb sits near the bottom of the phone, and reaching
+ * the handle takes a second hand.
+ *
+ * The swipe still has to yield to the sheet's own content: a scroller that is
+ * already scrolled owns the gesture, and so does a text field.
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (value: string) => value,
+}));
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: null }),
+}));
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({
+    systemUIVisible: false,
+    statusBarHeight: 0,
+    safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+  }),
+}));
+vi.mock('@/store/deviceStore', () => ({
+  useDeviceControlStore: () => ({
+    acquireBackKeyInterception: vi.fn(),
+    releaseBackKeyInterception: vi.fn(),
+  }),
+}));
+vi.mock('@tauri-apps/plugin-haptics', () => ({ impactFeedback: vi.fn() }));
+
+const { default: Dialog } = await import('@/components/Dialog');
+
+// jsdom has no Touch/TouchEvent constructors; Dialog and useDrag only read
+// touches[0].clientX/clientY, so a plain Event with the fields grafted on is a
+// faithful stand-in.
+const touchEvent = (type: string, x: number, y: number): Event => {
+  const event = new Event(type, { bubbles: true });
+  const touch = { clientX: x, clientY: y };
+  Object.assign(event, { touches: [touch], changedTouches: [touch] });
+  return event;
+};
+
+// jsdom reports every scroll metric as 0; pin the one the gesture reads.
+const mockScrollTop = (el: HTMLElement, scrollTop: number) =>
+  Object.defineProperty(el, 'scrollTop', { configurable: true, value: scrollTop });
+
+const setViewport = (width: number, height: number) => {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: width });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: height });
+};
+
+const swipeDown = (from: HTMLElement) => {
+  from.dispatchEvent(touchEvent('touchstart', 100, 300));
+  from.dispatchEvent(touchEvent('touchmove', 100, 320));
+  window.dispatchEvent(touchEvent('touchmove', 100, 800));
+  window.dispatchEvent(touchEvent('touchend', 100, 800));
+};
+
+const Sheet = ({ onClose }: { onClose: () => void }) => (
+  <Dialog isOpen snapHeight={0.75} title='Dictionary' onClose={onClose}>
+    <div data-testid='scroller'>
+      <p data-testid='entry'>a house is a building for people to live in</p>
+      <textarea data-testid='note' defaultValue='' />
+    </div>
+  </Dialog>
+);
+
+beforeEach(() => setViewport(390, 844));
+afterEach(() => cleanup());
+
+describe('Dialog swipe-to-dismiss', () => {
+  it('dismisses on a downward swipe that starts in the sheet body', () => {
+    const onClose = vi.fn();
+    render(<Sheet onClose={onClose} />);
+
+    swipeDown(screen.getByTestId('entry'));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('still dismisses on a downward swipe from the drag handle', () => {
+    const onClose = vi.fn();
+    render(<Sheet onClose={onClose} />);
+
+    swipeDown(document.querySelector('.drag-handle') as HTMLElement);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('leaves the gesture to a scroller that is already scrolled', () => {
+    const onClose = vi.fn();
+    render(<Sheet onClose={onClose} />);
+    mockScrollTop(screen.getByTestId('scroller'), 40);
+
+    swipeDown(screen.getByTestId('entry'));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('leaves the gesture to a text field', () => {
+    const onClose = vi.fn();
+    render(<Sheet onClose={onClose} />);
+
+    swipeDown(screen.getByTestId('note'));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('ignores a sideways swipe', () => {
+    const onClose = vi.fn();
+    render(<Sheet onClose={onClose} />);
+
+    const entry = screen.getByTestId('entry');
+    entry.dispatchEvent(touchEvent('touchstart', 100, 300));
+    entry.dispatchEvent(touchEvent('touchmove', 220, 310));
+    window.dispatchEvent(touchEvent('touchmove', 300, 800));
+    window.dispatchEvent(touchEvent('touchend', 300, 800));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not dismiss on a desktop-sized viewport', () => {
+    setViewport(1440, 900);
+    const onClose = vi.fn();
+    render(<Sheet onClose={onClose} />);
+
+    swipeDown(screen.getByTestId('entry'));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/useDrag.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useDrag.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, cleanup, act } from '@testing-library/react';
-import type { MouseEvent as ReactMouseEvent } from 'react';
+import type { MouseEvent as ReactMouseEvent, TouchEvent as ReactTouchEvent } from 'react';
 
 import { useDrag } from '@/hooks/useDrag';
 
@@ -25,6 +25,24 @@ const startMouseDrag = (api: Api, clientX = 100) => {
 const fireWindowMouse = (type: string, clientX: number, clientY = 0) => {
   act(() => {
     window.dispatchEvent(new MouseEvent(type, { clientX, clientY, bubbles: true }));
+  });
+};
+
+const startTouchDrag = (api: Api, clientY = 0) => {
+  act(() => {
+    api.handleDragStart({ touches: [{ clientX: 0, clientY }] } as unknown as ReactTouchEvent);
+  });
+};
+
+// jsdom has no Touch/TouchEvent constructors; the hook only reads
+// touches[0] / changedTouches[0], so a plain Event with the fields grafted on is
+// a faithful stand-in.
+const fireWindowTouch = (type: string, clientY: number) => {
+  act(() => {
+    const event = new Event(type, { bubbles: true });
+    const touch = { clientX: 0, clientY };
+    Object.assign(event, { touches: [touch], changedTouches: [touch] });
+    window.dispatchEvent(event);
   });
 };
 
@@ -66,5 +84,39 @@ describe('useDrag', () => {
     // No further resizing after release.
     fireWindowMouse('mousemove', 200);
     expect(onMove).toHaveBeenCalledTimes(1);
+  });
+
+  // The system can take a touch away mid-drag — an edge-swipe back gesture, the
+  // notification shade, an incoming call. Only `touchend` used to tear the drag
+  // down, so a cancel left the viewport-wide shield installed and every tap
+  // afterwards landed on it instead of the app.
+  it('tears the drag down when the system cancels the touch', () => {
+    const { getApi, onMove, onEnd } = setup();
+    startTouchDrag(getApi());
+    fireWindowTouch('touchmove', 60);
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(getShield()).not.toBeNull();
+
+    fireWindowTouch('touchcancel', 60);
+
+    expect(getShield()).toBeNull();
+    expect(document.body.style.userSelect).toBe('');
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    // Consumers must be able to tell a cancel from a release: a cancelled drag
+    // is not a decision, so it must not be read as one.
+    expect(onEnd.mock.calls[0]![0]!.canceled).toBe(true);
+
+    // No further dragging after the cancel.
+    fireWindowTouch('touchmove', 200);
+    expect(onMove).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a released drag as not cancelled', () => {
+    const { getApi, onEnd } = setup();
+    startMouseDrag(getApi());
+
+    fireWindowMouse('mouseup', 150);
+
+    expect(onEnd.mock.calls[0]![0]!.canceled).toBe(false);
   });
 });

--- a/apps/readest-app/src/components/Dialog.tsx
+++ b/apps/readest-app/src/components/Dialog.tsx
@@ -186,7 +186,7 @@ const Dialog: React.FC<DialogProps> = ({
     }
   };
 
-  const handleDragEnd = (data: { velocity: number; clientY: number }) => {
+  const handleDragEnd = (data: { velocity: number; clientY: number; canceled: boolean }) => {
     if (!dismissible || !isMobile || !dialogRef.current) return;
     const modal = dialogRef.current.querySelector('.modal-box') as HTMLElement;
     const overlay = dialogRef.current.querySelector('.overlay') as HTMLElement;
@@ -195,9 +195,12 @@ const Dialog: React.FC<DialogProps> = ({
     const top = data.clientY - dragOffsetRef.current;
     const snapUpper = snapHeight ? 1 - snapHeight - SNAP_THRESHOLD : 0.5;
     const snapLower = snapHeight ? 1 - snapHeight + SNAP_THRESHOLD : 0.5;
+    // A cancelled drag is the system taking the touch away, not the user letting
+    // go: put the sheet back where it was rather than reading a decision into it.
     if (
-      data.velocity > VELOCITY_THRESHOLD ||
-      (data.velocity >= 0 && top >= window.innerHeight * snapLower)
+      !data.canceled &&
+      (data.velocity > VELOCITY_THRESHOLD ||
+        (data.velocity >= 0 && top >= window.innerHeight * snapLower))
     ) {
       // dialog is dismissed
       const transitionDuration = 0.15 / Math.max(data.velocity, 0.5);
@@ -212,8 +215,8 @@ const Dialog: React.FC<DialogProps> = ({
       }, 300);
     } else if (
       snapHeight &&
-      top > window.innerHeight * snapUpper &&
-      top < window.innerHeight * snapLower
+      (data.canceled ||
+        (top > window.innerHeight * snapUpper && top < window.innerHeight * snapLower))
     ) {
       // dialog is snapped
       overlay.style.transition = `opacity 0.3s ease-out`;
@@ -230,7 +233,7 @@ const Dialog: React.FC<DialogProps> = ({
       modal.style.transform = `translateY(0%)`;
       overlay.style.opacity = '0';
     }
-    if (appService?.hasHaptics) {
+    if (appService?.hasHaptics && !data.canceled) {
       impactFeedback('medium');
     }
   };

--- a/apps/readest-app/src/components/Dialog.tsx
+++ b/apps/readest-app/src/components/Dialog.tsx
@@ -16,6 +16,10 @@ import { Overlay } from './Overlay';
 
 const VELOCITY_THRESHOLD = 0.5;
 const SNAP_THRESHOLD = 0.2;
+// How far a downward swipe that starts on the sheet body must travel before it
+// takes the gesture over from the content. Below it the touch still belongs to
+// the content, so taps and scrolls are unaffected.
+const SWIPE_DISMISS_THRESHOLD = 8;
 // How long the modal takes to fade and scale away once `isOpen` goes false.
 const CLOSE_TRANSITION_MS = 300;
 
@@ -43,6 +47,20 @@ interface DialogProps {
   onClose: () => void;
 }
 
+// A swipe that starts on a scroller which is not at its top belongs to that
+// scroller: the user is scrolling back up, not dismissing the sheet.
+const hasScrolledAncestor = (target: HTMLElement, root: HTMLElement) => {
+  for (let el: HTMLElement | null = target; el && el !== root; el = el.parentElement) {
+    if (el.scrollTop > 0) return true;
+  }
+  return false;
+};
+
+// Dragging inside a text field moves the caret; it must never close the sheet
+// the field lives in (the Annotate note editor is one).
+const isEditable = (target: HTMLElement) =>
+  !!target.closest('input, textarea, select, [contenteditable=""], [contenteditable="true"]');
+
 const Dialog: React.FC<DialogProps> = ({
   id,
   isOpen,
@@ -65,6 +83,11 @@ const Dialog: React.FC<DialogProps> = ({
   const [isFullHeightInMobile, setIsFullHeightInMobile] = useState(!snapHeight);
   const [isRtl] = useState(() => getDirFromUILanguage() === 'rtl');
   const dialogRef = useRef<HTMLDialogElement>(null);
+  // Where the finger sits relative to the sheet's top edge, so the sheet slides
+  // with it instead of snapping its top edge under it — the drag handle sits at
+  // that edge, the body does not.
+  const dragOffsetRef = useRef(0);
+  const pendingSwipeRef = useRef<{ x: number; y: number } | null>(null);
   const previousActiveElementRef = useRef<HTMLElement | null>(null);
   const iconSize22 = useResponsiveSize(22);
   const isMobile = window.innerWidth < 640 || window.innerHeight < 640;
@@ -149,7 +172,8 @@ const Dialog: React.FC<DialogProps> = ({
     const modal = dialogRef.current.querySelector('.modal-box') as HTMLElement;
     const overlay = dialogRef.current.querySelector('.overlay') as HTMLElement;
 
-    const heightFraction = data.clientY / window.innerHeight;
+    const top = data.clientY - dragOffsetRef.current;
+    const heightFraction = top / window.innerHeight;
     const newTop = Math.max(0.0, Math.min(1, heightFraction));
 
     if (modal && overlay) {
@@ -157,7 +181,7 @@ const Dialog: React.FC<DialogProps> = ({
       modal.style.transform = `translateY(${newTop * 100}%)`;
       overlay.style.opacity = `${1 - heightFraction}`;
 
-      setIsFullHeightInMobile(data.clientY < 44);
+      setIsFullHeightInMobile(top < 44);
       modal.style.transition = `padding-top 0.3s ease-out`;
     }
   };
@@ -168,11 +192,12 @@ const Dialog: React.FC<DialogProps> = ({
     const overlay = dialogRef.current.querySelector('.overlay') as HTMLElement;
     if (!modal || !overlay) return;
 
+    const top = data.clientY - dragOffsetRef.current;
     const snapUpper = snapHeight ? 1 - snapHeight - SNAP_THRESHOLD : 0.5;
     const snapLower = snapHeight ? 1 - snapHeight + SNAP_THRESHOLD : 0.5;
     if (
       data.velocity > VELOCITY_THRESHOLD ||
-      (data.velocity >= 0 && data.clientY >= window.innerHeight * snapLower)
+      (data.velocity >= 0 && top >= window.innerHeight * snapLower)
     ) {
       // dialog is dismissed
       const transitionDuration = 0.15 / Math.max(data.velocity, 0.5);
@@ -187,8 +212,8 @@ const Dialog: React.FC<DialogProps> = ({
       }, 300);
     } else if (
       snapHeight &&
-      data.clientY > window.innerHeight * snapUpper &&
-      data.clientY < window.innerHeight * snapLower
+      top > window.innerHeight * snapUpper &&
+      top < window.innerHeight * snapLower
     ) {
       // dialog is snapped
       overlay.style.transition = `opacity 0.3s ease-out`;
@@ -214,6 +239,51 @@ const Dialog: React.FC<DialogProps> = ({
 
   const { handleDragStart } = useDrag(handleDragMove, handleDragKeyDown, handleDragEnd);
 
+  const beginDrag = (e: React.MouseEvent | React.TouchEvent) => {
+    const modal = dialogRef.current?.querySelector('.modal-box') as HTMLElement | null;
+    const clientY = 'touches' in e ? e.touches[0]!.clientY : e.clientY;
+    dragOffsetRef.current = modal ? clientY - modal.getBoundingClientRect().top : 0;
+    handleDragStart(e);
+  };
+
+  // The drag handle is a 24px strip at the top of the sheet, out of reach of the
+  // thumb that just finished reading (#6089), so a downward swipe anywhere on the
+  // sheet dismisses it too. It only takes over once the finger has clearly gone
+  // down rather than sideways, and only when the content under it has nothing
+  // left to scroll — so the sheet never steals a tap, a scroll or a page swipe.
+  const handleSheetTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    pendingSwipeRef.current = null;
+    if (!dismissible || !isMobile || e.touches.length !== 1) return;
+    const target = e.target as HTMLElement;
+    // The handle starts its own drag on touchstart; don't arm a second one.
+    if (target.closest('.drag-handle')) return;
+    if (isEditable(target) || hasScrolledAncestor(target, e.currentTarget)) return;
+    const touch = e.touches[0]!;
+    pendingSwipeRef.current = { x: touch.clientX, y: touch.clientY };
+  };
+
+  const handleSheetTouchMove = (e: React.TouchEvent) => {
+    const pending = pendingSwipeRef.current;
+    if (!pending || e.touches.length !== 1) return;
+    const touch = e.touches[0]!;
+    const deltaX = touch.clientX - pending.x;
+    const deltaY = touch.clientY - pending.y;
+    if (Math.abs(deltaX) > Math.abs(deltaY) || deltaY < -SWIPE_DISMISS_THRESHOLD) {
+      // Sideways, or upwards: the gesture belongs to the content.
+      pendingSwipeRef.current = null;
+      return;
+    }
+    if (deltaY < SWIPE_DISMISS_THRESHOLD) return;
+    pendingSwipeRef.current = null;
+    beginDrag(e);
+  };
+
+  // Android hands the touch to its own selection handles once a long press turns
+  // into a selection drag, and cancels the page's sequence; disarm with it.
+  const handleSheetTouchCancel = () => {
+    pendingSwipeRef.current = null;
+  };
+
   return (
     <dialog
       ref={dialogRef}
@@ -237,7 +307,11 @@ const Dialog: React.FC<DialogProps> = ({
         )}
         onDismiss={onClose}
       />
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
       <div
+        onTouchStart={handleSheetTouchStart}
+        onTouchMove={handleSheetTouchMove}
+        onTouchCancel={handleSheetTouchCancel}
         className={clsx(
           'modal-box settings-content absolute z-20 flex flex-col rounded-none rounded-tl-2xl rounded-tr-2xl p-0 sm:rounded-2xl',
           'h-full max-h-full w-full max-w-full',
@@ -264,8 +338,8 @@ const Dialog: React.FC<DialogProps> = ({
             'drag-handle mb-2 h-6 max-h-6 min-h-6 w-full cursor-row-resize items-center justify-center',
             'transition-padding-top flex duration-300 ease-out sm:hidden',
           )}
-          onMouseDown={handleDragStart}
-          onTouchStart={handleDragStart}
+          onMouseDown={beginDrag}
+          onTouchStart={beginDrag}
         >
           <div className='bg-base-content/50 h-1 w-10 rounded-full'></div>
         </div>

--- a/apps/readest-app/src/hooks/useDrag.ts
+++ b/apps/readest-app/src/hooks/useDrag.ts
@@ -12,6 +12,10 @@ export const useDrag = (
     clientY: number;
     deltaX: number;
     deltaY: number;
+    // The system took the touch away (edge-swipe back gesture, notification
+    // shade, incoming call) instead of the user releasing it. A cancelled drag
+    // carries no decision — restore, never act on where it stopped.
+    canceled: boolean;
   }) => void,
   cursor: string = 'col-resize',
 ) => {
@@ -86,7 +90,7 @@ export const useDrag = (
         }
       };
 
-      const handleEnd = (event: MouseEvent | TouchEvent) => {
+      const handleEnd = (event: MouseEvent | TouchEvent, canceled = false) => {
         isDragging.current = false;
 
         shield.remove();
@@ -114,19 +118,26 @@ export const useDrag = (
         const velocity = deltaY / deltaT;
 
         if (onDragEnd) {
-          onDragEnd({ velocity, deltaT, clientX, clientY, deltaX, deltaY });
+          onDragEnd({ velocity, deltaT, clientX, clientY, deltaX, deltaY, canceled });
         }
 
         window.removeEventListener('mousemove', handleMove);
         window.removeEventListener('mouseup', handleEnd);
         window.removeEventListener('touchmove', handleMove);
         window.removeEventListener('touchend', handleEnd);
+        window.removeEventListener('touchcancel', handleCancel);
       };
+
+      // A cancelled touch never fires `touchend`, so without this the shield
+      // above stays in the DOM and swallows every tap until some later touch
+      // happens to end on the window.
+      const handleCancel = (event: TouchEvent) => handleEnd(event, true);
 
       window.addEventListener('mousemove', handleMove, { passive: true });
       window.addEventListener('mouseup', handleEnd);
       window.addEventListener('touchmove', handleMove, { passive: true });
       window.addEventListener('touchend', handleEnd);
+      window.addEventListener('touchcancel', handleCancel);
     },
     [onDragMove, onDragEnd, cursor],
   );

--- a/apps/readest-app/src/hooks/useSwipeToDismiss.ts
+++ b/apps/readest-app/src/hooks/useSwipeToDismiss.ts
@@ -33,15 +33,22 @@ export const useSwipeToDismiss = (
     onDragMove?.(data);
   };
 
-  const handleVerticalDragEnd = (data: { velocity: number; clientY: number }) => {
+  const handleVerticalDragEnd = (data: {
+    velocity: number;
+    clientY: number;
+    canceled: boolean;
+  }) => {
     const panel = panelRef.current;
     const overlay = overlayRef.current;
 
     if (!panel || !overlay) return;
 
+    // A cancelled drag is the system taking the touch away, not the user letting
+    // go: slide the panel back rather than reading a dismissal into it.
     if (
-      data.velocity > VELOCITY_THRESHOLD ||
-      (data.velocity >= 0 && data.clientY >= window.innerHeight * 0.5)
+      !data.canceled &&
+      (data.velocity > VELOCITY_THRESHOLD ||
+        (data.velocity >= 0 && data.clientY >= window.innerHeight * 0.5))
     ) {
       const transitionDuration = 0.15 / Math.max(data.velocity, 0.5);
       panel.style.transition = `transform ${transitionDuration}s ease-out`;


### PR DESCRIPTION
Closes #6089.

The drag handle is a 24px strip at the very top of the sheet. After reading a dictionary entry the thumb sits near the bottom of the phone, so dismissing meant reaching the whole way up — a two-handed gesture on a phone.

A downward swipe starting anywhere on the sheet now dismisses it. `Dialog` is the shared chassis, so this covers the dictionary, the note editor, the TTS player, Settings and the rest.

## How it stays out of the way

The gesture is armed on `touchstart` and only takes over once the finger has moved 8px and mostly vertically — until then the touch still belongs to the content, so taps, clicks and scrolls are untouched. It backs off entirely for:

- a target inside an already-scrolled ancestor (the user is scrolling back up, and that scroller owns the gesture)
- text fields and sliders (`input` / `textarea` / `select` / `contenteditable`) — the Annotate note editor's textarea, the TTS player's seek bar
- sideways or upward movement
- non-dismissible dialogs (the busy states in `BackupWindow`, `HardcoverLinkDialog`, `AudiobookPairingDialog`)
- multi-touch, and desktop-sized viewports
- `touchcancel`, which is what Android sends when a long press turns into a native selection drag

## Drag positioning

`handleDragMove` / `handleDragEnd` now place the sheet relative to where the finger grabbed it, instead of pinning the sheet's top edge to the finger. That was invisible while only the handle could start a drag — the handle sits at that edge — but dragging from the body needs it. It also stops the handle from jumping the sheet down by the handle height plus the status-bar padding at the start of a drag.

## Testing

`src/__tests__/components/dialog-swipe-dismiss.test.tsx` — written first, and confirmed failing on the body-swipe case only; the other five cases passed against the old code, which is what makes the harness trustworthy.

- `pnpm test` — full suite green
- `pnpm lint`, `pnpm format:check` — clean

**Not yet verified on a device.** The part I'd most want to see on real hardware is the gesture arbitration against Android WebView's native selection handles in the dictionary sheet, and the feel of the 8px takeover threshold against the sheet's own scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added swipe-to-dismiss support for mobile bottom sheets from the sheet body or drag handle.
  - Preserved scrolling and text-editing gestures within nested content.
  - Rejected unsupported horizontal or upward swipes and maintained non-dismissal behavior on desktop-sized screens.

- **Bug Fixes**
  - Improved drag positioning and dismissal decisions based on the gesture’s starting point.
  - Interrupted touch gestures now safely restore the sheet and clean up drag state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->