### PR TITLE
fix(ci): bundle the audio libraries the CEF AppImage dlopens

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -132,18 +132,13 @@ jobs:
         with:
           key: nightly-${{ matrix.config.os }}-${{ matrix.config.release }}-${{ matrix.config.arch }}-cargo
 
-      # The published @tauri-apps/cli-cef (3.0.0-alpha.26, pinned in
-      # apps/readest-app/scripts/tauri.mjs) bundles the AppImage with a fork of
-      # quick-sharun whose deployment array is broken — see the staging step
-      # below — and re-downloads that fork on every build with no way to point
-      # it elsewhere. The Linux legs build the CLI from readest/tauri instead,
-      # where sharun_cef.rs fetches a pinned, checksummed pkgforge revision and
-      # runs the tooling with bash and streamed output (the fix behind the
-      # STRACE_MODE hang, tauri-apps/tauri#12491). Pinned to a rev, not the
-      # branch tip, so a release cannot change behaviour under us; rust-cache
-      # keeps ~/.cargo/bin, and the marker file skips the ~6 minute rebuild
-      # while the pin is unchanged. TAURI_CEF_CARGO=1 in the build step makes
-      # scripts/tauri.mjs run `cargo tauri` with the same command line.
+      # The npm cli-cef bundles the AppImage with a broken quick-sharun fork
+      # and cannot be pointed elsewhere. Build the CLI from readest/tauri
+      # instead: its sharun_cef.rs pins a pkgforge revision (the one
+      # tauri-apps/tauri#12491 uses) and runs the tooling with bash and
+      # streamed output. Rev-pinned; the marker skips the rebuild while
+      # rust-cache keeps ~/.cargo/bin. scripts/tauri.mjs runs `cargo tauri`
+      # when TAURI_CEF_CARGO=1.
       - name: install the CEF tauri CLI from readest/tauri (linux only)
         if: matrix.config.release == 'linux'
         run: |
@@ -163,38 +158,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libfontconfig-dev libgtk-3-dev libwebkit2gtk-4.1 libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1 libjavascriptcoregtk-4.1-dev gir1.2-javascriptcoregtk-4.1 gir1.2-webkit2-4.1 libappindicator3-dev librsvg2-dev patchelf xdg-utils
 
-      # The CEF AppImage bundles the build host's glibc, so anything it does
-      # NOT bundle is resolved from the host at run time, against a glibc the
-      # bundled one cannot satisfy on any distro newer than the builder. The
-      # libraries Chromium dlopens by soname are the ones at risk; when they
-      # were missing, NSS aborted the app on first use (FATAL
-      # crypto/nss_util.cc, nss_error=-5925) and there was no audio output.
-      #
-      # quick-sharun deploys them itself: DEPLOY_CHROMIUM (which the bundler
-      # sets) covers the NSS modules and, via DEPLOY_PIPEWIRE -> DEPLOY_PULSE,
-      # libpulse and the ALSA pulse plugins. Verified with the pinned pkgforge
-      # revision the CLI above uses. This step only fills the two gaps no rule
-      # covers, the way the script itself prescribes — pass the file to
-      # quick-sharun rather than copy it in — through appimage.files entries
-      # under /usr/lib, which the bundler hands over as plain arguments:
-      #   - Debian keeps the NSS PKCS#11 modules in <triple>/nss/, and the
-      #     globs only know Arch's flat layout; copy them up a level so
-      #     `"$LIB_DIR"/libsoftokn3.so*` and friends match on the runner.
-      #   - nothing deploys libspeechd.so.2, without which the Web Speech TTS
-      #     engine has no system voices.
-      #
-      # Why the npm cli-cef could not do this (local builds still use it): its
-      # bundler downloads a fork of the script (FabianLars/Anylinux-AppImages,
-      # re-fetched from main on every build) whose HEAD, 3e280d1b "fix handling
-      # of spaces in input paths", turned
-      #   eval set -- "$TO_DEPLOY_ARRAY" "$@"   into   set -- $TO_DEPLOY_ARRAY "$@"
-      # The array entries come single-quoted from _save_array, so without the
-      # eval each keeps its literal quotes, fails `[ -f ]`, and EVERY DEPLOY_*
-      # extra is silently skipped — only ldd-derived libraries land. (Upstream's
-      # line does split positional paths on spaces; quoting them through the
-      # same helper keeps both.) tauri-apps/tauri#12491 takes the same route as
-      # the CLI above and also fixes the CI hang behind the STRACE_MODE pin in
-      # the build step; lift that pin when a cli-cef carries it.
+      # Chromium dlopens NSS, libpulse and libspeechd by soname; whatever the
+      # bundle lacks comes from the host at run time and fails against the
+      # bundled glibc on any newer distro (NSS: FATAL crypto/nss_util.cc).
+      # quick-sharun's DEPLOY_CHROMIUM deploys NSS and, via DEPLOY_PIPEWIRE,
+      # pulse — with the pinned pkgforge script the CLI above uses. Two gaps
+      # remain, passed as appimage.files under /usr/lib, which the bundler
+      # hands to quick-sharun as arguments: Debian keeps the NSS modules in
+      # <triple>/nss/ where the Arch-layout globs miss them, and nothing
+      # deploys libspeechd. The npm cli-cef could do none of this: its
+      # quick-sharun fork drops the `eval` that rebuilds the deploy array
+      # (FabianLars/Anylinux-AppImages@3e280d1b), so every DEPLOY_* extra is
+      # silently skipped.
       - name: stage CEF AppImage runtime libraries (linux only)
         if: matrix.config.release == 'linux'
         run: |
@@ -203,9 +178,7 @@ jobs:
           nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
           lib_dir=${nss_dir%/nss}
           sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
-          # Merge, don't assign: tauri.conf.json already ships an appimage.files
-          # entry for the AppRun hook that keeps the bundler's namespace hook
-          # from prompting for a root password (src-tauri/appimage/).
+          # +=: tauri.conf.json already ships the AppRun hook entry.
           conf=apps/readest-app/src-tauri/tauri.conf.json
           jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
               "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2")
@@ -305,9 +278,7 @@ jobs:
         timeout-minutes: 45
         env:
           TAURI_CEF_CARGO: '1'
-          # See release.yml: keep quick-sharun from running the app under
-          # Xvfb. Lift this together with the AppImage library staging above,
-          # once cli-cef carries tauri-apps/tauri#12491.
+          # See release.yml.
           STRACE_MODE: '0'
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -324,12 +295,8 @@ jobs:
           cd apps/readest-app
           pnpm tauri build ${{ matrix.config.args }}
 
-      # quick-sharun skips anything it cannot find without failing, which is
-      # how the AppImage shipped with no NSS modules at all. Fail the leg
-      # instead of shipping a bundle that crashes on first use. The path is the
-      # AppDir quick-sharun packed, left next to the AppImage in the WORKSPACE
-      # target dir (see the collect step below). libsqlite3 is not staged
-      # explicitly — it must arrive as libsoftokn3.so's own ldd dependency.
+      # quick-sharun skips what it cannot find without failing; catch that
+      # before it ships.
       - name: verify the AppImage bundle contents (linux only)
         if: matrix.config.release == 'linux'
         run: |
@@ -339,16 +306,13 @@ jobs:
                     libpulse.so.0 libspeechd.so.2; do
             [ -e "$lib/$so" ] || { echo "::error::$so is missing from the AppImage bundle"; exit 1; }
           done
-          # libpulse keeps its private half in a subdir and finds it by RUNPATH,
-          # which points at the HOST dir; only sharun's own library path (built
-          # from lib.path) makes it load the bundled copy instead.
+          # libpulse finds its private half through a host RUNPATH; lib.path
+          # has to cover the bundled copy for it to win.
           ls "$lib"/pulseaudio/libpulsecommon-*.so > /dev/null 2>&1 \
             || { echo "::error::libpulsecommon is missing from the AppImage bundle"; exit 1; }
           grep -qx '+/pulseaudio' "$lib/lib.path" \
             || { echo "::error::lib.path does not cover lib/pulseaudio, so libpulse cannot load"; exit 1; }
