### PR TITLE
ci(linux): build the CEF tauri CLI from readest/tauri with pkgforge pinned

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -132,6 +132,31 @@ jobs:
         with:
           key: nightly-${{ matrix.config.os }}-${{ matrix.config.release }}-${{ matrix.config.arch }}-cargo
 
+      # The published @tauri-apps/cli-cef (3.0.0-alpha.26, pinned in
+      # apps/readest-app/scripts/tauri.mjs) bundles the AppImage with a fork of
+      # quick-sharun whose deployment array is broken — see the staging step
+      # below — and re-downloads that fork on every build with no way to point
+      # it elsewhere. The Linux legs build the CLI from readest/tauri instead,
+      # where sharun_cef.rs fetches a pinned, checksummed pkgforge revision and
+      # runs the tooling with bash and streamed output (the fix behind the
+      # STRACE_MODE hang, tauri-apps/tauri#12491). Pinned to a rev, not the
+      # branch tip, so a release cannot change behaviour under us; rust-cache
+      # keeps ~/.cargo/bin, and the marker file skips the ~6 minute rebuild
+      # while the pin is unchanged. TAURI_CEF_CARGO=1 in the build step makes
+      # scripts/tauri.mjs run `cargo tauri` with the same command line.
+      - name: install the CEF tauri CLI from readest/tauri (linux only)
+        if: matrix.config.release == 'linux'
+        run: |
+          set -euo pipefail
+          rev=c62e9f90c1f5759a4e3795cc56b0b9a1273a5773
+          marker="$HOME/.cargo/bin/.cargo-tauri-rev"
+          if [ -x "$HOME/.cargo/bin/cargo-tauri" ] && [ "$(cat "$marker" 2>/dev/null)" = "$rev" ]; then
+            echo "cargo-tauri at $rev already installed"
+            exit 0
+          fi
+          cargo install tauri-cli --git https://github.com/readest/tauri --rev "$rev" --locked --force
+          echo "$rev" > "$marker"
+
       - name: install dependencies (ubuntu only)
         if: contains(matrix.config.os, 'ubuntu') && matrix.config.release != 'android'
         run: |
@@ -140,51 +165,36 @@ jobs:
 
       # The CEF AppImage bundles the build host's glibc, so anything it does
       # NOT bundle is resolved from the host at run time, against a glibc the
-      # bundled one cannot satisfy on any distro newer than the builder. Only
-      # libraries Chromium links against are bundled; the ones it dlopens by
-      # soname are not, and each one it misses fails that way:
-      #   libsoftokn3.so  NSS aborts the app on first use (FATAL
-      #                   crypto/nss_util.cc, nss_error=-5925)
-      #   libpulse.so.0   no audio output at all — the ALSA fallback then dies
-      #                   too, because its `default` PCM is a config hook that
-      #                   loads the host's libasound_module_conf_pulse.so
-      #   libspeechd.so.2 no system voices for the Web Speech TTS engine
+      # bundled one cannot satisfy on any distro newer than the builder. The
+      # libraries Chromium dlopens by soname are the ones at risk; when they
+      # were missing, NSS aborted the app on first use (FATAL
+      # crypto/nss_util.cc, nss_error=-5925) and there was no audio output.
       #
