### PR TITLE
fix(linux): stop the AppImage asking for a root password

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -179,8 +179,11 @@ jobs:
           nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
           lib_dir=${nss_dir%/nss}
           sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
+          # Merge, don't assign: tauri.conf.json already ships an appimage.files
+          # entry for the AppRun hook that keeps the bundler's namespace hook
+          # from prompting for a root password (src-tauri/appimage/).
           conf=apps/readest-app/src-tauri/tauri.conf.json
-          jq --arg d "$lib_dir" '.bundle.linux.appimage.files = {
+          jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
               "/usr/lib/libsoftokn3.so": ($d + "/libsoftokn3.so"),
               "/usr/lib/libfreeblpriv3.so": ($d + "/libfreeblpriv3.so"),
               "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so"),
@@ -306,7 +309,7 @@ jobs:
       # AppDir quick-sharun packed, left next to the AppImage in the WORKSPACE
       # target dir (see the collect step below). libsqlite3 is not staged
       # explicitly — it must arrive as libsoftokn3.so's own ldd dependency.
-      - name: verify the AppImage bundled its NSS modules (linux only)
+      - name: verify the AppImage bundle contents (linux only)
         if: matrix.config.release == 'linux'
         run: |
           set -euo pipefail
@@ -322,6 +325,11 @@ jobs:
             || { echo "::error::libpulsecommon is missing from the AppImage bundle"; exit 1; }
           grep -qx '+/pulseaudio' "$lib/lib.path" \
             || { echo "::error::lib.path does not cover lib/pulseaudio, so libpulse cannot load"; exit 1; }
+          # Ships through appimage.files, so it lands before quick-sharun adds
+          # the bundler's own hooks; without it every new AppImage asks for a
+          # root password on first launch.
+          [ -e "${lib%/lib}/bin/00-no-userns-prompt.hook" ] \
+            || { echo "::error::the no-userns-prompt hook is missing from the AppImage bundle"; exit 1; }
 
       # Portable Windows build: rebuild with NEXT_PUBLIC_PORTABLE_APP=true and
       # ship the raw exe (mirrors release.yml). Runs after the NSIS build above.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -419,8 +419,11 @@ jobs:
           nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
           lib_dir=${nss_dir%/nss}
           sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
+          # Merge, don't assign: tauri.conf.json already ships an appimage.files
+          # entry for the AppRun hook that keeps the bundler's namespace hook
+          # from prompting for a root password (src-tauri/appimage/).
           conf=apps/readest-app/src-tauri/tauri.conf.json
-          jq --arg d "$lib_dir" '.bundle.linux.appimage.files = {
+          jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
               "/usr/lib/libsoftokn3.so": ($d + "/libsoftokn3.so"),
               "/usr/lib/libfreeblpriv3.so": ($d + "/libfreeblpriv3.so"),
               "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so"),
@@ -567,7 +570,7 @@ jobs:
       # the AppDir quick-sharun packed, left next to the AppImage in the
       # WORKSPACE target dir. libsqlite3 is not staged explicitly — it must
       # arrive as libsoftokn3.so's own ldd dependency.
-      - name: verify the AppImage bundled its NSS modules (linux only)
+      - name: verify the AppImage bundle contents (linux only)
         if: matrix.config.release == 'linux'
         run: |
           set -euo pipefail
@@ -583,6 +586,11 @@ jobs:
             || { echo "::error::libpulsecommon is missing from the AppImage bundle"; exit 1; }
           grep -qx '+/pulseaudio' "$lib/lib.path" \
             || { echo "::error::lib.path does not cover lib/pulseaudio, so libpulse cannot load"; exit 1; }
+          # Ships through appimage.files, so it lands before quick-sharun adds
+          # the bundler's own hooks; without it every new AppImage asks for a
+          # root password on first launch.
+          [ -e "${lib%/lib}/bin/00-no-userns-prompt.hook" ] \
+            || { echo "::error::the no-userns-prompt hook is missing from the AppImage bundle"; exit 1; }
 
       # Attest the freshly built desktop bundles (installers, AppImage, dmg,
       # updater archives + their .sig). tauri-action reports their on-disk paths