-          # Ships through appimage.files, so it lands before quick-sharun adds
-          # the bundler's own hooks; without it every new AppImage asks for a
-          # root password on first launch.
+          # Without this hook every new AppImage asks for a root password.
           [ -e "${lib%/lib}/bin/00-no-userns-prompt.hook" ] \
             || { echo "::error::the no-userns-prompt hook is missing from the AppImage bundle"; exit 1; }
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -140,9 +140,15 @@ jobs:
 
       # The CEF AppImage bundles the build host's glibc, so anything it does
       # NOT bundle is resolved from the host at run time, against a glibc the
-      # bundled one cannot satisfy on any distro newer than the builder. NSS is
-      # the fatal case: Chromium dlopens libsoftokn3.so, gets the host copy and
-      # aborts on first use (FATAL crypto/nss_util.cc, nss_error=-5925).
+      # bundled one cannot satisfy on any distro newer than the builder. Only
+      # libraries Chromium links against are bundled; the ones it dlopens by
+      # soname are not, and each one it misses fails that way:
+      #   libsoftokn3.so  NSS aborts the app on first use (FATAL
+      #                   crypto/nss_util.cc, nss_error=-5925)
+      #   libpulse.so.0   no audio output at all — the ALSA fallback then dies
+      #                   too, because its `default` PCM is a config hook that
+      #                   loads the host's libasound_module_conf_pulse.so
+      #   libspeechd.so.2 no system voices for the Web Speech TTS engine
       #
       # quick-sharun's own DEPLOY_CHROMIUM rules cover these modules, but the
       # bundler in cli-cef 3.0.0-alpha.26 downloads a fork of that script
@@ -153,10 +159,11 @@ jobs:
       # in the bundle. tauri-apps/tauri#12491 drops that fork for a pinned,
       # checksummed upstream revision (facb95e8, which has the `eval`). Once it
       # reaches feat/cef and a new cli-cef ships, bump CEF_CLI in
-      # apps/readest-app/scripts/tauri.mjs, lift the STRACE_MODE pin in the
-      # build step and drop the jq call below. Keep the flatten unless dlopen
-      # discovery is doing the finding: upstream globs only Arch's flat layout,
-      # so a Debian builder hides these modules from it either way.
+      # apps/readest-app/scripts/tauri.mjs and lift the STRACE_MODE pin in the
+      # build step — upstream's own rules then cover NSS and libpulse. Keep the
+      # nss/ flatten and the libspeechd entry either way: upstream globs only
+      # Arch's flat layout, so a Debian builder hides the NSS modules from it,
+      # and nothing in it deploys libspeechd at all.
       #
       # Until then, hand the modules over as appimage.files: the bundler passes
       # files targeted at /usr/lib to quick-sharun as plain ELF arguments, the
@@ -168,7 +175,7 @@ jobs:
         if: matrix.config.release == 'linux'
         run: |
           set -euo pipefail
-          sudo apt-get install -y libnss3
+          sudo apt-get install -y libnss3 libpulse0 libspeechd2
           nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
           lib_dir=${nss_dir%/nss}
           sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
@@ -176,7 +183,9 @@ jobs:
           jq --arg d "$lib_dir" '.bundle.linux.appimage.files = {
               "/usr/lib/libsoftokn3.so": ($d + "/libsoftokn3.so"),
               "/usr/lib/libfreeblpriv3.so": ($d + "/libfreeblpriv3.so"),
-              "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so")
+              "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so"),
+              "/usr/lib/libpulse.so.0": ($d + "/libpulse.so.0"),
+              "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2")
             }' "$conf" > "$conf.tmp" && mv "$conf.tmp" "$conf"
 
       - name: create .env.local file for Next.js
@@ -302,9 +311,17 @@ jobs:
         run: |
           set -euo pipefail
           lib=target/release/bundle/appimage/Readest.AppDir/lib
-          for so in libsoftokn3.so libfreeblpriv3.so libnssckbi.so libsqlite3.so.0; do
+          for so in libsoftokn3.so libfreeblpriv3.so libnssckbi.so libsqlite3.so.0 \
+                    libpulse.so.0 libspeechd.so.2; do
             [ -e "$lib/$so" ] || { echo "::error::$so is missing from the AppImage bundle"; exit 1; }
           done
+          # libpulse keeps its private half in a subdir and finds it by RUNPATH,
+          # which points at the HOST dir; only sharun's own library path (built
+          # from lib.path) makes it load the bundled copy instead.
+          ls "$lib"/pulseaudio/libpulsecommon-*.so > /dev/null 2>&1 \
+            || { echo "::error::libpulsecommon is missing from the AppImage bundle"; exit 1; }
+          grep -qx '+/pulseaudio' "$lib/lib.path" \
+            || { echo "::error::lib.path does not cover lib/pulseaudio, so libpulse cannot load"; exit 1; }
 
       # Portable Windows build: rebuild with NEXT_PUBLIC_PORTABLE_APP=true and
       # ship the raw exe (mirrors release.yml). Runs after the NSIS build above.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -150,20 +150,34 @@ jobs:
       #                   loads the host's libasound_module_conf_pulse.so
       #   libspeechd.so.2 no system voices for the Web Speech TTS engine
       #
-      # quick-sharun's own DEPLOY_CHROMIUM rules cover these modules, but the
-      # bundler in cli-cef 3.0.0-alpha.26 downloads a fork of that script
-      # (FabianLars/Anylinux-AppImages, taken on feat/cef to fix spaces in
-      # paths) which is ~1100 lines behind pkgforge upstream and expands its
-      # deployment array without `eval`: every path keeps its literal quotes,
-      # so EVERY DEPLOY_* extra is skipped and only ldd-derived libraries land
-      # in the bundle. tauri-apps/tauri#12491 drops that fork for a pinned,
-      # checksummed upstream revision (facb95e8, which has the `eval`). Once it
-      # reaches feat/cef and a new cli-cef ships, bump CEF_CLI in
-      # apps/readest-app/scripts/tauri.mjs and lift the STRACE_MODE pin in the
-      # build step — upstream's own rules then cover NSS and libpulse. Keep the
-      # nss/ flatten and the libspeechd entry either way: upstream globs only
-      # Arch's flat layout, so a Debian builder hides the NSS modules from it,
-      # and nothing in it deploys libspeechd at all.
+      # quick-sharun's own DEPLOY_CHROMIUM rules cover the NSS modules and, via
+      # DEPLOY_PIPEWIRE -> DEPLOY_PULSE, libpulse. None of it reaches the
+      # bundle: the bundler in cli-cef 3.0.0-alpha.26 downloads a fork of the
+      # script (FabianLars/Anylinux-AppImages, re-fetched from its main on
+      # every build) whose HEAD, 3e280d1b "fix handling of spaces in input
+      # paths", is the one-line change
+      #   eval set -- "$TO_DEPLOY_ARRAY" "$@"   ->   set -- $TO_DEPLOY_ARRAY "$@"
+      # Upstream's line does split positional paths on spaces, and tauri names
+      # the AppDir after the product, so the change fixed something real — but
+      # the array entries come single-quoted from _save_array, so without the
+      # eval each keeps its literal quotes, fails `[ -f ]`, and EVERY DEPLOY_*
+      # extra is silently skipped. Only ldd-derived libraries land. The fix
+      # that keeps both halves is to quote the positional args the same way:
+      #   eval set -- "$TO_DEPLOY_ARRAY" "$(_save_array "$@")"
+      # Once that (or any restored eval) is on the fork's main, the next build
+      # deploys NSS and libpulse by itself and those entries below turn
+      # redundant — harmlessly, the tooling keeps files it already has.
+      # tauri-apps/tauri#12491 sidesteps the fork altogether (pinned pkgforge
+      # revision, no whitespace in the AppDir path) and fixes the CI hang the
+      # STRACE_MODE pin in the build step works around; lift that pin and bump
+      # CEF_CLI in apps/readest-app/scripts/tauri.mjs when cli-cef carries it.
+      # Keep the nss/ flatten and the libspeechd entry either way: every
+      # quick-sharun globs only Arch's flat layout, so a Debian builder hides
+      # the NSS modules from it, and no rule deploys libspeechd at all.
+      # libpipewire is deliberately not staged — Chromium needs it for the
+      # screen-share portal, not for audio — and neither are ALSA plugins:
+      # with libpulse in the bundle Chromium talks to PulseAudio/PipeWire
+      # directly, and a pure-ALSA host resolves `default` with built-ins.
       #
       # Until then, hand the modules over as appimage.files: the bundler passes
       # files targeted at /usr/lib to quick-sharun as plain ELF arguments, the

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -179,8 +179,11 @@ jobs:
           nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
           lib_dir=${nss_dir%/nss}
           sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
