### PR TITLE
fix(ci): bundle the NSS modules the CEF AppImage dlopens

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -138,6 +138,47 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libfontconfig-dev libgtk-3-dev libwebkit2gtk-4.1 libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1 libjavascriptcoregtk-4.1-dev gir1.2-javascriptcoregtk-4.1 gir1.2-webkit2-4.1 libappindicator3-dev librsvg2-dev patchelf xdg-utils
 
+      # The CEF AppImage bundles the build host's glibc, so anything it does
+      # NOT bundle is resolved from the host at run time, against a glibc the
+      # bundled one cannot satisfy on any distro newer than the builder. NSS is
+      # the fatal case: Chromium dlopens libsoftokn3.so, gets the host copy and
+      # aborts on first use (FATAL crypto/nss_util.cc, nss_error=-5925).
+      #
+      # quick-sharun's own DEPLOY_CHROMIUM rules cover these modules, but the
+      # bundler in cli-cef 3.0.0-alpha.26 downloads a fork of that script
+      # (FabianLars/Anylinux-AppImages, taken on feat/cef to fix spaces in
+      # paths) which is ~1100 lines behind pkgforge upstream and expands its
+      # deployment array without `eval`: every path keeps its literal quotes,
+      # so EVERY DEPLOY_* extra is skipped and only ldd-derived libraries land
+      # in the bundle. tauri-apps/tauri#12491 drops that fork for a pinned,
+      # checksummed upstream revision (facb95e8, which has the `eval`). Once it
+      # reaches feat/cef and a new cli-cef ships, bump CEF_CLI in
+      # apps/readest-app/scripts/tauri.mjs, lift the STRACE_MODE pin in the
+      # build step and drop the jq call below. Keep the flatten unless dlopen
+      # discovery is doing the finding: upstream globs only Arch's flat layout,
+      # so a Debian builder hides these modules from it either way.
+      #
+      # Until then, hand the modules over as appimage.files: the bundler passes
+      # files targeted at /usr/lib to quick-sharun as plain ELF arguments, the
+      # injection channel #12491 keeps. Sources must sit directly in the triple
+      # lib dir (Debian hides them in <triple>/nss/) because the destination
+      # inside the bundle mirrors the source dir, and only a flat source lands
+      # next to the libnss3.so that loads it.
+      - name: stage CEF AppImage runtime libraries (linux only)
+        if: matrix.config.release == 'linux'
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y libnss3
+          nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
+          lib_dir=${nss_dir%/nss}
+          sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
+          conf=apps/readest-app/src-tauri/tauri.conf.json
+          jq --arg d "$lib_dir" '.bundle.linux.appimage.files = {
+              "/usr/lib/libsoftokn3.so": ($d + "/libsoftokn3.so"),
+              "/usr/lib/libfreeblpriv3.so": ($d + "/libfreeblpriv3.so"),
+              "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so")
+            }' "$conf" > "$conf.tmp" && mv "$conf.tmp" "$conf"
+
       - name: create .env.local file for Next.js
         run: |
           echo "NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}" >> .env.local
@@ -231,7 +272,9 @@ jobs:
         # latest.json for ALL platforms (#4906).
         timeout-minutes: 45
         env:
-          # See release.yml: keep quick-sharun from running the app under Xvfb.
+          # See release.yml: keep quick-sharun from running the app under
+          # Xvfb. Lift this together with the AppImage library staging above,
+          # once cli-cef carries tauri-apps/tauri#12491.
           STRACE_MODE: '0'
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -247,6 +290,21 @@ jobs:
           node -e "const f='apps/readest-app/package.json';const j=require('./'+f);j.version='${version}';require('fs').writeFileSync(f, JSON.stringify(j,null,2)+'\n')"
           cd apps/readest-app
           pnpm tauri build ${{ matrix.config.args }}
+
+      # quick-sharun skips anything it cannot find without failing, which is
+      # how the AppImage shipped with no NSS modules at all. Fail the leg
+      # instead of shipping a bundle that crashes on first use. The path is the
+      # AppDir quick-sharun packed, left next to the AppImage in the WORKSPACE
+      # target dir (see the collect step below). libsqlite3 is not staged
+      # explicitly — it must arrive as libsoftokn3.so's own ldd dependency.
+      - name: verify the AppImage bundled its NSS modules (linux only)
+        if: matrix.config.release == 'linux'
+        run: |
+          set -euo pipefail
+          lib=target/release/bundle/appimage/Readest.AppDir/lib
+          for so in libsoftokn3.so libfreeblpriv3.so libnssckbi.so libsqlite3.so.0; do
+            [ -e "$lib/$so" ] || { echo "::error::$so is missing from the AppImage bundle"; exit 1; }
+          done
 
       # Portable Windows build: rebuild with NEXT_PUBLIC_PORTABLE_APP=true and
       # ship the raw exe (mirrors release.yml). Runs after the NSIS build above.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,6 +378,47 @@ jobs:
           echo 'CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc' >> $GITHUB_ENV
           echo 'CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS=--cfg=io_uring_skip_arch_check' >> $GITHUB_ENV
 
