### PR TITLE
fix(test): keep the curl leaf in flight until the incoming bitmap lands

### DIFF
--- a/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
@@ -1583,7 +1583,7 @@ describe('CapturedPageTurn two-column curl (browser)', () => {
   const rightHalf = { x: 10 + W / 2, y: 20, width: W / 2, height: H };
   const overlay = () => host.querySelector<HTMLElement>('div[aria-hidden="true"]');
   const isInner = (rect: { width: number }) => rect.width === W / 2;
-  const makeController = (overrides: Partial<CapturedTurnHost> = {}) => {
+  const makeController = (overrides: Partial<CapturedTurnHost> = {}, duration = 40) => {
     controller = new CapturedPageTurn(
       {
         getHostElement: () => host,
@@ -1594,7 +1594,7 @@ describe('CapturedPageTurn two-column curl (browser)', () => {
         coverRegion,
         ...overrides,
       },
-      { duration: 40 },
+      { duration },
     );
     return controller;
   };
@@ -1737,9 +1737,15 @@ describe('CapturedPageTurn two-column curl (browser)', () => {
   it('commits the incoming column when no overlay interferes', async () => {
     const setIncoming = vi.spyOn(PageCurlRenderer.prototype, 'setIncoming');
     try {
-      await makeController().turn(true, false, 'curl');
-      await vi.waitFor(() => expect(setIncoming).toHaveBeenCalledTimes(1));
+      // The turn waits INCOMING_WAIT_MS for the capture, then lands the leaf
+      // and rightly drops a bitmap that arrives after that. The capture needs
+      // four paint frames plus a decode, so on a loaded runner a 40 ms leaf
+      // lands first. Keep the leaf in flight until the bitmap is in.
+      const turning = makeController({}, 5_000).turn(true, false, 'curl');
+      await vi.waitFor(() => expect(setIncoming).toHaveBeenCalledTimes(1), { timeout: 3_000 });
       expect(setIncoming.mock.calls[0]![0]).toBeInstanceOf(ImageBitmap);
+      controller!.dispose();
+      await turning;
     } finally {
       setIncoming.mockRestore();
     }


### PR DESCRIPTION
`CapturedPageTurn two-column curl (browser) > commits the incoming column when no overlay interferes` (from #6107) fails on loaded runners — three of the last eight PR-checks runs, most recently on #6108's `test_web_app (1)`.

**Why:** `turn()` waits `INCOMING_WAIT_MS` (120 ms) for the incoming capture, then lands the leaf, and `#captureIncoming` correctly drops a bitmap that arrives after the turn is no longer active. The test's 40 ms leaf leaves ~160 ms for a capture that needs four paint frames plus an `ImageBitmap` decode — fine at 60 Hz, not when a busy runner stalls `requestAnimationFrame`.

**Fix (test only):** run the turn with a long leaf and don't await it, so the animation is still active when the bitmap decodes; dispose and `await turning` afterwards, mirroring the disposed-mid-capture test. `makeController` takes the duration as a second argument.

**Evidence:** under 26 busy workers on a 28-core machine the original fails 4/4; the fixed file passes 8/8 across 26 and 14 workers, plus idle runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for two-column page-turn behavior when capturing incoming content.
  * Added configurable animation durations and more reliable waiting and cleanup in the related test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->