+          # Merge, don't assign: tauri.conf.json already ships an appimage.files
+          # entry for the AppRun hook that keeps the bundler's namespace hook
+          # from prompting for a root password (src-tauri/appimage/).
           conf=apps/readest-app/src-tauri/tauri.conf.json
-          jq --arg d "$lib_dir" '.bundle.linux.appimage.files = {
+          jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
               "/usr/lib/libsoftokn3.so": ($d + "/libsoftokn3.so"),
               "/usr/lib/libfreeblpriv3.so": ($d + "/libfreeblpriv3.so"),
               "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so"),
@@ -306,7 +309,7 @@ jobs:
       # AppDir quick-sharun packed, left next to the AppImage in the WORKSPACE
       # target dir (see the collect step below). libsqlite3 is not staged
       # explicitly — it must arrive as libsoftokn3.so's own ldd dependency.
-      - name: verify the AppImage bundled its NSS modules (linux only)
+      - name: verify the AppImage bundle contents (linux only)
         if: matrix.config.release == 'linux'
         run: |
           set -euo pipefail
@@ -322,6 +325,11 @@ jobs:
             || { echo "::error::libpulsecommon is missing from the AppImage bundle"; exit 1; }
           grep -qx '+/pulseaudio' "$lib/lib.path" \
             || { echo "::error::lib.path does not cover lib/pulseaudio, so libpulse cannot load"; exit 1; }
+          # Ships through appimage.files, so it lands before quick-sharun adds
+          # the bundler's own hooks; without it every new AppImage asks for a
+          # root password on first launch.
+          [ -e "${lib%/lib}/bin/00-no-userns-prompt.hook" ] \
+            || { echo "::error::the no-userns-prompt hook is missing from the AppImage bundle"; exit 1; }
 
       # Portable Windows build: rebuild with NEXT_PUBLIC_PORTABLE_APP=true and
       # ship the raw exe (mirrors release.yml). Runs after the NSIS build above.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -132,6 +132,31 @@ jobs:
         with:
           key: nightly-${{ matrix.config.os }}-${{ matrix.config.release }}-${{ matrix.config.arch }}-cargo
 
+      # The published @tauri-apps/cli-cef (3.0.0-alpha.26, pinned in
+      # apps/readest-app/scripts/tauri.mjs) bundles the AppImage with a fork of
+      # quick-sharun whose deployment array is broken — see the staging step
+      # below — and re-downloads that fork on every build with no way to point
+      # it elsewhere. The Linux legs build the CLI from readest/tauri instead,
+      # where sharun_cef.rs fetches a pinned, checksummed pkgforge revision and
+      # runs the tooling with bash and streamed output (the fix behind the
+      # STRACE_MODE hang, tauri-apps/tauri#12491). Pinned to a rev, not the
+      # branch tip, so a release cannot change behaviour under us; rust-cache
+      # keeps ~/.cargo/bin, and the marker file skips the ~6 minute rebuild
+      # while the pin is unchanged. TAURI_CEF_CARGO=1 in the build step makes
+      # scripts/tauri.mjs run `cargo tauri` with the same command line.
+      - name: install the CEF tauri CLI from readest/tauri (linux only)
+        if: matrix.config.release == 'linux'
+        run: |
+          set -euo pipefail
+          rev=c62e9f90c1f5759a4e3795cc56b0b9a1273a5773
+          marker="$HOME/.cargo/bin/.cargo-tauri-rev"
+          if [ -x "$HOME/.cargo/bin/cargo-tauri" ] && [ "$(cat "$marker" 2>/dev/null)" = "$rev" ]; then
+            echo "cargo-tauri at $rev already installed"
+            exit 0
+          fi
+          cargo install tauri-cli --git https://github.com/readest/tauri --rev "$rev" --locked --force
+          echo "$rev" > "$marker"
+
       - name: install dependencies (ubuntu only)
         if: contains(matrix.config.os, 'ubuntu') && matrix.config.release != 'android'
         run: |
@@ -140,51 +165,36 @@ jobs:
 
       # The CEF AppImage bundles the build host's glibc, so anything it does
       # NOT bundle is resolved from the host at run time, against a glibc the
-      # bundled one cannot satisfy on any distro newer than the builder. Only
-      # libraries Chromium links against are bundled; the ones it dlopens by
-      # soname are not, and each one it misses fails that way:
-      #   libsoftokn3.so  NSS aborts the app on first use (FATAL
-      #                   crypto/nss_util.cc, nss_error=-5925)
-      #   libpulse.so.0   no audio output at all — the ALSA fallback then dies
-      #                   too, because its `default` PCM is a config hook that
-      #                   loads the host's libasound_module_conf_pulse.so
-      #   libspeechd.so.2 no system voices for the Web Speech TTS engine
+      # bundled one cannot satisfy on any distro newer than the builder. The
+      # libraries Chromium dlopens by soname are the ones at risk; when they
+      # were missing, NSS aborted the app on first use (FATAL
+      # crypto/nss_util.cc, nss_error=-5925) and there was no audio output.
       #
-      # quick-sharun's own DEPLOY_CHROMIUM rules cover the NSS modules and, via
-      # DEPLOY_PIPEWIRE -> DEPLOY_PULSE, libpulse. None of it reaches the
-      # bundle: the bundler in cli-cef 3.0.0-alpha.26 downloads a fork of the
-      # script (FabianLars/Anylinux-AppImages, re-fetched from its main on
-      # every build) whose HEAD, 3e280d1b "fix handling of spaces in input
-      # paths", is the one-line change
-      #   eval set -- "$TO_DEPLOY_ARRAY" "$@"   ->   set -- $TO_DEPLOY_ARRAY "$@"
-      # Upstream's line does split positional paths on spaces, and tauri names
-      # the AppDir after the product, so the change fixed something real — but
-      # the array entries come single-quoted from _save_array, so without the
+      # quick-sharun deploys them itself: DEPLOY_CHROMIUM (which the bundler
+      # sets) covers the NSS modules and, via DEPLOY_PIPEWIRE -> DEPLOY_PULSE,
+      # libpulse and the ALSA pulse plugins. Verified with the pinned pkgforge
+      # revision the CLI above uses. This step only fills the two gaps no rule
+      # covers, the way the script itself prescribes — pass the file to
+      # quick-sharun rather than copy it in — through appimage.files entries
+      # under /usr/lib, which the bundler hands over as plain arguments:
+      #   - Debian keeps the NSS PKCS#11 modules in <triple>/nss/, and the
+      #     globs only know Arch's flat layout; copy them up a level so
+      #     `"$LIB_DIR"/libsoftokn3.so*` and friends match on the runner.
+      #   - nothing deploys libspeechd.so.2, without which the Web Speech TTS
+      #     engine has no system voices.
+      #
+      # Why the npm cli-cef could not do this (local builds still use it): its
+      # bundler downloads a fork of the script (FabianLars/Anylinux-AppImages,
+      # re-fetched from main on every build) whose HEAD, 3e280d1b "fix handling
+      # of spaces in input paths", turned
+      #   eval set -- "$TO_DEPLOY_ARRAY" "$@"   into   set -- $TO_DEPLOY_ARRAY "$@"
+      # The array entries come single-quoted from _save_array, so without the
       # eval each keeps its literal quotes, fails `[ -f ]`, and EVERY DEPLOY_*