-      # quick-sharun's own DEPLOY_CHROMIUM rules cover the NSS modules and, via
-      # DEPLOY_PIPEWIRE -> DEPLOY_PULSE, libpulse. None of it reaches the
-      # bundle: the bundler in cli-cef 3.0.0-alpha.26 downloads a fork of the
-      # script (FabianLars/Anylinux-AppImages, re-fetched from its main on
-      # every build) whose HEAD, 3e280d1b "fix handling of spaces in input
-      # paths", is the one-line change
-      #   eval set -- "$TO_DEPLOY_ARRAY" "$@"   ->   set -- $TO_DEPLOY_ARRAY "$@"
-      # Upstream's line does split positional paths on spaces, and tauri names
-      # the AppDir after the product, so the change fixed something real — but
-      # the array entries come single-quoted from _save_array, so without the
+      # quick-sharun deploys them itself: DEPLOY_CHROMIUM (which the bundler
+      # sets) covers the NSS modules and, via DEPLOY_PIPEWIRE -> DEPLOY_PULSE,
+      # libpulse and the ALSA pulse plugins. Verified with the pinned pkgforge
+      # revision the CLI above uses. This step only fills the two gaps no rule
+      # covers, the way the script itself prescribes — pass the file to
+      # quick-sharun rather than copy it in — through appimage.files entries
+      # under /usr/lib, which the bundler hands over as plain arguments:
+      #   - Debian keeps the NSS PKCS#11 modules in <triple>/nss/, and the
+      #     globs only know Arch's flat layout; copy them up a level so
+      #     `"$LIB_DIR"/libsoftokn3.so*` and friends match on the runner.
+      #   - nothing deploys libspeechd.so.2, without which the Web Speech TTS
+      #     engine has no system voices.
+      #
+      # Why the npm cli-cef could not do this (local builds still use it): its
+      # bundler downloads a fork of the script (FabianLars/Anylinux-AppImages,
+      # re-fetched from main on every build) whose HEAD, 3e280d1b "fix handling
+      # of spaces in input paths", turned
+      #   eval set -- "$TO_DEPLOY_ARRAY" "$@"   into   set -- $TO_DEPLOY_ARRAY "$@"
+      # The array entries come single-quoted from _save_array, so without the
       # eval each keeps its literal quotes, fails `[ -f ]`, and EVERY DEPLOY_*
-      # extra is silently skipped. Only ldd-derived libraries land. The fix
-      # that keeps both halves is to quote the positional args the same way:
-      #   eval set -- "$TO_DEPLOY_ARRAY" "$(_save_array "$@")"
-      # Once that (or any restored eval) is on the fork's main, the next build
-      # deploys NSS and libpulse by itself and those entries below turn
-      # redundant — harmlessly, the tooling keeps files it already has.
-      # tauri-apps/tauri#12491 sidesteps the fork altogether (pinned pkgforge
-      # revision, no whitespace in the AppDir path) and fixes the CI hang the
-      # STRACE_MODE pin in the build step works around; lift that pin and bump
-      # CEF_CLI in apps/readest-app/scripts/tauri.mjs when cli-cef carries it.
-      # Keep the nss/ flatten and the libspeechd entry either way: every
-      # quick-sharun globs only Arch's flat layout, so a Debian builder hides
-      # the NSS modules from it, and no rule deploys libspeechd at all.
-      # libpipewire is deliberately not staged — Chromium needs it for the
-      # screen-share portal, not for audio — and neither are ALSA plugins:
-      # with libpulse in the bundle Chromium talks to PulseAudio/PipeWire
-      # directly, and a pure-ALSA host resolves `default` with built-ins.
-      #
-      # Until then, hand the modules over as appimage.files: the bundler passes
-      # files targeted at /usr/lib to quick-sharun as plain ELF arguments, the
-      # injection channel #12491 keeps. Sources must sit directly in the triple
-      # lib dir (Debian hides them in <triple>/nss/) because the destination
-      # inside the bundle mirrors the source dir, and only a flat source lands
-      # next to the libnss3.so that loads it.
+      # extra is silently skipped — only ldd-derived libraries land. (Upstream's
+      # line does split positional paths on spaces; quoting them through the
+      # same helper keeps both.) tauri-apps/tauri#12491 takes the same route as
+      # the CLI above and also fixes the CI hang behind the STRACE_MODE pin in
+      # the build step; lift that pin when a cli-cef carries it.
       - name: stage CEF AppImage runtime libraries (linux only)
         if: matrix.config.release == 'linux'
         run: |
@@ -198,10 +208,6 @@ jobs:
           # from prompting for a root password (src-tauri/appimage/).
           conf=apps/readest-app/src-tauri/tauri.conf.json
           jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
