### PR TITLE
fix(tts): allow Apple Enhanced and Premium Web TTS voices

### DIFF
--- a/apps/readest-app/src/services/tts/WebSpeechClient.ts
+++ b/apps/readest-app/src/services/tts/WebSpeechClient.ts
@@ -244,7 +244,11 @@ export class WebSpeechClient implements TTSClient {
   async getVoices(lang: string) {
     const locale = lang === 'en' ? getUserLocale(lang) || lang : lang;
     const isNotBlacklisted = (voice: SpeechSynthesisVoice) => {
-      return WEB_SPEECH_BLACKLISTED_VOICES.some((name) => voice.name.includes(name)) === false;
+      return (
+        !voice.voiceURI.startsWith('com.apple.eloquence.') &&
+        !voice.voiceURI.startsWith('com.apple.speech.synthesis.voice.') &&
+        !WEB_SPEECH_BLACKLISTED_VOICES.some((name) => voice.name.includes(name))
+      );
     };
     // Match by primary language so the voice set stays the same across a book
     // whose sections mix region variants (e.g. en-US front matter and en-GB
@@ -252,8 +256,19 @@ export class WebSpeechClient implements TTSClient {
     const filteredVoices = this.#voices
       .filter((voice) => isSameLang(voice.lang, lang))
       .filter(isNotBlacklisted);
+    const availableVoiceIds = new Set(filteredVoices.map((voice) => voice.voiceURI));
     const seenIds = new Set<string>();
     const voices = filteredVoices
+      // Keep compact voices as a fallback when no higher-quality variant is installed.
+      .filter((voice) => {
+        const compactPrefix = 'com.apple.voice.compact.';
+        if (!voice.voiceURI.startsWith(compactPrefix)) return true;
+        const voiceSuffix = voice.voiceURI.slice(compactPrefix.length);
+        return (
+          !availableVoiceIds.has(`com.apple.voice.enhanced.${voiceSuffix}`) &&
+          !availableVoiceIds.has(`com.apple.voice.premium.${voiceSuffix}`)
+        );
+      })
       .map(
         (voice) =>
           ({

--- a/apps/readest-app/src/services/tts/WebSpeechClient.ts
+++ b/apps/readest-app/src/services/tts/WebSpeechClient.ts
@@ -243,9 +243,6 @@ export class WebSpeechClient implements TTSClient {
 
   async getVoices(lang: string) {
     const locale = lang === 'en' ? getUserLocale(lang) || lang : lang;
-    const isValidVoice = (id: string) => {
-      return !id.includes('com.apple') || id.includes('com.apple.voice.compact');
-    };
     const isNotBlacklisted = (voice: SpeechSynthesisVoice) => {
       return WEB_SPEECH_BLACKLISTED_VOICES.some((name) => voice.name.includes(name)) === false;
     };
@@ -254,7 +251,6 @@ export class WebSpeechClient implements TTSClient {
     // body text); the requested locale's voices sort first. See #4033.
     const filteredVoices = this.#voices
       .filter((voice) => isSameLang(voice.lang, lang))
-      .filter((voice) => isValidVoice(voice.voiceURI || ''))
       .filter(isNotBlacklisted);
     const seenIds = new Set<string>();
     const voices = filteredVoices


### PR DESCRIPTION
Apple Enhanced and Premium voices reported by the browser were discarded by a compact-only Apple voice filter. Allow those voices in Web TTS while excluding Apple Eloquence and legacy speech-synthesis voice families, including voices missing from the existing name blacklist.

Hide a compact Apple voice when the matching Enhanced or Premium variant is installed; retain compact voices as a fallback otherwise. Preserve language filtering, the existing name blacklist, and voice ID deduplication.

Closes #6095.

Validation: `pnpm lint`, formatting, and `pnpm build` pass. Inspected the local macOS voice inventory to confirm the Eloquence blacklist gap. No unit tests added; the initial pre-push hook started Vitest and was stopped to honor the request to skip unit testing. Subsequent pushes bypass that hook after separate lint/build verification. Playback with downloaded Apple voices has not been manually verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined text-to-speech voice selection by excluding Apple Eloquence and standard system voices.
  * Compact Apple voices are available only when enhanced or premium alternatives are unavailable.
  * Voice selection continues to respect language compatibility and the configured blacklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->