### PR TITLE
feat(reader): hinge the two-column Page Curl at the spine

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/build.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/build.rs
@@ -51,6 +51,8 @@ const COMMANDS: &[&str] = &[
     "refresh_eink_screen",
     "update_reading_widget",
     "capture_webview_region",
+    "cover_webview_region",
+    "uncover_webview_region",
     "set_selection_suppressed",
     "set_multicast_lock",
     "read_share_clip_html",

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
@@ -570,6 +570,13 @@ extension WebViewLifecycleManager: WKNavigationDelegate {
 
 class NativeBridgePlugin: Plugin {
   private var webView: WKWebView?
+  // Native cover for the two-column page curl (#6106): a snapshot view of a
+  // region, placed as a sibling above the webview so `capture_webview_region`
+  // (which renders the webview's own layer tree) does not see it while the
+  // user keeps seeing the frozen pixels. Tokens keep a stale uncover from an
+  // interrupted turn from removing the next turn's cover.
+  private var turnCoverView: UIView?
+  private var turnCoverToken: Int = 0
   private var authSession: ASWebAuthenticationSession?
   private var currentOrientationMask: UIInterfaceOrientationMask = .all
   private var originalDelegate: UIApplicationDelegate?
@@ -1909,6 +1916,55 @@ class NativeBridgePlugin: Plugin {
       }
     }
   }
+
+  /// Freeze the on-screen pixels of a region of the webview (CSS px of the
+  /// JS viewport) behind a snapshot of what is currently presented there,
+  /// for the two-column page curl (#6106). The snapshot view is a sibling
+  /// above the webview: `takeSnapshot` renders the webview's own layer tree,
+  /// so the JS side can expose the incoming column underneath, capture it
+  /// with `capture_webview_region`, and restore its overlay — all while the
+  /// user still sees the frozen old pixels. Resolves a token for
+  /// `uncover_webview_region`.
+  @objc public func cover_webview_region(_ invoke: Invoke) {
+    guard let args = try? invoke.parseArgs(CaptureWebviewRegionArgs.self) else {
+      return invoke.reject("Failed to parse arguments")
+    }
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let webView = self.webView, let container = webView.superview else {
+        return invoke.reject("WebView not available")
+      }
+      let rect = CGRect(x: args.x, y: args.y, width: args.width, height: args.height)
+      guard
+        let cover = webView.resizableSnapshotView(
+          from: rect, afterScreenUpdates: false, withCapInsets: .zero)
+      else {
+        return invoke.reject("Snapshot view unavailable")
+      }
+      self.turnCoverView?.removeFromSuperview()
+      cover.frame = webView.convert(rect, to: container)
+      cover.isUserInteractionEnabled = false
+      container.addSubview(cover)
+      self.turnCoverToken += 1
+      self.turnCoverView = cover
+      invoke.resolve(["token": self.turnCoverToken])
+    }
+  }
+
+  /// Remove the cover put up by `cover_webview_region`. A token from an
+  /// earlier, already replaced cover is ignored.
+  @objc public func uncover_webview_region(_ invoke: Invoke) {
+    guard let args = try? invoke.parseArgs(UncoverWebviewRegionArgs.self) else {
+      return invoke.reject("Failed to parse arguments")
+    }
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return invoke.resolve() }
+      if args.token == self.turnCoverToken {
+        self.turnCoverView?.removeFromSuperview()
+        self.turnCoverView = nil
+      }
+      invoke.resolve()
+    }
+  }
 }
 
 /// Persistent store for security-scoped folder bookmarks.