-              "/usr/lib/libsoftokn3.so": ($d + "/libsoftokn3.so"),
-              "/usr/lib/libfreeblpriv3.so": ($d + "/libfreeblpriv3.so"),
-              "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so"),
-              "/usr/lib/libpulse.so.0": ($d + "/libpulse.so.0"),
               "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2")
             }' "$conf" > "$conf.tmp" && mv "$conf.tmp" "$conf"
 
@@ -298,6 +304,7 @@ jobs:
         # latest.json for ALL platforms (#4906).
         timeout-minutes: 45
         env:
+          TAURI_CEF_CARGO: '1'
           # See release.yml: keep quick-sharun from running the app under
           # Xvfb. Lift this together with the AppImage library staging above,
           # once cli-cef carries tauri-apps/tauri#12491.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,6 +360,31 @@ jobs:
         with:
           key: ${{ matrix.config.os }}-${{ matrix.config.release }}-${{ matrix.config.arch }}-cargo
 
+      # The published @tauri-apps/cli-cef (3.0.0-alpha.26, pinned in
+      # apps/readest-app/scripts/tauri.mjs) bundles the AppImage with a fork of
+      # quick-sharun whose deployment array is broken — see the staging step
+      # below — and re-downloads that fork on every build with no way to point
+      # it elsewhere. The Linux legs build the CLI from readest/tauri instead,
+      # where sharun_cef.rs fetches a pinned, checksummed pkgforge revision and
+      # runs the tooling with bash and streamed output (the fix behind the
+      # STRACE_MODE hang, tauri-apps/tauri#12491). Pinned to a rev, not the
+      # branch tip, so a release cannot change behaviour under us; rust-cache
+      # keeps ~/.cargo/bin, and the marker file skips the ~6 minute rebuild
+      # while the pin is unchanged. TAURI_CEF_CARGO=1 in the build step makes
+      # scripts/tauri.mjs run `cargo tauri` with the same command line.
+      - name: install the CEF tauri CLI from readest/tauri (linux only)
+        if: matrix.config.release == 'linux'
+        run: |
+          set -euo pipefail
+          rev=c62e9f90c1f5759a4e3795cc56b0b9a1273a5773
+          marker="$HOME/.cargo/bin/.cargo-tauri-rev"
+          if [ -x "$HOME/.cargo/bin/cargo-tauri" ] && [ "$(cat "$marker" 2>/dev/null)" = "$rev" ]; then
+            echo "cargo-tauri at $rev already installed"
+            exit 0
+          fi
+          cargo install tauri-cli --git https://github.com/readest/tauri --rev "$rev" --locked --force
+          echo "$rev" > "$marker"
+
       - name: install dependencies (ubuntu only)
         if: contains(matrix.config.os, 'ubuntu') && matrix.config.release != 'android' && matrix.config.arch != 'armhf'
         run: |
@@ -380,51 +405,36 @@ jobs:
 
       # The CEF AppImage bundles the build host's glibc, so anything it does
       # NOT bundle is resolved from the host at run time, against a glibc the
-      # bundled one cannot satisfy on any distro newer than the builder. Only
-      # libraries Chromium links against are bundled; the ones it dlopens by
-      # soname are not, and each one it misses fails that way:
-      #   libsoftokn3.so  NSS aborts the app on first use (FATAL
-      #                   crypto/nss_util.cc, nss_error=-5925)
-      #   libpulse.so.0   no audio output at all — the ALSA fallback then dies
-      #                   too, because its `default` PCM is a config hook that
-      #                   loads the host's libasound_module_conf_pulse.so
-      #   libspeechd.so.2 no system voices for the Web Speech TTS engine
+      # bundled one cannot satisfy on any distro newer than the builder. The
+      # libraries Chromium dlopens by soname are the ones at risk; when they
+      # were missing, NSS aborted the app on first use (FATAL
+      # crypto/nss_util.cc, nss_error=-5925) and there was no audio output.
       #
