### PR TITLE
feat(ui): remove e-ink mode checks for all devices and platforms

### DIFF
--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -799,14 +799,12 @@ const FoliateViewer: React.FC<{
       if (appService?.isIOSApp) {
         view.renderer.setAttribute('gpu-composite', '');
       }
-      if (appService?.isAndroidApp) {
-        if (eink) {
-          view.renderer.setAttribute('eink', '');
-        } else {
-          view.renderer.removeAttribute('eink');
-        }
-        applyEinkMode(eink);
+      if (eink) {
+        view.renderer.setAttribute('eink', '');
+      } else {
+        view.renderer.removeAttribute('eink');
       }
+      applyEinkMode(eink);
       if (bookDoc?.rendition?.layout === 'pre-paginated') {
         view.renderer.setAttribute('zoom', viewSettings.zoomMode);
         view.renderer.setAttribute('spread', viewSettings.spreadMode);

--- a/apps/readest-app/src/components/settings/ControlPanel.tsx
+++ b/apps/readest-app/src/components/settings/ControlPanel.tsx
@@ -507,23 +507,19 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
       </BoxedList>
 
       <BoxedList title={_('Device')} data-setting-id='settings.control.device'>
-        {(appService?.isAndroidApp || appService?.appPlatform === 'web') && (
-          <SettingsSwitchRow
-            label={_('E-Ink Mode')}
-            checked={isEink}
-            onChange={() => setIsEink(!isEink)}
-            data-setting-id='settings.control.einkMode'
-          />
-        )}
-        {(appService?.isAndroidApp || appService?.appPlatform === 'web') && (
-          <SettingsSwitchRow
-            label={_('Color E-Ink Mode')}
-            checked={isColorEink}
-            disabled={!isEink}
-            onChange={() => setIsColorEink(!isColorEink)}
-            data-setting-id='settings.control.colorEinkMode'
-          />
-        )}
+        <SettingsSwitchRow
+          label={_('E-Ink Mode')}
+          checked={isEink}
+          onChange={() => setIsEink(!isEink)}
+          data-setting-id='settings.control.einkMode'
+        />
+        <SettingsSwitchRow
+          label={_('Color E-Ink Mode')}
+          checked={isColorEink}
+          disabled={!isEink}
+          onChange={() => setIsColorEink(!isColorEink)}
+          data-setting-id='settings.control.colorEinkMode'
+        />
         {appService?.isMobileApp && (
           <SettingsSwitchRow
             label={_('System Screen Brightness')}


### PR DESCRIPTION
The PR removes the device and platform check for e-ink mode. Since theoretically all readest supported devices and platforms can output to an e-ink monitor, I see no reason to gate this mode. Feel free to close this if there is any reason to actually gate this mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - E-Ink Mode settings are now available across all platforms.
  - Color E-Ink Mode remains available when E-Ink Mode is enabled.
  - E-Ink rendering is applied consistently across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->