@@ -2156,6 +2212,10 @@ struct CaptureWebviewRegionArgs: Decodable {
   let y: Double
   let width: Double
   let height: Double
+}
+
+struct UncoverWebviewRegionArgs: Decodable {
+  let token: Int
 }
 
 @_cdecl("init_plugin_native_bridge")

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/default.toml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/default.toml
@@ -50,6 +50,8 @@ permissions = [
   "allow-refresh-eink-screen",
   "allow-update-reading-widget",
   "allow-capture-webview-region",
+  "allow-cover-webview-region",
+  "allow-uncover-webview-region",
   "allow-set-selection-suppressed",
   "allow-read-share-clip-html",
   "allow-icloud-container-status",

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/commands.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/commands.rs
@@ -363,6 +363,26 @@ pub(crate) async fn capture_webview_region<R: Runtime>(
     Ok(tauri::ipc::Response::new(png))
 }
 
+/// Freeze the on-screen pixels of a webview region behind a native layer
+/// that `capture_webview_region` does not see, for the two-column page curl
+/// (#6106). iOS only so far; other platforms reject and the JS side keeps
+/// a paper back on the leaf.
+#[command]
+pub(crate) async fn cover_webview_region<R: Runtime>(
+    app: AppHandle<R>,
+    payload: CaptureWebviewRegionRequest,
+) -> Result<CoverWebviewRegionResponse> {
+    app.native_bridge().cover_webview_region(payload)
+}
+
+#[command]
+pub(crate) async fn uncover_webview_region<R: Runtime>(
+    app: AppHandle<R>,
+    payload: UncoverWebviewRegionRequest,
+) -> Result<()> {
+    app.native_bridge().uncover_webview_region(payload)
+}
+
 #[command]
 pub(crate) async fn icloud_container_status<R: Runtime>(
     app: AppHandle<R>,

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/desktop.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/desktop.rs
@@ -448,6 +448,22 @@ impl<R: Runtime> NativeBridge<R> {
         }
     }
 
+    /// Native cover for the two-column page curl (#6106): not implemented on
+    /// desktop, where the leaf keeps a paper back.
+    pub fn cover_webview_region(
+        &self,
+        _payload: CaptureWebviewRegionRequest,
+    ) -> crate::Result<CoverWebviewRegionResponse> {
+        Err(crate::Error::UnsupportedPlatformError)
+    }
+
+    pub fn uncover_webview_region(
+        &self,
+        _payload: UncoverWebviewRegionRequest,
+    ) -> crate::Result<()> {
+        Err(crate::Error::UnsupportedPlatformError)
+    }
+
     /// Probe the iCloud ubiquity container. Non-macOS desktops report
     /// unavailable rather than erroring: the JS side treats `available:
     /// false` as "this backend cannot run here", the same shape as a Mac

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/lib.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/lib.rs
@@ -96,6 +96,8 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::refresh_eink_screen,
             commands::update_reading_widget,
             commands::capture_webview_region,
+            commands::cover_webview_region,
+            commands::uncover_webview_region,
             commands::set_selection_suppressed,
             commands::set_multicast_lock,
             commands::read_share_clip_html,

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/mobile.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/mobile.rs
@@ -485,6 +485,26 @@ impl<R: Runtime> NativeBridge<R> {
             .decode(response.data)
             .map_err(|e| crate::Error::NativeBridgeError(format!("invalid base64 PNG: {e}")))
     }
+
+    /// Native cover for the two-column page curl (#6106); see the Swift
+    /// side. Android has no implementation yet and rejects.
+    pub fn cover_webview_region(
+        &self,
+        payload: CaptureWebviewRegionRequest,
+    ) -> crate::Result<CoverWebviewRegionResponse> {
+        self.0
+            .run_mobile_plugin("cover_webview_region", payload)
+            .map_err(Into::into)
+    }
+
+    pub fn uncover_webview_region(
+        &self,
+        payload: UncoverWebviewRegionRequest,
+    ) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin("uncover_webview_region", payload)
+            .map_err(Into::into)
+    }
 }
 
 impl<R: Runtime> NativeBridge<R> {

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
@@ -569,6 +569,21 @@ pub struct CaptureWebviewRegionResponse {
     pub data: String,
 }
 
+/// Token for the native cover layer put up by `cover_webview_region`
+/// (#6106): the two-column page curl freezes the on-screen pixels of the
+/// incoming column behind it while the column is captured underneath.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoverWebviewRegionResponse {
+    pub token: u32,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UncoverWebviewRegionRequest {
+    pub token: u32,
+}
+
 /// iCloud ubiquity-container probe result. `documents_path` is the absolute
 /// path of the container's Documents folder (created on first probe);
 /// `available: false` covers no-iCloud-session, missing entitlement, and

--- a/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
@@ -4,6 +4,7 @@ import {
   CapturedTurnHost,
   type CapturedTurnStyle,
 } from '@/app/reader/utils/capturedTurn';
+import { PageCurlRenderer } from '@/utils/pageCurl';
 
 // Choreography tests for the captured page-turn controller (readest#555):
 // capture the page → overlay the captured bitmap → instantly navigate the
@@ -1704,6 +1705,44 @@ describe('CapturedPageTurn two-column curl (browser)', () => {
     expect(await makeController().turn(true, false, 'curl')).toBe(true);
     await vi.waitFor(() => expect(uncover).toHaveBeenCalledTimes(1));
     expect(overlay()).toBeNull();
+  });
+
+  it('drops the incoming column when a blocking overlay opens during its capture', async () => {
+    // A dialog that opens while the platform snapshot is pending is part of
+    // the composited pixels. The turn keeps going, but that bitmap must never
+    // reach the renderer, and the cover still comes down.
+    let allowed = true;
+    let finishCapture: (() => void) | null = null;
+    capture.mockImplementation((rect) =>
+      isInner(rect)
+        ? new Promise<ArrayBuffer>((resolve) => {
+            finishCapture = () => resolve(png);
+          })
+        : Promise.resolve(png),
+    );
+    const setIncoming = vi.spyOn(PageCurlRenderer.prototype, 'setIncoming');
+    try {
+      const turning = makeController({ isCaptureAllowed: () => allowed }).turn(true, false, 'curl');
+      await vi.waitFor(() => expect(capture).toHaveBeenCalledTimes(2));
+      allowed = false;
+      finishCapture!();
+      expect(await turning).toBe(true);
+      await vi.waitFor(() => expect(uncover).toHaveBeenCalledTimes(1));
+      expect(setIncoming).not.toHaveBeenCalled();
+    } finally {
+      setIncoming.mockRestore();
+    }
+  });
+
+  it('commits the incoming column when no overlay interferes', async () => {
+    const setIncoming = vi.spyOn(PageCurlRenderer.prototype, 'setIncoming');
+    try {
+      await makeController().turn(true, false, 'curl');
+      await vi.waitFor(() => expect(setIncoming).toHaveBeenCalledTimes(1));
+      expect(setIncoming.mock.calls[0]![0]).toBeInstanceOf(ImageBitmap);
+    } finally {
+      setIncoming.mockRestore();
+    }
   });
 
   it('lifts the cover when the turn is disposed mid-capture', async () => {

--- a/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
@@ -1561,3 +1561,168 @@ describe('CapturedPageTurn (browser)', () => {
     expect(host.querySelector('canvas')).toBeNull();
   });
 });
+
+// Two-column curl (readest#6106): the outer column turns as one leaf hinged
+// at the spine, and its back shows the incoming inner column. That column
+// sits under the overlay, so after the instant navigation the controller
+// asks the host to freeze the region's on-screen pixels natively, clips the
+// overlay to the leaf side to expose the live column to the platform
+// snapshot, captures it, restores the overlay, then lifts the cover.
+describe('CapturedPageTurn two-column curl (browser)', () => {
+  let host: HTMLDivElement;
+  let png: ArrayBuffer;
+  let capture: ReturnType<typeof vi.fn<CapturedTurnHost['capture']>>;
+  let navigate: ReturnType<typeof vi.fn<CapturedTurnHost['navigate']>>;
+  let uncover: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  let coverRegion: ReturnType<typeof vi.fn<NonNullable<CapturedTurnHost['coverRegion']>>>;
+  let controller: CapturedPageTurn | null;
+
+  const contentRect = () => new DOMRect(10, 20, W, H);
+  const leftHalf = { x: 10, y: 20, width: W / 2, height: H };
+  const rightHalf = { x: 10 + W / 2, y: 20, width: W / 2, height: H };
+  const overlay = () => host.querySelector<HTMLElement>('div[aria-hidden="true"]');
+  const isInner = (rect: { width: number }) => rect.width === W / 2;
+  const makeController = (overrides: Partial<CapturedTurnHost> = {}) => {
+    controller = new CapturedPageTurn(
+      {
+        getHostElement: () => host,
+        getContentRect: contentRect,
+        capture,
+        navigate,
+        getColumnCount: () => 2,
+        coverRegion,
+        ...overrides,
+      },
+      { duration: 40 },
+    );
+    return controller;
+  };
+
+  beforeEach(async () => {
+    host = document.createElement('div');
+    Object.assign(host.style, {
+      position: 'absolute',
+      left: '0',
+      top: '0',
+      width: '400px',
+      height: '300px',
+    });
+    document.body.appendChild(host);
+    png = await makePngBuffer();
+    capture = vi.fn<CapturedTurnHost['capture']>().mockResolvedValue(png);
+    navigate = vi.fn<CapturedTurnHost['navigate']>().mockResolvedValue(undefined);
+    uncover = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    coverRegion = vi
+      .fn<NonNullable<CapturedTurnHost['coverRegion']>>()
+      .mockImplementation(async () => uncover);
+    controller = null;
+  });
+
+  afterEach(() => {
+    controller?.dispose();
+    host.remove();
+  });
+
+  it('captures the incoming inner column under a cover after navigating', async () => {
+    await makeController().turn(true, false, 'curl');
+    await vi.waitFor(() => expect(uncover).toHaveBeenCalledTimes(1));
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith(true);
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(capture.mock.calls[0]![0]).toEqual({ x: 10, y: 20, width: W, height: H });
+    // Forward, LTR: the right leaf lands on the left column.
+    expect(capture.mock.calls[1]![0]).toEqual(leftHalf);
+    expect(coverRegion).toHaveBeenCalledTimes(1);
+    expect(coverRegion).toHaveBeenCalledWith(leftHalf);
+    // navigate → cover → capture the live column → uncover.
+    const order = (mock: { mock: { invocationCallOrder: number[] } }, i = 0) =>
+      mock.mock.invocationCallOrder[i]!;
+    expect(order(navigate)).toBeLessThan(order(coverRegion));
+    expect(order(coverRegion)).toBeLessThan(order(capture, 1));
+    expect(order(capture, 1)).toBeLessThan(order(uncover));
+  });
+
+  it('exposes only the leaf side of the overlay while the live column is captured', async () => {
+    let clipDuringCapture: string | null = null;
+    let clipAtUncover: string | null = null;
+    capture.mockImplementation(async (rect) => {
+      if (isInner(rect)) clipDuringCapture = overlay()?.style.clipPath ?? null;
+      return png;
+    });
+    uncover.mockImplementation(async () => {
+      clipAtUncover = overlay()?.style.clipPath ?? null;
+    });
+    await makeController().turn(true, false, 'curl');
+    await vi.waitFor(() => expect(uncover).toHaveBeenCalledTimes(1));
+
+    // The left (inner) column is cut away, the right leaf stays covered.
+    expect(clipDuringCapture).toMatch(/^inset\(0(px)? 0(px)? 0(px)? 50%\)$/);
+    // Restored before the native cover comes down.
+    expect(clipAtUncover).toBe('');
+  });
+
+  it('lands a backward leaf on the right column', async () => {
+    await makeController().turn(false, false, 'curl');
+    await vi.waitFor(() => expect(uncover).toHaveBeenCalledTimes(1));
+    expect(navigate).toHaveBeenCalledWith(false);
+    expect(capture.mock.calls[1]![0]).toEqual(rightHalf);
+    expect(coverRegion).toHaveBeenCalledWith(rightHalf);
+  });
+
+  it('lands an rtl forward leaf on the right column', async () => {
+    await makeController().turn(true, true, 'curl');
+    await vi.waitFor(() => expect(uncover).toHaveBeenCalledTimes(1));
+    expect(capture.mock.calls[1]![0]).toEqual(rightHalf);
+  });
+
+  it('turns a single column with one capture and no cover', async () => {
+    await makeController({ getColumnCount: () => 1 }).turn(true, false, 'curl');
+    await waitForTurnIdle();
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(coverRegion).not.toHaveBeenCalled();
+  });
+
+  it('leaves the slide style out of the leaf pipeline', async () => {
+    await makeController().turn(true, false, 'slide');
+    await waitForTurnIdle();
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(coverRegion).not.toHaveBeenCalled();
+  });
+
+  it('turns with a paper back where the host cannot cover', async () => {
+    expect(await makeController({ coverRegion: undefined }).turn(true, false, 'curl')).toBe(true);
+    await waitForTurnIdle();
+    expect(capture).toHaveBeenCalledTimes(1);
+  });
+
+  it('finishes the turn and lifts the cover when the incoming capture fails', async () => {
+    capture.mockImplementation(async (rect) => {
+      if (isInner(rect)) throw new Error('snapshot failed');
+      return png;
+    });
+    expect(await makeController().turn(true, false, 'curl')).toBe(true);
+    await vi.waitFor(() => expect(uncover).toHaveBeenCalledTimes(1));
+    expect(overlay()).toBeNull();
+  });
+
+  it('lifts the cover when the turn is disposed mid-capture', async () => {
+    let finishCapture: (() => void) | null = null;
+    capture.mockImplementation((rect) =>
+      isInner(rect)
+        ? new Promise<ArrayBuffer>((resolve) => {
+            finishCapture = () => resolve(png);
+          })
+        : Promise.resolve(png),
+    );
+    const turning = makeController().turn(true, false, 'curl');
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledTimes(2));
+    controller!.dispose();
+    finishCapture!();
+    await turning;
+    await vi.waitFor(() => expect(uncover).toHaveBeenCalledTimes(1));
+    expect(overlay()).toBeNull();
+  });
+
+  const waitForTurnIdle = () => new Promise<void>((resolve) => setTimeout(resolve, 150));
+});