-      # quick-sharun's own DEPLOY_CHROMIUM rules cover the NSS modules and, via
-      # DEPLOY_PIPEWIRE -> DEPLOY_PULSE, libpulse. None of it reaches the
-      # bundle: the bundler in cli-cef 3.0.0-alpha.26 downloads a fork of the
-      # script (FabianLars/Anylinux-AppImages, re-fetched from its main on
-      # every build) whose HEAD, 3e280d1b "fix handling of spaces in input
-      # paths", is the one-line change
-      #   eval set -- "$TO_DEPLOY_ARRAY" "$@"   ->   set -- $TO_DEPLOY_ARRAY "$@"
-      # Upstream's line does split positional paths on spaces, and tauri names
-      # the AppDir after the product, so the change fixed something real — but
-      # the array entries come single-quoted from _save_array, so without the
+      # quick-sharun deploys them itself: DEPLOY_CHROMIUM (which the bundler
+      # sets) covers the NSS modules and, via DEPLOY_PIPEWIRE -> DEPLOY_PULSE,
+      # libpulse and the ALSA pulse plugins. Verified with the pinned pkgforge
+      # revision the CLI above uses. This step only fills the two gaps no rule
+      # covers, the way the script itself prescribes — pass the file to
+      # quick-sharun rather than copy it in — through appimage.files entries
+      # under /usr/lib, which the bundler hands over as plain arguments:
+      #   - Debian keeps the NSS PKCS#11 modules in <triple>/nss/, and the
+      #     globs only know Arch's flat layout; copy them up a level so
+      #     `"$LIB_DIR"/libsoftokn3.so*` and friends match on the runner.
+      #   - nothing deploys libspeechd.so.2, without which the Web Speech TTS
+      #     engine has no system voices.
+      #
+      # Why the npm cli-cef could not do this (local builds still use it): its
+      # bundler downloads a fork of the script (FabianLars/Anylinux-AppImages,
+      # re-fetched from main on every build) whose HEAD, 3e280d1b "fix handling
+      # of spaces in input paths", turned
+      #   eval set -- "$TO_DEPLOY_ARRAY" "$@"   into   set -- $TO_DEPLOY_ARRAY "$@"
+      # The array entries come single-quoted from _save_array, so without the
       # eval each keeps its literal quotes, fails `[ -f ]`, and EVERY DEPLOY_*
-      # extra is silently skipped. Only ldd-derived libraries land. The fix
-      # that keeps both halves is to quote the positional args the same way:
-      #   eval set -- "$TO_DEPLOY_ARRAY" "$(_save_array "$@")"
-      # Once that (or any restored eval) is on the fork's main, the next build
-      # deploys NSS and libpulse by itself and those entries below turn
-      # redundant — harmlessly, the tooling keeps files it already has.
-      # tauri-apps/tauri#12491 sidesteps the fork altogether (pinned pkgforge
-      # revision, no whitespace in the AppDir path) and fixes the CI hang the
-      # STRACE_MODE pin in the build step works around; lift that pin and bump
-      # CEF_CLI in apps/readest-app/scripts/tauri.mjs when cli-cef carries it.
-      # Keep the nss/ flatten and the libspeechd entry either way: every
-      # quick-sharun globs only Arch's flat layout, so a Debian builder hides
-      # the NSS modules from it, and no rule deploys libspeechd at all.
-      # libpipewire is deliberately not staged — Chromium needs it for the
-      # screen-share portal, not for audio — and neither are ALSA plugins:
-      # with libpulse in the bundle Chromium talks to PulseAudio/PipeWire
-      # directly, and a pure-ALSA host resolves `default` with built-ins.
-      #
-      # Until then, hand the modules over as appimage.files: the bundler passes
-      # files targeted at /usr/lib to quick-sharun as plain ELF arguments, the
-      # injection channel #12491 keeps. Sources must sit directly in the triple
-      # lib dir (Debian hides them in <triple>/nss/) because the destination
-      # inside the bundle mirrors the source dir, and only a flat source lands
-      # next to the libnss3.so that loads it.
+      # extra is silently skipped — only ldd-derived libraries land. (Upstream's
+      # line does split positional paths on spaces; quoting them through the
+      # same helper keeps both.) tauri-apps/tauri#12491 takes the same route as
+      # the CLI above and also fixes the CI hang behind the STRACE_MODE pin in
+      # the build step; lift that pin when a cli-cef carries it.
       - name: stage CEF AppImage runtime libraries (linux only)
         if: matrix.config.release == 'linux'
         run: |