-      # extra is silently skipped. Only ldd-derived libraries land. The fix
-      # that keeps both halves is to quote the positional args the same way:
-      #   eval set -- "$TO_DEPLOY_ARRAY" "$(_save_array "$@")"
-      # Once that (or any restored eval) is on the fork's main, the next build
-      # deploys NSS and libpulse by itself and those entries below turn
-      # redundant — harmlessly, the tooling keeps files it already has.
-      # tauri-apps/tauri#12491 sidesteps the fork altogether (pinned pkgforge
-      # revision, no whitespace in the AppDir path) and fixes the CI hang the
-      # STRACE_MODE pin in the build step works around; lift that pin and bump
-      # CEF_CLI in apps/readest-app/scripts/tauri.mjs when cli-cef carries it.
-      # Keep the nss/ flatten and the libspeechd entry either way: every
-      # quick-sharun globs only Arch's flat layout, so a Debian builder hides
-      # the NSS modules from it, and no rule deploys libspeechd at all.
-      # libpipewire is deliberately not staged — Chromium needs it for the
-      # screen-share portal, not for audio — and neither are ALSA plugins:
-      # with libpulse in the bundle Chromium talks to PulseAudio/PipeWire
-      # directly, and a pure-ALSA host resolves `default` with built-ins.
-      #
-      # Until then, hand the modules over as appimage.files: the bundler passes
-      # files targeted at /usr/lib to quick-sharun as plain ELF arguments, the
-      # injection channel #12491 keeps. Sources must sit directly in the triple
-      # lib dir (Debian hides them in <triple>/nss/) because the destination
-      # inside the bundle mirrors the source dir, and only a flat source lands
-      # next to the libnss3.so that loads it.
+      # extra is silently skipped — only ldd-derived libraries land. (Upstream's
+      # line does split positional paths on spaces; quoting them through the
+      # same helper keeps both.) tauri-apps/tauri#12491 takes the same route as
+      # the CLI above and also fixes the CI hang behind the STRACE_MODE pin in
+      # the build step; lift that pin when a cli-cef carries it.
       - name: stage CEF AppImage runtime libraries (linux only)
         if: matrix.config.release == 'linux'
         run: |
@@ -198,10 +208,6 @@ jobs:
           # from prompting for a root password (src-tauri/appimage/).
           conf=apps/readest-app/src-tauri/tauri.conf.json
           jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
-              "/usr/lib/libsoftokn3.so": ($d + "/libsoftokn3.so"),
-              "/usr/lib/libfreeblpriv3.so": ($d + "/libfreeblpriv3.so"),
-              "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so"),
-              "/usr/lib/libpulse.so.0": ($d + "/libpulse.so.0"),
               "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2")
             }' "$conf" > "$conf.tmp" && mv "$conf.tmp" "$conf"
 
@@ -298,6 +304,7 @@ jobs:
         # latest.json for ALL platforms (#4906).
         timeout-minutes: 45
         env:
+          TAURI_CEF_CARGO: '1'
           # See release.yml: keep quick-sharun from running the app under
           # Xvfb. Lift this together with the AppImage library staging above,
           # once cli-cef carries tauri-apps/tauri#12491.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -419,8 +419,11 @@ jobs:
           nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
           lib_dir=${nss_dir%/nss}
           sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
+          # Merge, don't assign: tauri.conf.json already ships an appimage.files
+          # entry for the AppRun hook that keeps the bundler's namespace hook
+          # from prompting for a root password (src-tauri/appimage/).
           conf=apps/readest-app/src-tauri/tauri.conf.json
-          jq --arg d "$lib_dir" '.bundle.linux.appimage.files = {
+          jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
               "/usr/lib/libsoftokn3.so": ($d + "/libsoftokn3.so"),
               "/usr/lib/libfreeblpriv3.so": ($d + "/libfreeblpriv3.so"),
               "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so"),
@@ -567,7 +570,7 @@ jobs:
       # the AppDir quick-sharun packed, left next to the AppImage in the
       # WORKSPACE target dir. libsqlite3 is not staged explicitly — it must
       # arrive as libsoftokn3.so's own ldd dependency.
-      - name: verify the AppImage bundled its NSS modules (linux only)
+      - name: verify the AppImage bundle contents (linux only)
         if: matrix.config.release == 'linux'
         run: |
           set -euo pipefail
@@ -583,6 +586,11 @@ jobs:
             || { echo "::error::libpulsecommon is missing from the AppImage bundle"; exit 1; }
           grep -qx '+/pulseaudio' "$lib/lib.path" \
             || { echo "::error::lib.path does not cover lib/pulseaudio, so libpulse cannot load"; exit 1; }
+          # Ships through appimage.files, so it lands before quick-sharun adds
+          # the bundler's own hooks; without it every new AppImage asks for a
+          # root password on first launch.
+          [ -e "${lib%/lib}/bin/00-no-userns-prompt.hook" ] \
+            || { echo "::error::the no-userns-prompt hook is missing from the AppImage bundle"; exit 1; }
 
       # Attest the freshly built desktop bundles (installers, AppImage, dmg,
       # updater archives + their .sig). tauri-action reports their on-disk paths

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,18 +360,13 @@ jobs:
         with:
           key: ${{ matrix.config.os }}-${{ matrix.config.release }}-${{ matrix.config.arch }}-cargo
 
-      # The published @tauri-apps/cli-cef (3.0.0-alpha.26, pinned in
-      # apps/readest-app/scripts/tauri.mjs) bundles the AppImage with a fork of
-      # quick-sharun whose deployment array is broken — see the staging step
-      # below — and re-downloads that fork on every build with no way to point
-      # it elsewhere. The Linux legs build the CLI from readest/tauri instead,
-      # where sharun_cef.rs fetches a pinned, checksummed pkgforge revision and
-      # runs the tooling with bash and streamed output (the fix behind the
-      # STRACE_MODE hang, tauri-apps/tauri#12491). Pinned to a rev, not the
-      # branch tip, so a release cannot change behaviour under us; rust-cache
-      # keeps ~/.cargo/bin, and the marker file skips the ~6 minute rebuild
-      # while the pin is unchanged. TAURI_CEF_CARGO=1 in the build step makes
-      # scripts/tauri.mjs run `cargo tauri` with the same command line.
+      # The npm cli-cef bundles the AppImage with a broken quick-sharun fork
+      # and cannot be pointed elsewhere. Build the CLI from readest/tauri
+      # instead: its sharun_cef.rs pins a pkgforge revision (the one
+      # tauri-apps/tauri#12491 uses) and runs the tooling with bash and
+      # streamed output. Rev-pinned; the marker skips the rebuild while
+      # rust-cache keeps ~/.cargo/bin. scripts/tauri.mjs runs `cargo tauri`
+      # when TAURI_CEF_CARGO=1.
       - name: install the CEF tauri CLI from readest/tauri (linux only)
         if: matrix.config.release == 'linux'
         run: |
@@ -403,38 +398,18 @@ jobs:
           echo 'CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc' >> $GITHUB_ENV
           echo 'CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS=--cfg=io_uring_skip_arch_check' >> $GITHUB_ENV
 