--- a/apps/readest-app/src/__tests__/utils/page-curl.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/page-curl.browser.test.ts
@@ -156,3 +156,151 @@ describe('PageCurlRenderer (browser)', () => {
     expect(right[3]).toBe(255);
   });
 });
+
+// Two-column spreads turn one leaf hinged at the spine (readest#6106): the
+// outer column curls, stops at the middle, and lands on the inner column as
+// an exact mirror, showing the incoming page on its back. The incoming
+// texture is the inner column of the NEXT spread: a different two-tone
+// bitmap (cyan | magenta across its width) so the mirror mapping is
+// checkable — once landed, the leaf's back must read like the live page it
+// is about to hand over to, pixel for pixel.
+describe('PageCurlRenderer two-column leaf (browser)', () => {
+  let renderer: PageCurlRenderer;
+  let host: HTMLDivElement;
+  const HALF = W / 2;
+
+  const makeIncomingBitmap = async (): Promise<ImageBitmap> => {
+    const canvas = document.createElement('canvas');
+    canvas.width = HALF;
+    canvas.height = H;
+    const ctx = canvas.getContext('2d')!;
+    ctx.fillStyle = 'rgb(0, 200, 200)';
+    ctx.fillRect(0, 0, HALF / 2, H);
+    ctx.fillStyle = 'rgb(200, 0, 200)';
+    ctx.fillRect(HALF / 2, 0, HALF / 2, H);
+    const blob = await new Promise<Blob>((resolve) =>
+      canvas.toBlob((b) => resolve(b!), 'image/png'),
+    );
+    return createImageBitmap(blob);
+  };
+
+  const near = (px: number[], rgb: [number, number, number], tolerance = 12) =>
+    Math.abs(px[0]! - rgb[0]) <= tolerance &&
+    Math.abs(px[1]! - rgb[1]) <= tolerance &&
+    Math.abs(px[2]! - rgb[2]) <= tolerance;
+
+  beforeEach(async () => {
+    host = document.createElement('div');
+    Object.assign(host.style, {
+      position: 'absolute',
+      left: '0',
+      top: '0',
+      width: `${W}px`,
+      height: `${H}px`,
+    });
+    document.body.appendChild(host);
+    renderer = new PageCurlRenderer();
+    renderer.attach(host, W, H, 1);
+    renderer.setTexture(await makePageBitmap());
+    renderer.setColumns(2);
+  });
+
+  afterEach(() => {
+    renderer?.dispose();
+    host?.remove();
+  });
+
+  it('covers both columns exactly at progress 0', () => {
+    renderer.render(0, { x: 1, y: 0.5 });
+    expect(renderer.readPixel(20, 20).slice(0, 3)).toEqual([0, 160, 0]);
+    expect(renderer.readPixel(W - 20, 20).slice(0, 3)).toEqual([0, 0, 160]);
+    expect(renderer.readPixel(20, H - 20).slice(0, 3)).toEqual([160, 0, 0]);
+    expect(renderer.readPixel(W - 20, H - 20).slice(0, 3)).toEqual([160, 160, 0]);
+    expect(renderer.canvasOpacity).toBe('');
+  });
+
+  it('keeps the inner column flat while the outer leaf curls', () => {
+    renderer.render(0.35, { x: 1, y: 0.5 });
+    // The outer edge has lifted away: transparent, live page beneath.
+    expect(renderer.readPixel(W - 12, 75)[3]).toBe(0);
+    // The inner column is untouched and unshaded: exact green / red.
+    expect(renderer.readPixel(30, 75).slice(0, 3)).toEqual([0, 160, 0]);
+    expect(renderer.readPixel(30, H - 30).slice(0, 3)).toEqual([160, 0, 0]);
+    // Just inside the spine the leaf's own flat front is still there (blue).
+    const spineSide = renderer.readPixel(HALF + 12, 75);
+    expect(spineSide[3]).toBe(255);
+    expect(spineSide[2]).toBeGreaterThan(120);
+  });
+
+  it('lands the leaf on the inner column as an exact mirror of the incoming page', async () => {
+    renderer.setIncoming(await makeIncomingBitmap());
+    renderer.render(1, { x: 1, y: 0.5 });
+    // The outer column has turned away completely.
+    for (const x of [HALF + 20, HALF + HALF / 2, W - 20]) {
+      expect(renderer.readPixel(x, 150)[3]).toBe(0);
+    }
+    // The inner column now shows the incoming page, unmirrored and unshaded:
+    // cyan on its left half, magenta on its right half, at every row.
+    for (const y of [10, 75, 150, 225, H - 10]) {
+      const left = renderer.readPixel(HALF / 4, y);
+      const right = renderer.readPixel((3 * HALF) / 4, y);
+      expect(left[3]).toBe(255);
+      expect(right[3]).toBe(255);
+      expect(near(left, [0, 200, 200])).toBe(true);
+      expect(near(right, [200, 0, 200])).toBe(true);
+    }
+    // The spine edge and the outer edge of the incoming column both land.
+    expect(near(renderer.readPixel(HALF - 3, 150), [200, 0, 200])).toBe(true);
+    expect(near(renderer.readPixel(3, 150), [0, 200, 200])).toBe(true);
+    expect(renderer.canvasOpacity).toBe('');
+  });
+
+  it('shows the incoming page on the back of the leaf mid-turn', async () => {
+    renderer.setIncoming(await makeIncomingBitmap());
+    renderer.render(0.7, { x: 1, y: 0.5 });
+    // The landed part of the leaf lies over the inner column left of the
+    // spine. The leaf carries its content: the outer edge of the leaf is
+    // heading for the far edge of the inner column, so what has landed so
+    // far is the incoming page's far (cyan) half, unshaded.
+    const landed = renderer.readPixel(HALF - 20, 150);
+    expect(landed[3]).toBe(255);
+    expect(near(landed, [0, 200, 200])).toBe(true);
+    // Far from the spine the old inner page is still uncovered (green).
+    expect(renderer.readPixel(20, 75).slice(0, 3)).toEqual([0, 160, 0]);
+  });
+
+  it('fades out at the end when no incoming page is available', () => {
+    renderer.render(0.5, { x: 1, y: 0.5 });
+    expect(renderer.canvasOpacity).toBe('');
+    renderer.render(0.9, { x: 1, y: 0.5 });
+    expect(parseFloat(renderer.canvasOpacity)).toBeCloseTo(0.5, 1);
+    renderer.render(1, { x: 1, y: 0.5 });
+    expect(renderer.canvasOpacity).toBe('0');
+    // The paper back still lands on the inner column (whitened blue/yellow),
+    // never mirrored-away transparency, so the fade has something to fade.
+    const landed = renderer.readPixel(HALF / 2, 75);
+    expect(landed[3]).toBe(255);
+    expect(landed[0]).toBeGreaterThan(140);
+  });
+
+  it('turns the left column onto the right for rtl / backward leaves', async () => {
+    renderer.setIncoming(await makeIncomingBitmap());
+    renderer.render(1, { x: 0, y: 0.5 }, true);
+    // The left column has turned away; the right column shows the incoming
+    // page unmirrored: cyan on its left half, magenta on its right half.
+    expect(renderer.readPixel(20, 150)[3]).toBe(0);
+    expect(renderer.readPixel(HALF - 20, 150)[3]).toBe(0);
+    expect(near(renderer.readPixel(HALF + HALF / 4, 150), [0, 200, 200])).toBe(true);
+    expect(near(renderer.readPixel(HALF + (3 * HALF) / 4, 150), [200, 0, 200])).toBe(true);
+  });
+
+  it('leaves single-column pages untouched by leaf state', async () => {
+    renderer.setIncoming(await makeIncomingBitmap());
+    renderer.setColumns(1);
+    renderer.render(1, { x: 1, y: 0.5 });
+    for (const x of [20, W / 2, W - 20]) {
+      expect(renderer.readPixel(x, 150)[3]).toBe(0);
+    }
+    expect(renderer.canvasOpacity).toBe('');
+  });
+});

