### PR TITLE
fix(reader): never let the hidden nav buttons take taps

### DIFF
--- a/apps/readest-app/src/__tests__/components/page-navigation-buttons.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/page-navigation-buttons.browser.test.tsx
@@ -6,6 +6,7 @@ import '@/styles/globals.css';
 const mockPlatform = vi.hoisted(() => ({
   isAndroidApp: true,
   hoveredBookKey: null as string | null,
+  showPaginationButtons: false,
 }));
 
 vi.mock('@/context/EnvContext', () => ({
@@ -22,7 +23,10 @@ vi.mock('@/store/readerStore', () => ({
   ) =>
     selector({
       getView: () => null,
-      getViewSettings: () => ({ rtl: false, showPaginationButtons: true }),
+      getViewSettings: () => ({
+        rtl: false,
+        showPaginationButtons: mockPlatform.showPaginationButtons,
+      }),
       hoveredBookKey: mockPlatform.hoveredBookKey,
     }),
 }));
@@ -50,10 +54,21 @@ const { default: PageNavigationButtons } = await import(
 
 const navigationLabels = ['Previous Section', 'Previous Page', 'Next Page', 'Next Section'];
 
+// Returns whatever actually answers a tap at the given point. Never null in a
+// laid-out page, so a `false` from `button.contains()` means the tap really did
+// land on something else rather than on nothing at all.
+const hitTargetAt = (button: Element, offsetY: number) => {
+  const bounds = button.getBoundingClientRect();
+  const target = document.elementFromPoint(bounds.left + bounds.width / 2, bounds.top + offsetY);
+  expect(target).not.toBeNull();
+  return target;
+};
+
 afterEach(() => {
   cleanup();
   mockPlatform.isAndroidApp = true;
   mockPlatform.hoveredBookKey = null;
+  mockPlatform.showPaginationButtons = false;
 });
 
 describe('PageNavigationButtons Android hit areas', () => {
@@ -65,12 +80,31 @@ describe('PageNavigationButtons Android hit areas', () => {
       const bounds = button.getBoundingClientRect();
       expect([bounds.width, bounds.height], label).toEqual([8, 8]);
 
-      const hitTarget = document.elementFromPoint(bounds.left + bounds.width / 2, bounds.top - 1);
-      expect(button.contains(hitTarget), label).toBe(false);
+      expect(button.contains(hitTargetAt(button, -1)), label).toBe(false);
+    }
+  });
+
+  it('keeps the hidden controls tappable so screen readers can reach them', () => {
+    render(<PageNavigationButtons bookKey='book' isDropdownOpen={false} />);
+
+    for (const label of navigationLabels) {
+      const button = screen.getByRole('button', { name: label });
+      expect(button.contains(hitTargetAt(button, 4)), label).toBe(true);
+    }
+  });
+
+  it('lets taps fall through when the visible navigation buttons are enabled', () => {
+    mockPlatform.showPaginationButtons = true;
+    render(<PageNavigationButtons bookKey='book' isDropdownOpen={false} />);
+
+    for (const label of navigationLabels) {
+      const button = screen.getByRole('button', { name: label });
+      expect(button.contains(hitTargetAt(button, 4)), label).toBe(false);
     }
   });
 
   it('keeps the four visible controls large and distinctly labelled', () => {
+    mockPlatform.showPaginationButtons = true;
     mockPlatform.hoveredBookKey = 'book';
     render(<PageNavigationButtons bookKey='book' isDropdownOpen={false} />);
 

--- a/apps/readest-app/src/__tests__/components/page-navigation-buttons.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/page-navigation-buttons.browser.test.tsx
@@ -71,7 +71,7 @@ afterEach(() => {
   mockPlatform.showPaginationButtons = false;
 });
 
-describe('PageNavigationButtons Android hit areas', () => {
+describe('PageNavigationButtons hit areas', () => {
   it('shrinks all four hidden controls so they do not cover selectable text', () => {
     render(<PageNavigationButtons bookKey='book' isDropdownOpen={false} />);
 
@@ -84,22 +84,43 @@ describe('PageNavigationButtons Android hit areas', () => {
     }
   });
 
-  it('keeps the hidden controls tappable so screen readers can reach them', () => {
+  it('lets taps fall through the hidden controls with the setting off', () => {
     render(<PageNavigationButtons bookKey='book' isDropdownOpen={false} />);
 
     for (const label of navigationLabels) {
       const button = screen.getByRole('button', { name: label });
-      expect(button.contains(hitTargetAt(button, 4)), label).toBe(true);
+      expect(button.contains(hitTargetAt(button, 4)), label).toBe(false);
     }
   });
 
-  it('lets taps fall through when the visible navigation buttons are enabled', () => {
+  it('lets taps fall through the hidden controls with the setting on', () => {
     mockPlatform.showPaginationButtons = true;
     render(<PageNavigationButtons bookKey='book' isDropdownOpen={false} />);
 
     for (const label of navigationLabels) {
       const button = screen.getByRole('button', { name: label });
       expect(button.contains(hitTargetAt(button, 4)), label).toBe(false);
+    }
+  });
+
+  it('lets taps fall through the hidden controls off Android too', () => {
+    mockPlatform.isAndroidApp = false;
+    render(<PageNavigationButtons bookKey='book' isDropdownOpen={false} />);
+
+    for (const label of navigationLabels) {
+      const button = screen.getByRole('button', { name: label });
+      expect(button.contains(hitTargetAt(button, 4)), label).toBe(false);
+    }
+  });
+
+  it('takes taps once the controls are actually visible', () => {
+    mockPlatform.showPaginationButtons = true;
+    mockPlatform.hoveredBookKey = 'book';
+    render(<PageNavigationButtons bookKey='book' isDropdownOpen={false} />);
+
+    for (const label of navigationLabels) {
+      const button = screen.getByRole('button', { name: label });
+      expect(button.contains(hitTargetAt(button, 4)), label).toBe(true);
     }
   });
 

--- a/apps/readest-app/src/app/reader/components/PageNavigationButtons.tsx
+++ b/apps/readest-app/src/app/reader/components/PageNavigationButtons.tsx
@@ -37,6 +37,10 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
 
   const isPageNavigationButtonsVisible =
     (hoveredBookKey === bookKey || isDropdownOpen) && viewSettings?.showPaginationButtons;
+  // Android screen readers only announce the hidden controls if they still hit-test,
+  // so they keep their taps there. Once the visible navigation buttons are enabled
+  // those serve the same purpose and the hidden ones let taps through instead.
+  const captureHiddenTaps = !!appService?.isAndroidApp && !viewSettings?.showPaginationButtons;
   const navigationButtonSize =
     !isPageNavigationButtonsVisible && appService?.isAndroidApp
       ? 'h-2 w-2 overflow-hidden'
@@ -95,7 +99,7 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
           'absolute left-2 -translate-y-1/2',
           'flex items-center gap-1',
           isPageNavigationButtonsVisible ? 'top-1/2 opacity-100' : 'bottom-2 opacity-0',
-          !isPageNavigationButtonsVisible && !appService?.isAndroidApp ? 'pointer-events-none' : '',
+          !isPageNavigationButtonsVisible && !captureHiddenTaps ? 'pointer-events-none' : '',
         )}
       >
         <button
@@ -147,7 +151,7 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
           'absolute right-2 -translate-y-1/2',
           'flex items-center gap-1',
           isPageNavigationButtonsVisible ? 'top-1/2 opacity-100' : 'bottom-2 opacity-0',
-          !isPageNavigationButtonsVisible && !appService?.isAndroidApp ? 'pointer-events-none' : '',
+          !isPageNavigationButtonsVisible && !captureHiddenTaps ? 'pointer-events-none' : '',
         )}
       >
         <button

--- a/apps/readest-app/src/app/reader/components/PageNavigationButtons.tsx
+++ b/apps/readest-app/src/app/reader/components/PageNavigationButtons.tsx
@@ -37,10 +37,6 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
 
   const isPageNavigationButtonsVisible =
     (hoveredBookKey === bookKey || isDropdownOpen) && viewSettings?.showPaginationButtons;
-  // Android screen readers only announce the hidden controls if they still hit-test,
-  // so they keep their taps there. Once the visible navigation buttons are enabled
-  // those serve the same purpose and the hidden ones let taps through instead.
-  const captureHiddenTaps = !!appService?.isAndroidApp && !viewSettings?.showPaginationButtons;
   const navigationButtonSize =
     !isPageNavigationButtonsVisible && appService?.isAndroidApp
       ? 'h-2 w-2 overflow-hidden'
@@ -99,7 +95,7 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
           'absolute left-2 -translate-y-1/2',
           'flex items-center gap-1',
           isPageNavigationButtonsVisible ? 'top-1/2 opacity-100' : 'bottom-2 opacity-0',
-          !isPageNavigationButtonsVisible && !captureHiddenTaps ? 'pointer-events-none' : '',
+          !isPageNavigationButtonsVisible ? 'pointer-events-none' : '',
         )}
       >
         <button
@@ -151,7 +147,7 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
           'absolute right-2 -translate-y-1/2',
           'flex items-center gap-1',
           isPageNavigationButtonsVisible ? 'top-1/2 opacity-100' : 'bottom-2 opacity-0',
-          !isPageNavigationButtonsVisible && !captureHiddenTaps ? 'pointer-events-none' : '',
+          !isPageNavigationButtonsVisible ? 'pointer-events-none' : '',
         )}
       >
         <button


### PR DESCRIPTION
Closes #6079.

## The report

Scroll mode on Android, ~1/8 of the screen height at the bottom won't scroll. Disabling the header and footer doesn't help.

## Two things were going on

**1. The reporter's dead zone is already fixed on `main` — 0.12.6 just predates the fix.** Neither #5974 nor #6001 is an ancestor of `v0.12.6` (v0.12.6 = f6146c217, 2026-08-28; the 8px shrink cd4a76fef landed 2026-09-01).

In 0.12.6 the button class was `'flex h-20 w-20 ...'` with a conditional `'h-4 w-4'` appended. Same specificity — and Tailwind emits `.h-4` **before** `.h-20`, so `h-20` won and the override was dead code. That left two 80px-tall, ~164px-wide hit boxes in each bottom corner, which is where the "about 1/8 of the screen height" comes from. #6001 fixed it by picking one size token (`navigationButtonSize`) instead of two conflicting ones.

**2. The four hidden buttons still hit-tested on Android at all.** They stay mounted while hidden so screen readers can reach them, and the Android branch deliberately left `pointer-events` on. Shrinking them to 8px made the dead zone small, but it never made it zero.

## The change

```diff
-!isPageNavigationButtonsVisible && !appService?.isAndroidApp ? 'pointer-events-none' : '',
+!isPageNavigationButtonsVisible ? 'pointer-events-none' : '',
```

on both containers. The Android exception is gone: the hidden controls stop hit-testing on every platform, so there is no bottom dead zone in any configuration, whether or not **Settings → Behavior → Show Page Navigation Buttons** is on.

They only take taps once they are actually visible, which needs the setting enabled *and* the reader chrome shown.

Accessibility is preserved: the buttons stay mounted with their `aria-label`s and `tabIndex={0}`, and `opacity-0` plus `pointer-events: none` does not remove a node from the accessibility tree, so screen reader swipe navigation still reaches them. What is given up is explore-by-touch landing on an invisible 8px target — which was the thing eating the taps.

## Tests

`page-navigation-buttons.browser.test.tsx` hit-tests with `document.elementFromPoint` at the button centre — real Chromium, real `globals.css`, so it also catches CSS-order regressions like the 0.12.6 one that a jsdom test cannot see. `hitTargetAt` asserts a non-null target so a negative assertion cannot pass vacuously.

Four cases now pinned: taps fall through the hidden controls with the setting off, with the setting on, and off Android; and the controls do take taps once visible.

## Verification

- `pnpm lint` (tsc + Biome) — clean
- `pnpm format:check` — clean
- `pnpm test` — 907 files, 10950 passed
- `pnpm test:browser` — 55 files, 441 passed

Heads up on an unrelated flake seen during this work: `dialog-close-frames.browser.test.tsx` → "never paints the box without its body" failed 1 of 3 runs on clean `main` with this branch stashed out — same test, same assertion (`expected [ Array(1) ] to deeply equal []`), a rAF paint-order timing check. Pre-existing fragility, worth its own issue.

Not device-verified on Android hardware; the screen reader behaviour in particular wants a TalkBack pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Hidden page navigation buttons no longer intercept taps, allowing interactions with the underlying page content.
  - Tap behavior is now consistent across Android and non-Android platforms when pagination controls are hidden.

- **Tests**
  - Expanded coverage for pagination-button visibility and platform-specific interaction behavior.
  - Added checks confirming hidden controls pass taps through while visible controls remain interactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->