-      # The CEF AppImage bundles the build host's glibc, so anything it does
-      # NOT bundle is resolved from the host at run time, against a glibc the
-      # bundled one cannot satisfy on any distro newer than the builder. The
-      # libraries Chromium dlopens by soname are the ones at risk; when they
-      # were missing, NSS aborted the app on first use (FATAL
-      # crypto/nss_util.cc, nss_error=-5925) and there was no audio output.
-      #
-      # quick-sharun deploys them itself: DEPLOY_CHROMIUM (which the bundler
-      # sets) covers the NSS modules and, via DEPLOY_PIPEWIRE -> DEPLOY_PULSE,
-      # libpulse and the ALSA pulse plugins. Verified with the pinned pkgforge
-      # revision the CLI above uses. This step only fills the two gaps no rule
-      # covers, the way the script itself prescribes — pass the file to
-      # quick-sharun rather than copy it in — through appimage.files entries
-      # under /usr/lib, which the bundler hands over as plain arguments:
-      #   - Debian keeps the NSS PKCS#11 modules in <triple>/nss/, and the
-      #     globs only know Arch's flat layout; copy them up a level so
-      #     `"$LIB_DIR"/libsoftokn3.so*` and friends match on the runner.
-      #   - nothing deploys libspeechd.so.2, without which the Web Speech TTS
-      #     engine has no system voices.
-      #
-      # Why the npm cli-cef could not do this (local builds still use it): its
-      # bundler downloads a fork of the script (FabianLars/Anylinux-AppImages,
-      # re-fetched from main on every build) whose HEAD, 3e280d1b "fix handling
-      # of spaces in input paths", turned
-      #   eval set -- "$TO_DEPLOY_ARRAY" "$@"   into   set -- $TO_DEPLOY_ARRAY "$@"
-      # The array entries come single-quoted from _save_array, so without the
-      # eval each keeps its literal quotes, fails `[ -f ]`, and EVERY DEPLOY_*
-      # extra is silently skipped — only ldd-derived libraries land. (Upstream's
-      # line does split positional paths on spaces; quoting them through the
-      # same helper keeps both.) tauri-apps/tauri#12491 takes the same route as
-      # the CLI above and also fixes the CI hang behind the STRACE_MODE pin in
-      # the build step; lift that pin when a cli-cef carries it.
+      # Chromium dlopens NSS, libpulse and libspeechd by soname; whatever the
+      # bundle lacks comes from the host at run time and fails against the
+      # bundled glibc on any newer distro (NSS: FATAL crypto/nss_util.cc).
+      # quick-sharun's DEPLOY_CHROMIUM deploys NSS and, via DEPLOY_PIPEWIRE,
+      # pulse — with the pinned pkgforge script the CLI above uses. Two gaps
+      # remain, passed as appimage.files under /usr/lib, which the bundler
+      # hands to quick-sharun as arguments: Debian keeps the NSS modules in
+      # <triple>/nss/ where the Arch-layout globs miss them, and nothing
+      # deploys libspeechd. The npm cli-cef could do none of this: its
+      # quick-sharun fork drops the `eval` that rebuilds the deploy array
+      # (FabianLars/Anylinux-AppImages@3e280d1b), so every DEPLOY_* extra is
+      # silently skipped.
       - name: stage CEF AppImage runtime libraries (linux only)
         if: matrix.config.release == 'linux'
         run: |
@@ -443,9 +418,7 @@ jobs:
           nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
           lib_dir=${nss_dir%/nss}
           sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
-          # Merge, don't assign: tauri.conf.json already ships an appimage.files
-          # entry for the AppRun hook that keeps the bundler's namespace hook
-          # from prompting for a root password (src-tauri/appimage/).
+          # +=: tauri.conf.json already ships the AppRun hook entry.
           conf=apps/readest-app/src-tauri/tauri.conf.json
           jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
               "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2")
@@ -555,15 +528,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_CEF_CARGO: '1'
-          # The CEF AppImage bundler (quick-sharun) otherwise launches the app
-          # under Xvfb to discover dlopen'ed libraries and never gets it to
-          # exit, hanging the Linux legs (#4906); ldd-based discovery only.
-          # The hang is the tooling's: it kills the traced app with a
-          # process-group signal that dash (/bin/sh on Ubuntu) never sets up
-          # without a terminal, and the CLI captures its output, so a surviving
-          # CEF child holds the pipes open. tauri-apps/tauri#12491 fixes both
-          # (bash + streamed output); drop this pin when cli-cef carries it and
-          # dlopen discovery — which is what bundles mesa/GL — comes back.
+          # quick-sharun would otherwise run the app under Xvfb to find dlopen'ed
+          # libraries and hung CI (#4906). The CLI now runs it with bash and
+          # streamed output, which fixes that; lifting this is its own change.
           STRACE_MODE: '0'
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -585,12 +552,8 @@ jobs:
           releaseBody: ${{ needs.get-release.outputs.release_note }}
           args: ${{ matrix.config.args || '' }}
 
-      # quick-sharun skips anything it cannot find without failing, which is
-      # how a nightly AppImage shipped with no NSS modules at all. Fail the leg
-      # instead of publishing a bundle that crashes on first use. The path is
-      # the AppDir quick-sharun packed, left next to the AppImage in the
-      # WORKSPACE target dir. libsqlite3 is not staged explicitly — it must
-      # arrive as libsoftokn3.so's own ldd dependency.
+      # quick-sharun skips what it cannot find without failing; catch that
+      # before it ships.
       - name: verify the AppImage bundle contents (linux only)
         if: matrix.config.release == 'linux'
         run: |
@@ -600,16 +563,13 @@ jobs:
                     libpulse.so.0 libspeechd.so.2; do
             [ -e "$lib/$so" ] || { echo "::error::$so is missing from the AppImage bundle"; exit 1; }
           done
-          # libpulse keeps its private half in a subdir and finds it by RUNPATH,
-          # which points at the HOST dir; only sharun's own library path (built
-          # from lib.path) makes it load the bundled copy instead.
+          # libpulse finds its private half through a host RUNPATH; lib.path
+          # has to cover the bundled copy for it to win.
           ls "$lib"/pulseaudio/libpulsecommon-*.so > /dev/null 2>&1 \
             || { echo "::error::libpulsecommon is missing from the AppImage bundle"; exit 1; }
           grep -qx '+/pulseaudio' "$lib/lib.path" \
             || { echo "::error::lib.path does not cover lib/pulseaudio, so libpulse cannot load"; exit 1; }
-          # Ships through appimage.files, so it lands before quick-sharun adds
-          # the bundler's own hooks; without it every new AppImage asks for a
-          # root password on first launch.
+          # Without this hook every new AppImage asks for a root password.
           [ -e "${lib%/lib}/bin/00-no-userns-prompt.hook" ] \
             || { echo "::error::the no-userns-prompt hook is missing from the AppImage bundle"; exit 1; }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,9 +380,15 @@ jobs:
 
       # The CEF AppImage bundles the build host's glibc, so anything it does
       # NOT bundle is resolved from the host at run time, against a glibc the
-      # bundled one cannot satisfy on any distro newer than the builder. NSS is
-      # the fatal case: Chromium dlopens libsoftokn3.so, gets the host copy and
-      # aborts on first use (FATAL crypto/nss_util.cc, nss_error=-5925).
+      # bundled one cannot satisfy on any distro newer than the builder. Only
+      # libraries Chromium links against are bundled; the ones it dlopens by
+      # soname are not, and each one it misses fails that way:
+      #   libsoftokn3.so  NSS aborts the app on first use (FATAL
+      #                   crypto/nss_util.cc, nss_error=-5925)
+      #   libpulse.so.0   no audio output at all — the ALSA fallback then dies
+      #                   too, because its `default` PCM is a config hook that
+      #                   loads the host's libasound_module_conf_pulse.so
+      #   libspeechd.so.2 no system voices for the Web Speech TTS engine
       #
       # quick-sharun's own DEPLOY_CHROMIUM rules cover these modules, but the
       # bundler in cli-cef 3.0.0-alpha.26 downloads a fork of that script
@@ -393,10 +399,11 @@ jobs:
       # in the bundle. tauri-apps/tauri#12491 drops that fork for a pinned,
       # checksummed upstream revision (facb95e8, which has the `eval`). Once it
       # reaches feat/cef and a new cli-cef ships, bump CEF_CLI in
-      # apps/readest-app/scripts/tauri.mjs, lift the STRACE_MODE pin in the
-      # build step and drop the jq call below. Keep the flatten unless dlopen
-      # discovery is doing the finding: upstream globs only Arch's flat layout,
-      # so a Debian builder hides these modules from it either way.
+      # apps/readest-app/scripts/tauri.mjs and lift the STRACE_MODE pin in the
+      # build step — upstream's own rules then cover NSS and libpulse. Keep the
+      # nss/ flatten and the libspeechd entry either way: upstream globs only
+      # Arch's flat layout, so a Debian builder hides the NSS modules from it,
+      # and nothing in it deploys libspeechd at all.
       #
       # Until then, hand the modules over as appimage.files: the bundler passes
       # files targeted at /usr/lib to quick-sharun as plain ELF arguments, the
@@ -408,7 +415,7 @@ jobs:
         if: matrix.config.release == 'linux'
         run: |
           set -euo pipefail
-          sudo apt-get install -y libnss3
+          sudo apt-get install -y libnss3 libpulse0 libspeechd2
           nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
           lib_dir=${nss_dir%/nss}
           sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
@@ -416,7 +423,9 @@ jobs:
           jq --arg d "$lib_dir" '.bundle.linux.appimage.files = {
               "/usr/lib/libsoftokn3.so": ($d + "/libsoftokn3.so"),
               "/usr/lib/libfreeblpriv3.so": ($d + "/libfreeblpriv3.so"),