--- a/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
+++ b/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
@@ -6,7 +6,7 @@ import { useBookDataStore } from '@/store/bookDataStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useThemeStore } from '@/store/themeStore';
-import { captureWebviewRegion } from '@/utils/bridge';
+import { captureWebviewRegion, coverWebviewRegion, uncoverWebviewRegion } from '@/utils/bridge';
 import { getInitializedAppService, isTauriAppPlatform } from '@/services/environment';
 import { detectViewTransitionGroup } from '@/utils/viewTransition';
 import { TURN_GESTURE_LEFT_INSET_ATTRIBUTE } from '../utils/brightnessGesture';
@@ -364,6 +364,20 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
         restoreToolbarOnCancelRef.current = useReaderStore.getState().hoveredBookKey === bookKey;
       },
       capture: captureWebviewRegion,
+      // A two-column spread turns only its outer column, hinged at the spine
+      // (readest#6106). Vertical writing stacks its columns instead, which
+      // the leaf model does not describe.
+      getColumnCount: () =>
+        getViewSettings(bookKey)?.vertical ? 1 : (view.renderer.columnCount ?? 1),
+      // The leaf's back shows the incoming column, captured under the overlay
+      // behind a native cover. Only iOS has the cover so far; elsewhere the
+      // back is theme paper.
+      coverRegion: getInitializedAppService()?.isIOSApp
+        ? async (rect) => {
+            const { token } = await coverWebviewRegion(rect);
+            return () => uncoverWebviewRegion({ token });
+          }
+        : undefined,
       preparePixelCapture: async () => {
         const transientVisible =
           document.querySelector(CAPTURE_INVALIDATING_OVERLAY_SELECTOR) !== null;

--- a/apps/readest-app/src/app/reader/utils/capturedTurn.ts
+++ b/apps/readest-app/src/app/reader/utils/capturedTurn.ts
@@ -67,6 +67,19 @@ export interface CapturedTurnHost {
   onCancelled?: (style: CapturedTurnStyle) => void | Promise<void>;
   /** Instant (animation-less) page turn of the live view. */
   navigate: (forward: boolean) => Promise<void>;
+  /**
+   * How many page columns the reader cell shows (1 when unknown). With two,
+   * the curl turns only the outer column, hinged at the spine like a book
+   * leaf, and lands it on the inner column (readest#6106).
+   */
+  getColumnCount?: () => number;
+  /**
+   * Freeze the on-screen pixels of `rect` (viewport CSS px) behind a native
+   * layer that `capture` does not see. The two-column curl uses it to capture
+   * the incoming inner column under the overlay without ever showing it.
+   * Resolves to the function that removes the layer again.
+   */
+  coverRegion?: (rect: CaptureRect) => Promise<() => Promise<void>>;
 }
 
 export type CapturedTurnStyle = 'curl' | 'slide';
@@ -76,6 +89,10 @@ interface TurnRenderer {
   attach(container: HTMLElement, width: number, height: number, dpr?: number): void;
   setTexture(source: ImageBitmap): void;
   setBackdrop?(source: TexImageSource): void;
+  /** Page columns in the captured bitmap; 2 turns one leaf hinged at the spine. */
+  setColumns?(columns: number): void;
+  /** The incoming inner column shown on the back of a two-column leaf. */
+  setIncoming?(source: TexImageSource | null): void;
   /** Whether an idle GPU surface survived context eviction. */
   isUsable?(): boolean;
   render(progress: number, grab: CurlGrab, rtl: boolean): void;
@@ -133,6 +150,10 @@ interface ActiveTurn {
   forward: boolean;
   /** Renderer-space mirror flag (spine side of the turn), not book direction. */
   rendererRtl: boolean;
+  /** Page columns in the captured bitmap (2 = one leaf hinged at the spine). */
+  columns: number;
+  /** In-flight capture of the incoming column for the leaf's back, if any. */
+  incoming: Promise<void> | null;
   progress: number;
   grabY: number;
   /** Buffered input and identity token, absent for programmatic turns. */
@@ -144,6 +165,13 @@ interface ActiveTurn {
 }
 
 const easeInOutQuad = (t: number) => (t < 0.5 ? 2 * t * t : 1 - (1 - t) * (1 - t) * 2);
+const waitForPaint = () =>
+  new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  });
+// A programmatic two-column turn gives the incoming column this long to
+// arrive before the leaf's back would show; a slow capture must not stall it.
+const INCOMING_WAIT_MS = 120;
 const easeOutCubic = (t: number) => 1 - (1 - t) ** 3;
 const RELEASE_SETTLE_CONFIG = {
   // Keep a visible momentum lift without compressing a half-page tail into
@@ -352,6 +380,12 @@ export class CapturedPageTurn {
           return false;
         }
         try {
+          if (active.incoming) {
+            await Promise.race([
+              active.incoming,
+              new Promise<void>((resolve) => setTimeout(resolve, INCOMING_WAIT_MS)),
+            ]);
+          }
           await this.#playTo(active, 1);
           return true;
         } finally {
@@ -689,6 +723,8 @@ export class CapturedPageTurn {
       // (left for LTR books). Backward: the mirror image — it recedes over
       // the outer edge, revealing the previous page.
       rendererRtl: forward ? rtl : !rtl,
+      columns: style === 'curl' && (this.#host.getColumnCount?.() ?? 1) >= 2 ? 2 : 1,
+      incoming: null,
       progress: 0,
       grabY: 0.5,
       dragSession,
@@ -701,6 +737,7 @@ export class CapturedPageTurn {
     // First frame draws the captured page exactly covering the content box,
     // hiding the instant page swap happening underneath.
     try {
+      renderer.setColumns?.(active.columns);
       renderer.render(0, this.#grab(active), active.rendererRtl);
       if (renderer.isUsable?.() === false) {
         throw new Error('Captured page-turn renderer became unavailable before navigation');
@@ -735,6 +772,10 @@ export class CapturedPageTurn {
       }
       await this.#host.navigate(forward);
       if (this.#disposed || this.#active !== active) return null;
+      if (active.columns === 2 && this.#host.coverRegion) {
+        // Runs alongside the turn; a failure simply leaves the paper back.
+        active.incoming = this.#captureIncoming(active, captureRect).catch(() => {});
+      }
       return active;
     } catch (error) {
       if (this.#disposed) return null;
@@ -755,6 +796,54 @@ export class CapturedPageTurn {
 
   #grab(active: ActiveTurn) {
     return { x: active.rendererRtl ? 0 : 1, y: active.grabY };
+  }
+
+  /**
+   * Two-column curl: capture the inner column of the spread the live view has
+   * just turned to, for the back of the leaf, so the landed leaf matches the
+   * live page pixel for pixel when the overlay comes off. The overlay hides
+   * that column behind the old page, so the host first freezes the region's
+   * on-screen pixels natively, the overlay is clipped to the leaf side to
+   * expose the live column to the platform snapshot, and both are restored
+   * in order before the native cover comes down. The turn keeps animating
+   * throughout; the texture is swapped in as soon as it arrives.
+   */
+  async #captureIncoming(active: ActiveTurn, rect: CaptureRect) {
+    const half = rect.width / 2;
+    // The leaf lands on the column opposite its grabbed edge.
+    const inner: CaptureRect = {
+      x: active.rendererRtl ? rect.x + half : rect.x,
+      y: rect.y,
+      width: half,
+      height: rect.height,
+    };
+    const uncover = await this.#host.coverRegion!(inner);
+    let image: ArrayBuffer | null = null;
+    try {
+      if (this.#active !== active || this.#host.isCaptureAllowed?.() === false) return;
+      active.overlay.style.clipPath = active.rendererRtl ? 'inset(0 50% 0 0)' : 'inset(0 0 0 50%)';
+      await waitForPaint();
+      if (this.#active !== active) return;
+      const restorePixels = await this.#host.preparePixelCapture?.();
+      try {
+        image = await this.#host.capture(inner);
+      } finally {
+        await restorePixels?.();
+      }
+    } finally {
+      active.overlay.style.clipPath = '';
+      await waitForPaint();
+      await uncover();
+    }
+    if (!image || this.#active !== active) return;
+    const bitmap = await createImageBitmap(new Blob([image]));
+    try {
+      if (this.#active !== active) return;
+      active.renderer.setIncoming?.(bitmap);
+      active.renderer.render(active.progress, this.#grab(active), active.rendererRtl);
+    } finally {
+      bitmap.close();
+    }
   }
 
   #applyDragSession(active: ActiveTurn, session: DragSession) {

--- a/apps/readest-app/src/app/reader/utils/capturedTurn.ts
+++ b/apps/readest-app/src/app/reader/utils/capturedTurn.ts
@@ -826,6 +826,11 @@ export class CapturedPageTurn {
       if (this.#active !== active) return;
       const restorePixels = await this.#host.preparePixelCapture?.();
       try {
+        // A modal can open during any of these awaits, and the platform
+        // snapshot would include its composited pixels. Re-check the gate at
+        // every step, as the outgoing capture does, so a dialog never ends up
+        // on the back of the leaf.
+        if (this.#active !== active || this.#host.isCaptureAllowed?.() === false) return;
         image = await this.#host.capture(inner);
       } finally {
         await restorePixels?.();
@@ -835,10 +840,10 @@ export class CapturedPageTurn {
       await waitForPaint();
       await uncover();
     }
-    if (!image || this.#active !== active) return;
+    if (!image || this.#active !== active || this.#host.isCaptureAllowed?.() === false) return;
     const bitmap = await createImageBitmap(new Blob([image]));
     try {
-      if (this.#active !== active) return;
+      if (this.#active !== active || this.#host.isCaptureAllowed?.() === false) return;
       active.renderer.setIncoming?.(bitmap);
       active.renderer.render(active.progress, this.#grab(active), active.rendererRtl);
     } finally {

--- a/apps/readest-app/src/utils/bridge.ts
+++ b/apps/readest-app/src/utils/bridge.ts
@@ -348,6 +348,29 @@ export async function captureWebviewRegion(
   });
 }
 
+export interface CoverWebviewRegionResponse {
+  token: number;
+}
+
+/**
+ * Freeze the on-screen pixels of a webview region behind a native snapshot
+ * view that `captureWebviewRegion` does not see (iOS only so far). The
+ * two-column page curl uses it to capture the incoming column under its
+ * overlay without ever showing it (#6106). Rejects where unimplemented.
+ */
+export async function coverWebviewRegion(
+  request: CaptureWebviewRegionRequest,
+): Promise<CoverWebviewRegionResponse> {
+  return await invoke<CoverWebviewRegionResponse>('plugin:native-bridge|cover_webview_region', {
+    payload: request,
+  });
+}
+
+/** Remove the cover put up by `coverWebviewRegion`; stale tokens are ignored. */
+export async function uncoverWebviewRegion(request: { token: number }): Promise<void> {
+  await invoke('plugin:native-bridge|uncover_webview_region', { payload: request });
+}
+
 // ── Sync passphrase keychain ────────────────────────────────────────────
 // Tauri-only. Wired into the TauriPassphraseStore (src/libs/crypto/
 // passphrase.ts) so the user's sync passphrase persists across app

--- a/apps/readest-app/src/utils/pageCurl.ts
+++ b/apps/readest-app/src/utils/pageCurl.ts
@@ -8,6 +8,13 @@
  * setBackdrop). The canvas is transparent wherever the page has curled
  * away, so the live (already turned) page shows through underneath.
  *
+ * With two columns on screen (setColumns), only the outer column is a leaf:
+ * it is hinged at the spine like a real book page, the fold stops at the
+ * spine, and the leaf lands on the inner column as an exact mirror. Its back
+ * shows the incoming page (setIncoming) so that the moment the overlay is
+ * removed matches the live page underneath; without an incoming texture the
+ * back is theme paper and the canvas fades out over the last stretch.
+ *
  * The renderer knows nothing about capture or gestures: callers provide an
  * ImageBitmap of the outgoing page and drive `render(progress, grab)`.
  */
@@ -18,24 +25,34 @@ uniform vec2 uPage;       // page size in px
 uniform vec2 uFold;       // a point on the fold line, page px
 uniform vec2 uDir;        // fold normal (unit): points toward the curled side
 uniform float uRadius;    // cylinder radius, px
+uniform vec2 uLeaf;       // open x interval (page px) of the leaf that may deform
 varying vec2 vUv;
-varying float vLift;      // 0 flat .. 1 on top of the cylinder
+varying float vLift;      // 0 flat .. 1 on top of the cylinder / landed
+varying float vShade;     // 0 flat or landed .. 1 at the top of the roll
 
 const float PI = 3.141592653589793;
 
 void main() {
   vec2 p = aPos * uPage;
   float s = dot(p - uFold, uDir);
-  float z = 0.0;
-  if (s > 0.0) {
-    if (s < PI * uRadius) {
-      float wrapped = uRadius * sin(s / uRadius);
-      z = uRadius * (1.0 - cos(s / uRadius));
+  float lift = 0.0;
+  float shade = 0.0;
+  // Vertices on the spine itself never move: they are the hinge shared with
+  // the flat inner column, which must not stretch.
+  if (p.x > uLeaf.x && p.x < uLeaf.y && s > 0.0) {
+    float r = max(uRadius, 1.0e-3);
+    if (s < PI * r) {
+      float wrapped = r * sin(s / r);
+      float z = r * (1.0 - cos(s / r));
       p -= uDir * (s - wrapped);
+      lift = z / (2.0 * r);
+      shade = sin(s / r);
     } else {
-      // Past the half turn: lies flat on top, mirrored about the fold.
-      p -= uDir * (2.0 * s - PI * uRadius);
-      z = 2.0 * uRadius;
+      // Past the half turn: lies flat on top, mirrored about the fold. With
+      // a zero radius this is an exact reflection, which is how a leaf lands
+      // on the facing page.
+      p -= uDir * (2.0 * s - PI * r);
+      lift = 1.0;
     }
   }
   // Texture row 0 is the top of the captured page and aPos.y = 0 is the top
@@ -43,7 +60,8 @@ void main() {
   // rely on UNPACK_FLIP_Y_WEBGL to reconcile them: WebKit ignores it for
   // ImageBitmap uploads, which turned the curl upside down on iOS.
   vUv = aPos;
-  vLift = clamp(z / (2.0 * uRadius + 1.0e-4), 0.0, 1.0);
+  vLift = lift;
+  vShade = shade;
   vec2 clip = (p / uPage) * 2.0 - 1.0;
   // Lifted parts draw on top of flat parts.
   gl_Position = vec4(clip.x, -clip.y, -vLift * 0.5, 1.0);
@@ -54,14 +72,24 @@ const FRAGMENT_SHADER = `
 precision mediump float;
 uniform sampler2D uTex;
 uniform sampler2D uBack;
+uniform sampler2D uIncoming;
+uniform float uHasIncoming;
+uniform vec2 uIncomingMap; // incoming u = uIncomingMap.x + uIncomingMap.y * page u
 varying vec2 vUv;
 varying float vLift;
+varying float vShade;
 
 void main() {
   vec4 c = texture2D(uTex, vUv);
   if (gl_FrontFacing) {
     // Slight contact shading as the page lifts.
     c.rgb *= 1.0 - 0.18 * vLift;
+  } else if (uHasIncoming > 0.5) {
+    // The back of a leaf: the incoming page, mirrored about the spine so it
+    // reads correctly once the leaf has landed. Shaded only on the roll so
+    // the landed part matches the live page pixel for pixel.
+    c = texture2D(uIncoming, vec2(uIncomingMap.x + uIncomingMap.y * vUv.x, vUv.y));
+    c.rgb *= 1.0 - 0.22 * vShade;
   } else {
     // The back of the page: the mirrored content bleeding through the
     // paper — the theme background supplied via setBackdrop.
@@ -74,6 +102,9 @@ void main() {
 `;
 
 const GRID = 64;
+// Without an incoming texture a two-column leaf lands showing paper; fade the
+// whole canvas over the last stretch so the live page takes over smoothly.
+const LEAF_FADE_START = 0.8;
 
 export interface CurlGrab {
   /** Normalized grab point on the page, 0..1 in both axes. */
@@ -81,10 +112,18 @@ export interface CurlGrab {
   y: number;
 }
 
+const smoothstep = (edge0: number, edge1: number, x: number) => {
+  const t = Math.min(1, Math.max(0, (x - edge0) / (edge1 - edge0)));
+  return t * t * (3 - 2 * t);
+};
+
 export class PageCurlRenderer {
   private canvas: HTMLCanvasElement | null = null;
   private gl: WebGLRenderingContext | null = null;
   private backTex: WebGLTexture | null = null;
+  private incomingTex: WebGLTexture | null = null;
+  private hasIncoming = false;
+  private columns = 1;
   private indexCount = 0;
   private width = 0;
   private height = 0;
@@ -149,7 +188,8 @@ export class PageCurlRenderer {
     // biome-ignore lint/correctness/useHookAtTopLevel: WebGL API, not a React hook
     gl.useProgram(program);
 
-    // Grid mesh of GRID x GRID quads over the unit page.
+    // Grid mesh of GRID x GRID quads over the unit page. GRID is even, so a
+    // two-column spine falls on a grid line and no quad straddles the hinge.
     const verts: number[] = [];
     for (let y = 0; y <= GRID; y++) {
       for (let x = 0; x <= GRID; x++) {
@@ -177,32 +217,31 @@ export class PageCurlRenderer {
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
 
-    for (const name of ['uPage', 'uFold', 'uDir', 'uRadius', 'uTex', 'uBack']) {
+    for (const name of [
+      'uPage',
+      'uFold',
+      'uDir',
+      'uRadius',
+      'uLeaf',
+      'uTex',
+      'uBack',
+      'uIncoming',
+      'uHasIncoming',
+      'uIncomingMap',
+    ]) {
       this.uniforms[name] = gl.getUniformLocation(program, name);
     }
     gl.uniform2f(this.uniforms['uPage']!, width, height);
 
     // Back-face paper on unit 1: plain white until setBackdrop supplies the
     // theme background.
-    this.backTex = gl.createTexture();
-    gl.activeTexture(gl.TEXTURE1);
-    gl.bindTexture(gl.TEXTURE_2D, this.backTex);
-    gl.texImage2D(
-      gl.TEXTURE_2D,
-      0,
-      gl.RGBA,
-      1,
-      1,
-      0,
-      gl.RGBA,
-      gl.UNSIGNED_BYTE,
-      new Uint8Array([255, 255, 255, 255]),
-    );
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    this.backTex = this.createPlaceholderTexture(gl, 1, [255, 255, 255, 255]);
     gl.uniform1i(this.uniforms['uBack']!, 1);
+    // Incoming page on unit 2: unused until setIncoming supplies it.
+    this.incomingTex = this.createPlaceholderTexture(gl, 2, [0, 0, 0, 0]);
+    gl.uniform1i(this.uniforms['uIncoming']!, 2);
+    gl.uniform1f(this.uniforms['uHasIncoming']!, 0);
+    gl.uniform2f(this.uniforms['uIncomingMap']!, 0, 1);
     gl.activeTexture(gl.TEXTURE0);
 
     gl.viewport(0, 0, canvas.width, canvas.height);
@@ -214,6 +253,28 @@ export class PageCurlRenderer {
     gl.frontFace(gl.CW);
     gl.enable(gl.BLEND);
     gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+  }
+
+  private createPlaceholderTexture(gl: WebGLRenderingContext, unit: number, rgba: number[]) {
+    const tex = gl.createTexture();
+    gl.activeTexture(gl.TEXTURE0 + unit);
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA,
+      1,
+      1,
+      0,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      new Uint8Array(rgba),
+    );
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    return tex;
   }
 
   /** Upload the captured page (drawn at progress 0 it exactly covers). */
@@ -247,6 +308,34 @@ export class PageCurlRenderer {
   }
 
   /**
+   * How many page columns the captured page holds. With 2, only the outer
+   * column turns, hinged at the spine (the middle of the page); the inner
+   * column stays flat until the leaf lands on it.
+   */
+  setColumns(columns: number) {
+    this.columns = columns >= 2 ? 2 : 1;
+  }
+
+  /**
+   * The incoming page shown on the back of a two-column leaf: a capture of
+   * the inner column of the page the live view has already turned to (the
+   * column the leaf lands on), at the same height as the captured page.
+   * `null` reverts to the paper back.
+   */
+  setIncoming(source: TexImageSource | null) {
+    const gl = this.gl;
+    if (!gl || !this.incomingTex) return;
+    this.hasIncoming = source !== null;
+    if (source) {
+      gl.activeTexture(gl.TEXTURE2);
+      gl.bindTexture(gl.TEXTURE_2D, this.incomingTex);
+      gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source);
+      gl.activeTexture(gl.TEXTURE0);
+    }
+  }
+
+  /**
    * Draw the curl at `progress` (0 = flat, 1 = fully turned). `grab` picks
    * where the reader lifted the page: y near 1 curls from the bottom corner
    * (a diagonal fold that straightens as the turn completes), y near 0.5
@@ -257,6 +346,13 @@ export class PageCurlRenderer {
     const gl = this.gl;
     if (!gl) return;
     const { width: w, height: h } = this;
+    const leaf = this.columns === 2;
+    // The sheet being turned: the whole page, or the outer column of a
+    // two-column spread.
+    const leafWidth = leaf ? w / 2 : w;
+    // Only the spine is a hinge; the outer edge (and a single page) is open.
+    const leafMin = leaf && !rtl ? w / 2 : -1e9;
+    const leafMax = leaf && rtl ? w / 2 : 1e9;
 
     // Fold normal: mostly horizontal, tilted by how far the grab sits from
     // the vertical middle. The tilt decays with progress — a corner grab
@@ -268,16 +364,37 @@ export class PageCurlRenderer {
     const len = Math.hypot(1, tilt);
     const dir: [number, number] = [dx / len, tilt / len];
 
-    // The cylinder tightens slightly as the page lifts off.
-    const radius = Math.max(24, 0.16 * w * (1 - 0.4 * progress));
-    // The fold sweeps from the grabbed edge along the grab row; by progress 1
-    // (tilt 0) it must cross the page plus the final half-circumference so
-    // the spine-side column has fully wrapped off.
-    const endRadius = Math.max(24, 0.16 * w * 0.6);
-    const travel = w + Math.PI * endRadius;
+    let radius: number;
+    let travel: number;
+    if (leaf) {
+      // The roll tightens all the way to nothing so the leaf lands flat on
+      // the inner column, and the fold stops exactly at the spine.
+      radius = 0.16 * leafWidth * (1 - progress * progress);
+      travel = leafWidth;
+    } else {
+      // The cylinder tightens slightly as the page lifts off.
+      radius = Math.max(24, 0.16 * w * (1 - 0.4 * progress));
+      // The fold sweeps from the grabbed edge along the grab row; by progress 1
+      // (tilt 0) it must cross the page plus the final half-circumference so
+      // the spine-side column has fully wrapped off.
+      const endRadius = Math.max(24, 0.16 * w * 0.6);
+      travel = w + Math.PI * endRadius;
+    }
     const start: [number, number] = [rtl ? 0 : w, grab.y * h];
     const foldX = start[0] - dir[0] * travel * progress;
     const foldY = start[1] - dir[1] * travel * progress;
+
+    // The leaf's back shows the incoming inner column mirrored about the
+    // spine: page u in [0.5, 1] maps to incoming u in [1, 0] for a right
+    // leaf, page u in [0, 0.5] to incoming u in [1, 0] for a left leaf.
+    const showIncoming = leaf && this.hasIncoming;
+    gl.uniform1f(this.uniforms['uHasIncoming']!, showIncoming ? 1 : 0);
+    gl.uniform2f(this.uniforms['uIncomingMap']!, rtl ? 1 : 2, -2);
+    gl.uniform2f(this.uniforms['uLeaf']!, leafMin, leafMax);
+    if (this.canvas) {
+      const opacity = leaf && !this.hasIncoming ? 1 - smoothstep(LEAF_FADE_START, 1, progress) : 1;
+      this.canvas.style.opacity = opacity < 1 ? String(opacity) : '';
+    }
 
     gl.clearColor(0, 0, 0, 0);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -295,6 +412,11 @@ export class PageCurlRenderer {
     const data = new Uint8Array(4);
     gl.readPixels(x, canvas.height - 1 - y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, data);
     return [data[0]!, data[1]!, data[2]!, data[3]!];
+  }
+
+  /** The canvas opacity the last render applied ('' when fully opaque). */
+  get canvasOpacity(): string {
+    return this.canvas?.style.opacity ?? '';
   }
 
   /** An idle prepared surface may lose its WebGL context under memory pressure. */


### PR DESCRIPTION
Closes #6106.

With two columns on screen, **Page Curl** treated the whole spread as one sheet hinged at the outer screen edge: the entire spread lifted from the left edge and the back showed the outgoing spread mirrored through the paper. A book (and Apple Books' two-page mode) hinges each leaf at the spine.

### What changes

**Renderer (`pageCurl.ts`)** — a leaf mode, on only when the captured page holds two columns:
- Only the outer column deforms; vertices on the spine are the hinge and the inner column stays flat.
- The fold stops at the spine and the roll radius tightens to zero, so the leaf lands on the inner column as an exact mirror.
- The back of the leaf samples a second texture, the incoming inner column, mirrored about the spine so it reads correctly once landed. The landed part is unshaded, so removing the overlay is pixel-identical to the live page underneath.
- Without an incoming texture the back is theme paper (as before) and the canvas fades out over the last 20% so the live page takes over smoothly.
- Single-column behaviour is unchanged; the existing tests still pass untouched.

**Orchestrator (`capturedTurn.ts`)** — after the instant navigation, a two-column curl captures the inner column of the new spread for the leaf's back. That column is under the overlay, so the host first freezes the region's on-screen pixels behind a native cover, the overlay is clipped to the leaf side to expose the live column to the platform snapshot, and both are restored in order before the cover comes down. The turn keeps animating throughout; the texture is swapped in when it arrives. A programmatic turn waits up to 120 ms for it. Any failure leaves the paper back.

**Native (`native-bridge`)** — two new commands, `cover_webview_region` / `uncover_webview_region`. On iOS the cover is a `resizableSnapshotView` of the region added as a **sibling above** the `WKWebView`: `takeSnapshot` renders the webview's own layer tree, so the cover hides the live column from the user but not from the capture. Tokens keep a stale uncover from an interrupted turn from removing the next turn's cover. Android and desktop reject (the hook only offers `coverRegion` on iOS), so they get the paper back + fade.

**Hook (`useCapturedTurn.ts`)** — passes `renderer.columnCount` (1 for vertical writing, whose columns stack) and the iOS cover callbacks to the controller.

### Tests
- `page-curl.browser.test.ts`: seven new leaf cases, including "lands the leaf on the inner column as an exact mirror of the incoming page" (asserts the landed back against the incoming bitmap at many sample points), mid-turn carry, rtl/backward, the no-incoming fade, and single-column isolation.
- `captured-turn.browser.test.ts`: nine new orchestration cases — inner-rect selection for forward/backward/rtl, cover→clip→capture→restore→uncover ordering, overlay clip during capture, failure and mid-turn disposal still lifting the cover, and slide/single-column staying on the old path.

```
pnpm test:browser -- src/__tests__/utils/page-curl.browser.test.ts src/__tests__/utils/captured-turn.browser.test.ts
```

### Verified
- Browser suites: `page-curl.browser.test.ts` 14/14 and `captured-turn.browser.test.ts` 80/80; the full web unit suite passes (10,961 tests) with `NODE_OPTIONS=--no-experimental-webstorage` (Node 26's built-in `localStorage` shadows jsdom's, unrelated to this change).
- On device: development build on an iPhone 15 Pro Max (iOS 27.0), landscape two columns with Page Curl. Forward and backward turns hinge at the spine, the inner page stays flat until covered, and the incoming page is readable on the back of the leaf as it lands with no visible pop when the overlay comes off. Portrait single-column turns are unchanged.
- Rust: `cargo check -p tauri-plugin-native-bridge` on macOS and `aarch64-apple-ios-sim`; the Swift plugin compiles in the iOS device build.

### Not in this PR
- Android/macOS covers (Android would need a cover outside the window for `PixelCopy`; macOS's web-process snapshot races presentation). Both fall back cleanly.
- Slide style in two-column mode is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code) running Claude Fable 5.1, driven and verified on device by @kad-air.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two-column page-curl support for spread layouts.
  * The outer page curls around the spine while the incoming inner page appears on the reverse side.
  * Improved page-turn rendering for forward, backward, and right-to-left navigation.
  * Added a smoother iOS transition by temporarily preserving the incoming column during the animation.
  * Other platforms continue using the existing paper-back fallback when native coverage is unavailable.

* **Bug Fixes**
  * Prevented obstructed or interrupted page captures from displaying incomplete incoming content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->