+      # The CEF AppImage bundles the build host's glibc, so anything it does
+      # NOT bundle is resolved from the host at run time, against a glibc the
+      # bundled one cannot satisfy on any distro newer than the builder. NSS is
+      # the fatal case: Chromium dlopens libsoftokn3.so, gets the host copy and
+      # aborts on first use (FATAL crypto/nss_util.cc, nss_error=-5925).
+      #
+      # quick-sharun's own DEPLOY_CHROMIUM rules cover these modules, but the
+      # bundler in cli-cef 3.0.0-alpha.26 downloads a fork of that script
+      # (FabianLars/Anylinux-AppImages, taken on feat/cef to fix spaces in
+      # paths) which is ~1100 lines behind pkgforge upstream and expands its
+      # deployment array without `eval`: every path keeps its literal quotes,
+      # so EVERY DEPLOY_* extra is skipped and only ldd-derived libraries land
+      # in the bundle. tauri-apps/tauri#12491 drops that fork for a pinned,
+      # checksummed upstream revision (facb95e8, which has the `eval`). Once it
+      # reaches feat/cef and a new cli-cef ships, bump CEF_CLI in
+      # apps/readest-app/scripts/tauri.mjs, lift the STRACE_MODE pin in the
+      # build step and drop the jq call below. Keep the flatten unless dlopen
+      # discovery is doing the finding: upstream globs only Arch's flat layout,
+      # so a Debian builder hides these modules from it either way.
+      #
+      # Until then, hand the modules over as appimage.files: the bundler passes
+      # files targeted at /usr/lib to quick-sharun as plain ELF arguments, the
+      # injection channel #12491 keeps. Sources must sit directly in the triple
+      # lib dir (Debian hides them in <triple>/nss/) because the destination
+      # inside the bundle mirrors the source dir, and only a flat source lands
+      # next to the libnss3.so that loads it.
+      - name: stage CEF AppImage runtime libraries (linux only)
+        if: matrix.config.release == 'linux'
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y libnss3
+          nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
+          lib_dir=${nss_dir%/nss}
+          sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
+          conf=apps/readest-app/src-tauri/tauri.conf.json
+          jq --arg d "$lib_dir" '.bundle.linux.appimage.files = {
+              "/usr/lib/libsoftokn3.so": ($d + "/libsoftokn3.so"),
+              "/usr/lib/libfreeblpriv3.so": ($d + "/libfreeblpriv3.so"),
+              "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so")
+            }' "$conf" > "$conf.tmp" && mv "$conf.tmp" "$conf"
+
       - name: create .env.local file for Next.js
         run: |
           echo "NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}" >> .env.local
@@ -484,6 +525,12 @@ jobs:
           # The CEF AppImage bundler (quick-sharun) otherwise launches the app
           # under Xvfb to discover dlopen'ed libraries and never gets it to
           # exit, hanging the Linux legs (#4906); ldd-based discovery only.
+          # The hang is the tooling's: it kills the traced app with a
+          # process-group signal that dash (/bin/sh on Ubuntu) never sets up
+          # without a terminal, and the CLI captures its output, so a surviving
+          # CEF child holds the pipes open. tauri-apps/tauri#12491 fixes both
+          # (bash + streamed output); drop this pin when cli-cef carries it and
+          # dlopen discovery — which is what bundles mesa/GL — comes back.
           STRACE_MODE: '0'
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -504,6 +551,21 @@ jobs:
           releaseId: ${{ needs.get-release.outputs.release_id }}
           releaseBody: ${{ needs.get-release.outputs.release_note }}
           args: ${{ matrix.config.args || '' }}
+
+      # quick-sharun skips anything it cannot find without failing, which is
+      # how a nightly AppImage shipped with no NSS modules at all. Fail the leg
+      # instead of publishing a bundle that crashes on first use. The path is
+      # the AppDir quick-sharun packed, left next to the AppImage in the
+      # WORKSPACE target dir. libsqlite3 is not staged explicitly — it must
+      # arrive as libsoftokn3.so's own ldd dependency.
+      - name: verify the AppImage bundled its NSS modules (linux only)
+        if: matrix.config.release == 'linux'
+        run: |
+          set -euo pipefail
+          lib=target/release/bundle/appimage/Readest.AppDir/lib
+          for so in libsoftokn3.so libfreeblpriv3.so libnssckbi.so libsqlite3.so.0; do
+            [ -e "$lib/$so" ] || { echo "::error::$so is missing from the AppImage bundle"; exit 1; }
+          done
 
       # Attest the freshly built desktop bundles (installers, AppImage, dmg,
       # updater archives + their .sig). tauri-action reports their on-disk paths