-              "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so")
+              "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so"),
+              "/usr/lib/libpulse.so.0": ($d + "/libpulse.so.0"),
+              "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2")
             }' "$conf" > "$conf.tmp" && mv "$conf.tmp" "$conf"
 
       - name: create .env.local file for Next.js
@@ -563,9 +572,17 @@ jobs:
         run: |
           set -euo pipefail
           lib=target/release/bundle/appimage/Readest.AppDir/lib
-          for so in libsoftokn3.so libfreeblpriv3.so libnssckbi.so libsqlite3.so.0; do
+          for so in libsoftokn3.so libfreeblpriv3.so libnssckbi.so libsqlite3.so.0 \
+                    libpulse.so.0 libspeechd.so.2; do
             [ -e "$lib/$so" ] || { echo "::error::$so is missing from the AppImage bundle"; exit 1; }
           done
+          # libpulse keeps its private half in a subdir and finds it by RUNPATH,
+          # which points at the HOST dir; only sharun's own library path (built
+          # from lib.path) makes it load the bundled copy instead.
+          ls "$lib"/pulseaudio/libpulsecommon-*.so > /dev/null 2>&1 \
+            || { echo "::error::libpulsecommon is missing from the AppImage bundle"; exit 1; }
+          grep -qx '+/pulseaudio' "$lib/lib.path" \
+            || { echo "::error::lib.path does not cover lib/pulseaudio, so libpulse cannot load"; exit 1; }
 
       # Attest the freshly built desktop bundles (installers, AppImage, dmg,
       # updater archives + their .sig). tauri-action reports their on-disk paths

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,20 +390,34 @@ jobs:
       #                   loads the host's libasound_module_conf_pulse.so
       #   libspeechd.so.2 no system voices for the Web Speech TTS engine
       #
-      # quick-sharun's own DEPLOY_CHROMIUM rules cover these modules, but the
-      # bundler in cli-cef 3.0.0-alpha.26 downloads a fork of that script
-      # (FabianLars/Anylinux-AppImages, taken on feat/cef to fix spaces in
-      # paths) which is ~1100 lines behind pkgforge upstream and expands its
-      # deployment array without `eval`: every path keeps its literal quotes,
-      # so EVERY DEPLOY_* extra is skipped and only ldd-derived libraries land
-      # in the bundle. tauri-apps/tauri#12491 drops that fork for a pinned,
-      # checksummed upstream revision (facb95e8, which has the `eval`). Once it
-      # reaches feat/cef and a new cli-cef ships, bump CEF_CLI in
-      # apps/readest-app/scripts/tauri.mjs and lift the STRACE_MODE pin in the
-      # build step — upstream's own rules then cover NSS and libpulse. Keep the
-      # nss/ flatten and the libspeechd entry either way: upstream globs only
-      # Arch's flat layout, so a Debian builder hides the NSS modules from it,
-      # and nothing in it deploys libspeechd at all.
+      # quick-sharun's own DEPLOY_CHROMIUM rules cover the NSS modules and, via
+      # DEPLOY_PIPEWIRE -> DEPLOY_PULSE, libpulse. None of it reaches the
+      # bundle: the bundler in cli-cef 3.0.0-alpha.26 downloads a fork of the
+      # script (FabianLars/Anylinux-AppImages, re-fetched from its main on
+      # every build) whose HEAD, 3e280d1b "fix handling of spaces in input
+      # paths", is the one-line change
+      #   eval set -- "$TO_DEPLOY_ARRAY" "$@"   ->   set -- $TO_DEPLOY_ARRAY "$@"
+      # Upstream's line does split positional paths on spaces, and tauri names
+      # the AppDir after the product, so the change fixed something real — but
+      # the array entries come single-quoted from _save_array, so without the
+      # eval each keeps its literal quotes, fails `[ -f ]`, and EVERY DEPLOY_*
+      # extra is silently skipped. Only ldd-derived libraries land. The fix
+      # that keeps both halves is to quote the positional args the same way:
+      #   eval set -- "$TO_DEPLOY_ARRAY" "$(_save_array "$@")"
+      # Once that (or any restored eval) is on the fork's main, the next build
+      # deploys NSS and libpulse by itself and those entries below turn
+      # redundant — harmlessly, the tooling keeps files it already has.
+      # tauri-apps/tauri#12491 sidesteps the fork altogether (pinned pkgforge
+      # revision, no whitespace in the AppDir path) and fixes the CI hang the
+      # STRACE_MODE pin in the build step works around; lift that pin and bump
+      # CEF_CLI in apps/readest-app/scripts/tauri.mjs when cli-cef carries it.
+      # Keep the nss/ flatten and the libspeechd entry either way: every
+      # quick-sharun globs only Arch's flat layout, so a Debian builder hides
+      # the NSS modules from it, and no rule deploys libspeechd at all.
+      # libpipewire is deliberately not staged — Chromium needs it for the
+      # screen-share portal, not for audio — and neither are ALSA plugins:
+      # with libpulse in the bundle Chromium talks to PulseAudio/PipeWire
+      # directly, and a pure-ALSA host resolves `default` with built-ins.
       #
       # Until then, hand the modules over as appimage.files: the bundler passes
       # files targeted at /usr/lib to quick-sharun as plain ELF arguments, the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,6 +360,31 @@ jobs:
         with:
           key: ${{ matrix.config.os }}-${{ matrix.config.release }}-${{ matrix.config.arch }}-cargo
 
+      # The published @tauri-apps/cli-cef (3.0.0-alpha.26, pinned in
+      # apps/readest-app/scripts/tauri.mjs) bundles the AppImage with a fork of
+      # quick-sharun whose deployment array is broken — see the staging step
+      # below — and re-downloads that fork on every build with no way to point
+      # it elsewhere. The Linux legs build the CLI from readest/tauri instead,
+      # where sharun_cef.rs fetches a pinned, checksummed pkgforge revision and
+      # runs the tooling with bash and streamed output (the fix behind the
+      # STRACE_MODE hang, tauri-apps/tauri#12491). Pinned to a rev, not the
+      # branch tip, so a release cannot change behaviour under us; rust-cache
+      # keeps ~/.cargo/bin, and the marker file skips the ~6 minute rebuild
+      # while the pin is unchanged. TAURI_CEF_CARGO=1 in the build step makes
+      # scripts/tauri.mjs run `cargo tauri` with the same command line.
+      - name: install the CEF tauri CLI from readest/tauri (linux only)
+        if: matrix.config.release == 'linux'
+        run: |
+          set -euo pipefail
+          rev=c62e9f90c1f5759a4e3795cc56b0b9a1273a5773
+          marker="$HOME/.cargo/bin/.cargo-tauri-rev"
+          if [ -x "$HOME/.cargo/bin/cargo-tauri" ] && [ "$(cat "$marker" 2>/dev/null)" = "$rev" ]; then
+            echo "cargo-tauri at $rev already installed"
+            exit 0
+          fi
+          cargo install tauri-cli --git https://github.com/readest/tauri --rev "$rev" --locked --force
+          echo "$rev" > "$marker"
+
       - name: install dependencies (ubuntu only)
         if: contains(matrix.config.os, 'ubuntu') && matrix.config.release != 'android' && matrix.config.arch != 'armhf'
         run: |
@@ -380,51 +405,36 @@ jobs:
 
       # The CEF AppImage bundles the build host's glibc, so anything it does
       # NOT bundle is resolved from the host at run time, against a glibc the
-      # bundled one cannot satisfy on any distro newer than the builder. Only
-      # libraries Chromium links against are bundled; the ones it dlopens by
-      # soname are not, and each one it misses fails that way:
-      #   libsoftokn3.so  NSS aborts the app on first use (FATAL
-      #                   crypto/nss_util.cc, nss_error=-5925)
-      #   libpulse.so.0   no audio output at all — the ALSA fallback then dies
-      #                   too, because its `default` PCM is a config hook that
-      #                   loads the host's libasound_module_conf_pulse.so
-      #   libspeechd.so.2 no system voices for the Web Speech TTS engine
+      # bundled one cannot satisfy on any distro newer than the builder. The
+      # libraries Chromium dlopens by soname are the ones at risk; when they
+      # were missing, NSS aborted the app on first use (FATAL
+      # crypto/nss_util.cc, nss_error=-5925) and there was no audio output.
       #