@@ -438,10 +448,6 @@ jobs:
           # from prompting for a root password (src-tauri/appimage/).
           conf=apps/readest-app/src-tauri/tauri.conf.json
           jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
-              "/usr/lib/libsoftokn3.so": ($d + "/libsoftokn3.so"),
-              "/usr/lib/libfreeblpriv3.so": ($d + "/libfreeblpriv3.so"),
-              "/usr/lib/libnssckbi.so": ($d + "/libnssckbi.so"),
-              "/usr/lib/libpulse.so.0": ($d + "/libpulse.so.0"),
               "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2")
             }' "$conf" > "$conf.tmp" && mv "$conf.tmp" "$conf"
 
@@ -548,6 +554,7 @@ jobs:
         if: matrix.config.release != 'android'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_CEF_CARGO: '1'
           # The CEF AppImage bundler (quick-sharun) otherwise launches the app
           # under Xvfb to discover dlopen'ed libraries and never gets it to
           # exit, hanging the Linux legs (#4906); ldd-based discovery only.

--- a/apps/readest-app/scripts/tauri.mjs
+++ b/apps/readest-app/scripts/tauri.mjs
@@ -35,6 +35,11 @@ const CEF_CLI = '@tauri-apps/cli-cef@3.0.0-alpha.26';
 // Offline builds (Flatpak) cannot `pnpm dlx`; they point this at an unpacked
 // copy of the CLI package's `tauri.js` instead.
 const localCefCli = process.env['TAURI_CEF_CLI'];
+// CI builds the CLI from readest/tauri instead (`cargo install tauri-cli`),
+// because the published cli-cef's AppImage bundler fetches a broken fork of
+// quick-sharun; see the "install the CEF tauri CLI" step in the workflows.
+// The cargo-installed `cargo tauri` takes the same command line as the npm CLI.
+const cargoCefCli = process.env['TAURI_CEF_CARGO'] === '1';
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = path.resolve(appDir, '../..');
 const cargoConfig = path.join(appDir, 'src-tauri/.cargo/cef.toml');
@@ -105,7 +110,9 @@ if (!useCef) {
     process.on(signal, () => {});
   }
 