### PR DESCRIPTION
## The bug

The nightly CEF AppImage dies ~1.5s after launch on any distro newer than the builder:

```
ERROR:crypto/nss_util.cc:256] Error initializing NSS with a persistent database (sql:~/.pki/nssdb):
  <mount>/lib/libm.so.6: version `GLIBC_2.38' not found (required by /usr/lib/x86_64-linux-gnu/libsqlite3.so.0)
FATAL:crypto/nss_util.cc:146] nss_error=-5925, os_error=0
```

The bundle carries the build host's glibc (2.35, `ubuntu-22.04`) and its own loader, but not NSS's PKCS#11 modules. Chromium's `dlopen("libsoftokn3.so")` therefore falls through to the host copy, which drags in the host `libsqlite3` built against a newer glibc, NSS returns -5925, and Chromium `CHECK`-fails. ANGLE loses `libGL.so.1` the same way, which is why the GPU process exits during startup and rendering falls back to SwiftShader.

Reproduced on Ubuntu 25.04 (glibc 2.41) with `Readest_0.12.6-2026090606_amd64.AppImage`: exit 133 with that FATAL. Dropping jammy-built `libsoftokn3`/`libfreeblpriv3`/`libnssckbi`/`libsqlite3` into the extracted `lib/` makes it start and stay up.

## Why nothing was bundled

`quick-sharun`'s `DEPLOY_CHROMIUM` rules already list `libsoftokn3.so`, `libfreeblpriv3.so` and `libnss*.so*`. But the script `cli-cef@3.0.0-alpha.26` downloads is a fork (`FabianLars/Anylinux-AppImages`, taken on `feat/cef` in tauri-apps/tauri@d4a3d0fd to fix spaces in paths) that is ~1100 lines behind pkgforge upstream, including this line:

```sh
set -- $TO_DEPLOY_ARRAY "$@"          # fork:     paths keep their literal quotes
eval set -- "$TO_DEPLOY_ARRAY" "$@"   # upstream: what it is supposed to be
```

Without the `eval`, every entry stays `'/usr/lib/...'` quotes and all, fails `[ -f ]`, and is skipped — so **every** `DEPLOY_*` extra (NSS, mesa/GL, pipewire, p11-kit) is silently dropped and only `ldd`-derived libraries reach the bundle. Confirmed in a jammy container: the log prints "Deploying electron/chromium / OpenGL / vulkan / pipewire", then copies `libc.so.6` and `ld-linux` and nothing else. Ubuntu compounds it by keeping those modules in `<triple>/nss/`, which the Arch-shaped globs miss anyway.

## The fix

A linux-only step before the build:

1. flattens Debian's `<triple>/nss/*.so` into the triple lib dir, so the bundle destination (which mirrors the source dir) is `lib/`, next to the `libnss3.so` that loads them;
2. registers the three modules as `bundle.linux.appimage.files` under `/usr/lib` — the channel the bundler hands to quick-sharun as plain ELF arguments, which is unaffected by the fork's bug.

`libsqlite3` follows as `libsoftokn3`'s own `ldd` dependency. A post-build step fails the leg if any of them is missing from the packed AppDir, since the tooling skips what it cannot find without erroring — which is how this shipped in the first place.

Verified in an `ubuntu:22.04` container against the real script: `lib/` gets `libsoftokn3.so`, `libfreeblpriv3.so`, `libnssckbi.so`, `libsqlite3.so.0`, `libnspr4.so`, `libnssutil3.so` — the set that fixed the crash locally.

## Follow-up

tauri-apps/tauri#12491 supersedes this: it pins pkgforge upstream at `facb95e8` with a checksum (verified: that revision has the `eval`), runs the tooling with bash and streams its output — which fixes the CI hang that #4906 worked around with `STRACE_MODE=0`, and with it dlopen discovery, the thing that would bundle mesa/GL too. It also keeps `appimage.files` as the documented injection channel, so this workaround stays valid. `feat/cef` does not have it yet and npm's newest `cli-cef` is still the alpha.26 we pin, so there is nothing to bump to today. The comments spell out what to remove when there is; note the flatten should stay, since even upstream globs only Arch's flat layout.

Still not fixed by this PR, all downstream of the same missing deployment: GPU acceleration (software rendering meanwhile), host gio modules, and fcitx/IME on hosts newer than the builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux AppImage packaging by bundling required Chromium runtime libraries.
  * Added validation to ensure required libraries are included in the final AppImage, preventing incomplete builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->