-      # quick-sharun's own DEPLOY_CHROMIUM rules cover the NSS modules and, via
-      # DEPLOY_PIPEWIRE -> DEPLOY_PULSE, libpulse. None of it reaches the
-      # bundle: the bundler in cli-cef 3.0.0-alpha.26 downloads a fork of the
-      # script (FabianLars/Anylinux-AppImages, re-fetched from its main on
-      # every build) whose HEAD, 3e280d1b "fix handling of spaces in input
-      # paths", is the one-line change
-      #   eval set -- "$TO_DEPLOY_ARRAY" "$@"   ->   set -- $TO_DEPLOY_ARRAY "$@"
-      # Upstream's line does split positional paths on spaces, and tauri names
-      # the AppDir after the product, so the change fixed something real — but
-      # the array entries come single-quoted from _save_array, so without the
+      # quick-sharun deploys them itself: DEPLOY_CHROMIUM (which the bundler
+      # sets) covers the NSS modules and, via DEPLOY_PIPEWIRE -> DEPLOY_PULSE,
+      # libpulse and the ALSA pulse plugins. Verified with the pinned pkgforge
+      # revision the CLI above uses. This step only fills the two gaps no rule
+      # covers, the way the script itself prescribes — pass the file to
+      # quick-sharun rather than copy it in — through appimage.files entries
+      # under /usr/lib, which the bundler hands over as plain arguments:
+      #   - Debian keeps the NSS PKCS#11 modules in <triple>/nss/, and the
+      #     globs only know Arch's flat layout; copy them up a level so
+      #     `"$LIB_DIR"/libsoftokn3.so*` and friends match on the runner.
+      #   - nothing deploys libspeechd.so.2, without which the Web Speech TTS
+      #     engine has no system voices.
+      #
+      # Why the npm cli-cef could not do this (local builds still use it): its
+      # bundler downloads a fork of the script (FabianLars/Anylinux-AppImages,
+      # re-fetched from main on every build) whose HEAD, 3e280d1b "fix handling
+      # of spaces in input paths", turned
+      #   eval set -- "$TO_DEPLOY_ARRAY" "$@"   into   set -- $TO_DEPLOY_ARRAY "$@"
+      # The array entries come single-quoted from _save_array, so without the
       # eval each keeps its literal quotes, fails `[ -f ]`, and EVERY DEPLOY_*
-      # extra is silently skipped. Only ldd-derived libraries land. The fix
-      # that keeps both halves is to quote the positional args the same way:
-      #   eval set -- "$TO_DEPLOY_ARRAY" "$(_save_array "$@")"
-      # Once that (or any restored eval) is on the fork's main, the next build
-      # deploys NSS and libpulse by itself and those entries below turn
-      # redundant — harmlessly, the tooling keeps files it already has.
-      # tauri-apps/tauri#12491 sidesteps the fork altogether (pinned pkgforge
-      # revision, no whitespace in the AppDir path) and fixes the CI hang the
-      # STRACE_MODE pin in the build step works around; lift that pin and bump
-      # CEF_CLI in apps/readest-app/scripts/tauri.mjs when cli-cef carries it.
-      # Keep the nss/ flatten and the libspeechd entry either way: every
-      # quick-sharun globs only Arch's flat layout, so a Debian builder hides
-      # the NSS modules from it, and no rule deploys libspeechd at all.
-      # libpipewire is deliberately not staged — Chromium needs it for the
-      # screen-share portal, not for audio — and neither are ALSA plugins:
-      # with libpulse in the bundle Chromium talks to PulseAudio/PipeWire
-      # directly, and a pure-ALSA host resolves `default` with built-ins.
-      #
-      # Until then, hand the modules over as appimage.files: the bundler passes
-      # files targeted at /usr/lib to quick-sharun as plain ELF arguments, the
-      # injection channel #12491 keeps. Sources must sit directly in the triple
-      # lib dir (Debian hides them in <triple>/nss/) because the destination
-      # inside the bundle mirrors the source dir, and only a flat source lands
-      # next to the libnss3.so that loads it.
+      # extra is silently skipped — only ldd-derived libraries land. (Upstream's
+      # line does split positional paths on spaces; quoting them through the
+      # same helper keeps both.) tauri-apps/tauri#12491 takes the same route as
+      # the CLI above and also fixes the CI hang behind the STRACE_MODE pin in
+      # the build step; lift that pin when a cli-cef carries it.
       - name: stage CEF AppImage runtime libraries (linux only)
         if: matrix.config.release == 'linux'
         run: |
@@ -438,10 +448,6 @@ jobs:
           # from prompting for a root password (src-tauri/appimage/).
           conf=apps/readest-app/src-tauri/tauri.conf.json
           jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
-              "/usr/lib/libsoftokn3.so": ($d + "/libsoftokn3.so"),
-              "/usr/lib/libfreeblpriv3.so": ($d + "/libfreeblpriv3.so"),
-              "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so"),
-              "/usr/lib/libpulse.so.0": ($d + "/libpulse.so.0"),
               "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2")
             }' "$conf" > "$conf.tmp" && mv "$conf.tmp" "$conf"
 
@@ -548,6 +554,7 @@ jobs:
         if: matrix.config.release != 'android'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_CEF_CARGO: '1'
           # The CEF AppImage bundler (quick-sharun) otherwise launches the app
           # under Xvfb to discover dlopen'ed libraries and never gets it to
           # exit, hanging the Linux legs (#4906); ldd-based discovery only.

--- a/apps/readest-app/scripts/tauri.mjs
+++ b/apps/readest-app/scripts/tauri.mjs
@@ -35,6 +35,11 @@ const CEF_CLI = '@tauri-apps/cli-cef@3.0.0-alpha.26';
 // Offline builds (Flatpak) cannot `pnpm dlx`; they point this at an unpacked
 // copy of the CLI package's `tauri.js` instead.
 const localCefCli = process.env['TAURI_CEF_CLI'];
+// CI builds the CLI from readest/tauri instead (`cargo install tauri-cli`),
+// because the published cli-cef's AppImage bundler fetches a broken fork of
+// quick-sharun; see the "install the CEF tauri CLI" step in the workflows.
+// The cargo-installed `cargo tauri` takes the same command line as the npm CLI.
+const cargoCefCli = process.env['TAURI_CEF_CARGO'] === '1';
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = path.resolve(appDir, '../..');
 const cargoConfig = path.join(appDir, 'src-tauri/.cargo/cef.toml');
@@ -105,7 +110,9 @@ if (!useCef) {
     process.on(signal, () => {});
   }
 
