### PR TITLE
fix(ui): pad the plans section so its buttons align on mobile

### DIFF
--- a/apps/readest-app/src/app/user/page.tsx
+++ b/apps/readest-app/src/app/user/page.tsx
@@ -369,7 +369,7 @@ const ProfilePage = () => {
                   </div>
                 ) : (
                   <>
-                    <div className='flex flex-col gap-y-8 sm:px-6'>
+                    <div className='flex flex-col gap-y-8 px-2 sm:px-6'>
                       <PlansComparison
                         availablePlans={availablePlans}
                         userPlan={userProfilePlan}


### PR DESCRIPTION
## Problem

On the account page every section wrapper uses `px-6` except the plans grid, which used `sm:px-6`. Below the `sm` breakpoint that section had no horizontal padding at all, so the plan cards ran edge to edge while the account action buttons underneath sat 24px in. The card's own button ended up 7px to the left of the "Manage Subscription" rail, which reads as a misalignment when the two groups stack vertically.

The cards were also overflowing the viewport by a hair: 392.73px wide against a 392px viewport.

## Fix

One class on the plans section wrapper: `sm:px-6` to `px-2 sm:px-6`.

`px-2` (8px) is the step that lands the alignment, because the card contributes 16px of its own `p-4` padding plus a 1px border on top of whatever the wrapper gives it. Nothing changes at `sm` and up, where `sm:px-6` still wins and the cards are meant to read as separate panels.

## Verification

Measured on a Xiaomi 13 (Android, 392px viewport, DPR 2.75) by reading live element geometry over CDP, before and after:

| | before | after | action buttons |
|---|---|---|---|
| Card left edge | `0` | `8` | — |
| Card right edge | `392.73` (overflowed) | `384.73` | — |
| Card button left | `16.73` | **`24.73`** | `24` |
| Card button right | `376` | **`368`** | `368.73` |

Both edges now land 0.73px from the action buttons. That residue is the card's 1px border rendering as two device pixels at DPR 2.75, so it is a single hairline rather than a visible step. For reference, `px-1` would have left the button at 20.73px, a 3.27px gap or about 9 device pixels.

- `pnpm test` — 10970 passed, 16 skipped
- `pnpm lint` — clean
- `pnpm format:check` — clean
- On-device check on the 0.12.6 Android build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing around the plans comparison section on smaller screens for a more polished mobile layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->