-  if (localCefCli) {
+  if (cargoCefCli) {
+    run('cargo', ['tauri', ...args], restoreLock);
+  } else if (localCefCli) {
     run('node', [localCefCli, ...args], restoreLock);
   } else {
     run('pnpm', ['dlx', CEF_CLI, ...args], restoreLock);


### PR DESCRIPTION
Stacked on #6108 (retarget to `main` once it merges). This is the direction @Samueru-sama and @FabianLars pointed at in that thread: let quick-sharun deploy Chromium's dependencies itself instead of hand-staging them, and take the pinned-pkgforge route of tauri-apps/tauri#12491 rather than the fork.

## Why a self-built CLI

`@tauri-apps/cli-cef@3.0.0-alpha.26` bundles the AppImage with FabianLars' fork of quick-sharun, whose HEAD drops the `eval` that rebuilds the deployment array, so every `DEPLOY_*` extra is silently skipped. It re-downloads that fork on every build and offers no way to point elsewhere: no env var, `TAURI_BUNDLER_TOOLS_GITHUB_MIRROR` only rewrites `github.com` URLs, and the cache seed the workflow used before #6074 is dead because the `if !exists` guard is commented out. There is no newer `cli-cef` on npm, and #12491 has not reached `feat/cef`.

So the Linux legs build the CLI from readest/tauri, the way the workflow did until #6074. readest/tauri@c62e9f90 (`feat/cef-pkgforge-bundler`, +107/−26 on `sharun_cef.rs`) does what #12491's bundler does, on top of the CEF-aware one:

- fetches pkgforge-dev/Anylinux-AppImages at `facb95e8` verified against #12491's SHA-256, cached under the revision, and pins `ANYLINUX_LIB_SOURCE` to the same rev;
- runs the script with bash and streams its output — the two halves of the #4906 hang (dash never creates the process group the script signals; the captured pipes stayed open in surviving CEF children);
- passes the deploy list as arguments and keeps whitespace out of the AppDir name, since that revision's `eval` splits positional paths on it;
- drops `ADD_HOOKS=fix-namespaces.hook`: CEF never asks for user namespaces without the sandbox feature, so the hook only produced the root-password prompt (#6110's shim stays and is now a no-op);
- lifts the Windows-only cfg on `HashAlgorithm::Sha256` (#12491's `http_utils.rs` change).

Pinned to a rev, not the branch tip; rust-cache keeps `~/.cargo/bin` and a marker skips the ~6 min rebuild while the pin holds. `scripts/tauri.mjs` runs `cargo tauri` when `TAURI_CEF_CARGO=1`, same command line as the npm CLI.

## What the tooling now does on its own

Built locally with that CLI (`--bundles appimage`, `STRACE_MODE=0` as in CI). The AppDir quick-sharun produced, with **no** staging step involved:

- audio: `libpulse.so.0`, `libpipewire-0.3.so.0`, `alsa-lib/libasound_module_{conf,ctl,pcm}_pulse.so`, `pulseaudio/` on `lib.path` — via `DEPLOY_CHROMIUM` → `DEPLOY_PIPEWIRE` → `DEPLOY_PULSE`, exactly as Samueru-sama described;
- NSS: `libsoftokn3.so`, `libfreeblpriv3.so`, `libnssckbi.so`, `libnssdbm3.so`;
- GL: mesa EGL/GLX, `dri/`, `gbm`, `vdpau` (and the host's NVIDIA libs, since this box has them);
- also gconv, gio modules, gvfs, gdk-pixbuf loaders, GTK IM modules, p11-kit, spa/pipewire modules; 397 libraries in all;
- hooks: `00-no-userns-prompt`, `01-path-mapping-hardcoded`, `05-vulkan-check` — no fix-namespaces.

The resulting AppImage, run headless with a fresh `$HOME`: alive for the whole window, zero `FATAL`/`GLIBC_`/`nss_error`/`zenity`/`pkexec` lines, and the GPU process does **not** exit. Inside the bundle's own runtime (`LD_DEBUG=libs` under its loader and `lib.path`):

```
calling init: <bundle>/lib/libpulse.so.0
calling init: <bundle>/lib/pulseaudio/libpulsecommon-17.0.so
calling init: <bundle>/lib/libsoftokn3.so
calling init: <bundle>/lib/libGL.so.1
```

## What the staging step keeps

Down to the two gaps no rule covers, passed to quick-sharun as arguments the way the script itself prescribes rather than copied in:

- Debian keeps the NSS PKCS#11 modules in `<triple>/nss/` and the globs only know Arch's flat layout, so the runner copies them up a level for `"$LIB_DIR"/libsoftokn3.so*` to match (this box, Ubuntu 25.04, ships them flat, which is why the local build found them unaided; jammy does not);
- `libspeechd.so.2`, which nothing deploys and without which the Web Speech engine has no voices.

The libpulse and NSS `appimage.files` entries are gone; the guard step still checks the full set lands.

## Not in this PR

`STRACE_MODE` stays off. The hang it works around is fixed by the bash/streamed-output change, but turning dlopen discovery back on is its own change with its own validation. Cannot be exercised by PR CI — it needs a full CEF build — so the first nightly after merge is the CI validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)