-  if (localCefCli) {
+  if (cargoCefCli) {
+    run('cargo', ['tauri', ...args], restoreLock);
+  } else if (localCefCli) {
     run('node', [localCefCli, ...args], restoreLock);
   } else {
     run('pnpm', ['dlx', CEF_CLI, ...args], restoreLock);

--- a/apps/readest-app/scripts/tauri.mjs
+++ b/apps/readest-app/scripts/tauri.mjs
@@ -35,10 +35,8 @@ const CEF_CLI = '@tauri-apps/cli-cef@3.0.0-alpha.26';
 // Offline builds (Flatpak) cannot `pnpm dlx`; they point this at an unpacked
 // copy of the CLI package's `tauri.js` instead.
 const localCefCli = process.env['TAURI_CEF_CLI'];
-// CI builds the CLI from readest/tauri instead (`cargo install tauri-cli`),
-// because the published cli-cef's AppImage bundler fetches a broken fork of
-// quick-sharun; see the "install the CEF tauri CLI" step in the workflows.
-// The cargo-installed `cargo tauri` takes the same command line as the npm CLI.
+// CI builds the CLI from readest/tauri instead (same command line); see the
+// "install the CEF tauri CLI" step in the workflows for why.
 const cargoCefCli = process.env['TAURI_CEF_CARGO'] === '1';
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = path.resolve(appDir, '../..');

--- a/apps/readest-app/src-tauri/appimage/00-no-userns-prompt.hook
+++ b/apps/readest-app/src-tauri/appimage/00-no-userns-prompt.hook
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Sourced by the AppImage's AppRun before the bundler's own hooks — AppRun runs
+# `for hook in $APPDIR/bin/*.hook`, so the 00- prefix is what puts this first.
+#
+# Readest's CEF runtime is built without tauri-runtime-cef's `sandbox` feature,
+# so CefSettings.no_sandbox is set and every Chromium child process runs with
+# --no-sandbox: the app never asks the kernel for an unprivileged user
+# namespace. The AppImage bundler's fix-namespaces.hook cannot know that. On
+# distros that restrict unprivileged userns (Ubuntu 24.04+ and friends) it
+# blocks startup with a dialog and offers to install an AppArmor profile
+# through pkexec — a root password prompt for a capability this build does not
+# use, and one that comes back with every new AppImage, because the profile it
+# writes is keyed to the file's exact path.
+#
+# Stubbing the two helpers it prompts through (both live in AppRun.lib, and
+# nothing else in the bundle calls them) leaves the rest of that hook harmless:
+# its checks still run, they just cannot reach the user.
+#
+# If Readest ever enables the CEF sandbox on Linux, delete this file and the
+# appimage.files entry that ships it: the namespace requirement becomes real,
+# and deb/rpm should then ship /etc/apparmor.d/readest the way Chrome does.
+notify() { return 1; }
+run_gui_sudo() { return 1; }

--- a/apps/readest-app/src-tauri/appimage/00-no-userns-prompt.hook
+++ b/apps/readest-app/src-tauri/appimage/00-no-userns-prompt.hook
@@ -1,23 +1,9 @@
 #!/bin/sh
-# Sourced by the AppImage's AppRun before the bundler's own hooks — AppRun runs
-# `for hook in $APPDIR/bin/*.hook`, so the 00- prefix is what puts this first.
-#
-# Readest's CEF runtime is built without tauri-runtime-cef's `sandbox` feature,
-# so CefSettings.no_sandbox is set and every Chromium child process runs with
-# --no-sandbox: the app never asks the kernel for an unprivileged user
-# namespace. The AppImage bundler's fix-namespaces.hook cannot know that. On
-# distros that restrict unprivileged userns (Ubuntu 24.04+ and friends) it
-# blocks startup with a dialog and offers to install an AppArmor profile
-# through pkexec — a root password prompt for a capability this build does not
-# use, and one that comes back with every new AppImage, because the profile it
-# writes is keyed to the file's exact path.
-#
-# Stubbing the two helpers it prompts through (both live in AppRun.lib, and
-# nothing else in the bundle calls them) leaves the rest of that hook harmless:
-# its checks still run, they just cannot reach the user.
-#
-# If Readest ever enables the CEF sandbox on Linux, delete this file and the
-# appimage.files entry that ships it: the namespace requirement becomes real,
-# and deb/rpm should then ship /etc/apparmor.d/readest the way Chrome does.
+# Sourced by AppRun before the bundler's own hooks (glob order). Its
+# fix-namespaces hook asks for a root password to enable unprivileged user
+# namespaces, which this build never needs: CEF runs without the sandbox
+# feature, every child with --no-sandbox. Stub the two helpers it prompts
+# through; nothing else calls them. Delete this if the CEF sandbox is ever
+# enabled on Linux.
 notify() { return 1; }
 run_gui_sudo() { return 1; }

--- a/apps/readest-app/src-tauri/tauri.conf.json
+++ b/apps/readest-app/src-tauri/tauri.conf.json
@@ -71,6 +71,11 @@
       },
       "rpm": {
         "depends": ["libwebkit2gtk-4.1.so.0()(64bit)"]
+      },
+      "appimage": {
+        "files": {
+          "bin/00-no-userns-prompt.hook": "appimage/00-no-userns-prompt.hook"
+        }
       }
     },
     "android": {


### PR DESCRIPTION
TTS played through with working highlighting but nothing was audible; every new AppImage also asked for a root password on first launch. This branch fixes both by doing what @Samueru-sama and @FabianLars pointed at in the thread: let quick-sharun deploy Chromium's dependencies itself, and take the pinned-pkgforge route of tauri-apps/tauri#12491 instead of the fork.

## Root cause

Chromium dlopens `libpulse.so.0`, `libspeechd.so.2` and the NSS modules by soname; only libraries CEF *links* against were in the bundle. Whatever is missing is resolved from the host at run time and fails against the bundled glibc 2.35 on any newer distro — no audio path at all (the ALSA fallback dies through the same host plugin), and NSS aborts the app on first use.

quick-sharun's `DEPLOY_CHROMIUM` rule already covers NSS and, via `DEPLOY_PIPEWIRE` → `DEPLOY_PULSE`, pulse. None of it reached the bundle because `@tauri-apps/cli-cef@3.0.0-alpha.26` fetches [FabianLars' fork](https://github.com/tauri-apps/tauri/blob/feat/cef/crates/tauri-bundler/src/bundle/linux/appimage/sharun_cef.rs#L68) of the script, whose HEAD [3e280d1b](https://github.com/FabianLars/Anylinux-AppImages/commit/3e280d1b2270fecfcb2c2c823b490c782ecf1277) drops the `eval` that rebuilds the deployment array: every entry keeps the quotes `_save_array` puts on it, fails `[ -f ]`, and every `DEPLOY_*` extra is silently skipped. The fix that keeps both halves is `eval set -- "$TO_DEPLOY_ARRAY" "$(_save_array "$@")"`. The CLI re-downloads the fork on every build with no way to point it elsewhere.

## Changes

- **Build the CEF tauri CLI from readest/tauri on the Linux legs** (readest/tauri@c62e9f90, the model the workflow used until #6074): `sharun_cef.rs` fetches pkgforge at `facb95e8` verified against #12491's SHA-256, runs the tooling with bash and streamed output (the two halves of the #4906 hang), passes the deploy list as arguments, keeps whitespace out of the AppDir name, and adds no `fix-namespaces` hook. Rev-pinned; a marker skips the rebuild while rust-cache keeps `~/.cargo/bin`. `scripts/tauri.mjs` runs `cargo tauri` when `TAURI_CEF_CARGO=1`.
- **Staging reduced to the two gaps no rule covers**, passed to quick-sharun as arguments via `appimage.files`: Debian keeps the NSS modules in `<triple>/nss/` where the Arch-layout globs miss them, and nothing deploys `libspeechd`.
- **No root-password prompt** (#6110, merged here): a `00-` AppRun hook stubs the two helpers the bundler's hook prompts through; CEF runs without the sandbox feature, so the namespaces it asked for were never used.
- Post-build guard checks the full set lands, including `lib.path` covering `lib/pulseaudio`.

## Verification

Built locally with the patched CLI. quick-sharun deployed, with no staging involved: `libpulse`, `libpipewire`, `alsa-lib/libasound_module_*_pulse.so`, the NSS modules, mesa/dri, gconv, gio and GTK IM modules — 397 libraries, hooks `00-no-userns-prompt`, `01-path-mapping-hardcoded`, `05-vulkan-check`. The AppImage ran headless for the full window with no `FATAL`/`GLIBC_`/`nss_error`/`zenity`/`pkexec` output and the GPU process stayed up; under its own loader and `lib.path`, `libpulse`, `libpulsecommon`, `libsoftokn3` and `libGL` resolve from `<bundle>/lib`. Before the change, the same probes on the shipped `2026090706` bundle failed with `GLIBC_2.38 not found` and a 440 Hz tone through a staged libpulse was the only way to reach PipeWire.

PR CI cannot exercise this (it needs a full CEF build); the first nightly after merge is the CI validation. `STRACE_MODE` stays off — re-enabling dlopen discovery is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux AppImage audio support by bundling required PulseAudio libraries.
  * Improved Web Speech text-to-speech support by bundling the required Speech Dispatcher library.
  * Prevented unnecessary user-namespace setup prompts when launching the Linux AppImage.
  * Expanded build verification to confirm required audio libraries, runtime components, and startup files are packaged correctly in nightly and release builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux AppImage audio support by ensuring required PulseAudio libraries are packaged.
  * Improved Web Speech text-to-speech support by including the required Speech Dispatcher library.
  * Prevented unnecessary user-namespace setup prompts when launching the Linux AppImage.
  * Improved reliability of Linux AppImage builds and verification for required runtime libraries and startup components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->