### PR TITLE
Fix Wayland WebKitGTK window sizing bug on non-CEF Linux builds

### DIFF
--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -357,6 +357,27 @@ type AppRuntime = tauri::Wry;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 #[cfg_attr(all(feature = "cef", target_os = "linux"), tauri::cef_entry_point)]
 pub fn run() {
+    // WebKitGTK's native-Wayland surface handling has a longstanding GTK/Mutter
+    // bug where a webview's first `configure` event can report a 0 height
+    // (`gdk_wayland_window_configure: assertion 'height > 0' failed`), and
+    // subsequent frames get cropped/rescaled until the compositor forces a
+    // relayout (e.g. on focus change). It reproduces on GNOME's Wayland
+    // session but not XWayland, and only affects the WebKitGTK (`wry`)
+    // runtime used by non-CEF Linux builds such as Flatpak; the CEF runtime
+    // that ships in our official deb/rpm/AppImage builds is unaffected (see
+    // #6096). This must run before GTK/webkit initialize (i.e. before
+    // `tauri::Builder::run`), so force XWayland here unless the user already
+    // picked a backend. This mirrors the same workaround already applied to
+    // the Nix dev shell in flake.nix.
+    #[cfg(all(target_os = "linux", not(feature = "cef")))]
+    if std::env::var_os("GDK_BACKEND").is_none() && std::env::var_os("WAYLAND_DISPLAY").is_some() {
+        // SAFETY: this is the first thing `run()` does, before any other
+        // thread (tauri's async runtime, GTK, etc.) exists to race with it.
+        unsafe {
+            std::env::set_var("GDK_BACKEND", "x11");
+        }
+    }
+
     // Initialize Sentry as early as possible so panics during startup are
     // captured. `None` DSN (unset SENTRY_DSN) => disabled, so local and fork
     // builds don't report. This client covers Rust panics and the events the


### PR DESCRIPTION
Fixes #6096.

## Problem
On GNOME/Wayland (e.g. Ubuntu 26.04, GNOME 50), the Flatpak build shows:
1. New reader windows spawning with zero height (only page number/progress bar visible) until manually resized.
2. Pages becoming cropped/zoomed after a few pagination cycles, which resets when the window loses focus.

The log includes `gdk_wayland_window_configure: assertion 'height > 0' failed`, a known GTK/WebKitGTK bug on native Wayland sessions that does not reproduce under XWayland.

The reporter noted the AppImage build doesn't have this problem — that's because our official deb/rpm/AppImage releases ship the CEF webview runtime (see `.github/workflows/release.yml`), while Flatpak (built externally, outside this repo's release pipeline) uses the default WebKitGTK (`wry`) runtime, which hits this bug. Notably, our own Nix dev shell (`flake.nix`) already forces `GDK_BACKEND = "x11"` for the same reason.

## Fix
At the very start of `run()`, for Linux builds without the `cef` feature, force `GDK_BACKEND=x11` when running under a native Wayland session (`WAYLAND_DISPLAY` set) and the user hasn't already picked a backend. This runs before GTK/WebKitGTK initialize, so it reliably routes the webview through XWayland, avoiding the buggy native-Wayland configure path.

This only affects non-CEF Linux builds (in practice, Flatpak and from-source builds); the official deb/rpm/AppImage releases are already unaffected since they use CEF.

## Testing
No local Rust toolchain was available in this environment to run a full `cargo check`/build, so this change was reviewed carefully for correctness (cfg gating, edition-appropriate `unsafe` around `env::set_var`, and placement before any other initialization). I'd appreciate a CI build/Flatpak test to confirm, and I'm happy to iterate based on feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup on Linux systems using Wayland by preventing webview windows from appearing with an incorrect zero height.
  * CEF builds and non-Linux platforms remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->