--- a/apps/readest-app/src-tauri/appimage/00-no-userns-prompt.hook
+++ b/apps/readest-app/src-tauri/appimage/00-no-userns-prompt.hook
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Sourced by the AppImage's AppRun before the bundler's own hooks — AppRun runs
+# `for hook in $APPDIR/bin/*.hook`, so the 00- prefix is what puts this first.
+#
+# Readest's CEF runtime is built without tauri-runtime-cef's `sandbox` feature,
+# so CefSettings.no_sandbox is set and every Chromium child process runs with
+# --no-sandbox: the app never asks the kernel for an unprivileged user
+# namespace. The AppImage bundler's fix-namespaces.hook cannot know that. On
+# distros that restrict unprivileged userns (Ubuntu 24.04+ and friends) it
+# blocks startup with a dialog and offers to install an AppArmor profile
+# through pkexec — a root password prompt for a capability this build does not
+# use, and one that comes back with every new AppImage, because the profile it
+# writes is keyed to the file's exact path.
+#
+# Stubbing the two helpers it prompts through (both live in AppRun.lib, and
+# nothing else in the bundle calls them) leaves the rest of that hook harmless:
+# its checks still run, they just cannot reach the user.
+#
+# If Readest ever enables the CEF sandbox on Linux, delete this file and the
+# appimage.files entry that ships it: the namespace requirement becomes real,
+# and deb/rpm should then ship /etc/apparmor.d/readest the way Chrome does.
+notify() { return 1; }
+run_gui_sudo() { return 1; }

--- a/apps/readest-app/src-tauri/tauri.conf.json
+++ b/apps/readest-app/src-tauri/tauri.conf.json
@@ -71,6 +71,11 @@
       },
       "rpm": {
         "depends": ["libwebkit2gtk-4.1.so.0()(64bit)"]
+      },
+      "appimage": {
+        "files": {
+          "bin/00-no-userns-prompt.hook": "appimage/00-no-userns-prompt.hook"
+        }
       }
     },
     "android": {


### PR DESCRIPTION
Stacked on #6108 (same `appimage.files` map, so it would conflict otherwise). Retarget to `main` once that merges.

## The prompt

Every new AppImage blocks on a modal at first launch and then asks for the root password through `pkexec`. That is the bundler's `fix-namespaces.hook`: distros like Ubuntu 24.04+ set `kernel.apparmor_restrict_unprivileged_userns=1`, the hook sees `unshare -Urm` fail, and offers to install an AppArmor profile granting `userns`. The profile it writes is keyed to the AppImage's *exact path*:

```
profile readest-appimage /home/user/Desktop/Readest_0.12.6-2026090706_amd64.AppImage flags=(unconfined) {
```

so every nightly is a new file and asks again.

## Why it is pointless here

Readest doesn't use the Chromium sandbox. `tauri-runtime-cef` sets `CefSettings.no_sandbox = !cfg!(feature = "sandbox")`, and this build compiles it without that feature. Every child process of the shipped `0.12.6-2026090706` AppImage:

```
pid 1567277: --type=zygote  --no-sandbox
pid 1567301: --type=utility --no-sandbox
```

and the app starts and runs normally on a machine where `unshare -Urm /bin/true` is denied and no profile is installed. The hook is boilerplate for Chromium apps that *do* sandbox; for this one it buys a root prompt and nothing else.

## Fix

An AppRun hook that sorts ahead of it (`AppRun` does `for hook in $APPDIR/bin/*.hook`) and stubs the two helpers it prompts through. Both come from `AppRun.lib` and nothing else in the bundle calls them, so the rest of `fix-namespaces.hook` still runs — its checks just can't reach the user.

It ships through `appimage.files` from `tauri.conf.json` rather than the workflows, so local Linux builds get it too; the CI staging step now merges into that map (`+=`) instead of replacing it, and the guard fails the build if the hook does not reach the packed AppDir.

## Verification

Against the extracted `0.12.6-2026090706` bundle, headless, on a host where unprivileged userns is denied:

| | result |
|---|---|
| stock hooks | blocks on the dialog — 3 lines of log, app never starts |
| with this hook | app starts normally, 117 lines, no `zenity`, no `pkexec` |

Also verified in an `ubuntu:22.04` container that a file placed through `appimage.files` survives quick-sharun and lands in `bin/` ahead of the bundler's own hooks:

```
### bin/ after bundling:
00-no-userns-prompt.hook
01-path-mapping-hardcoded.hook
fix-namespaces.hook
vulkan-check.hook
```

## Scope

This leaves the AppImage exactly as sandboxed as it is today — which is also what the WebKitGTK builds before it were, since Tauri never enabled WebKit's bubblewrap sandbox. Actually sandboxing the renderer on Linux is a separate piece of work: it needs the CEF `sandbox` feature, plus `/etc/apparmor.d/readest` shipped in the deb/rpm the way Chrome's package does, and this hook would then have to go — the hook file says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)