### PR TITLE
fix(sync): repair missing local covers from the file-sync remote

### DIFF
--- a/apps/readest-app/src/__tests__/services/sync/file/engine-cover-repair.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-cover-repair.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { Book, BookConfig } from '@/types/book';
+import { FileSyncEngine } from '@/services/sync/file/engine';
+import type { FileSyncProvider } from '@/services/sync/file/provider';
+import type { LocalStore } from '@/services/sync/file/localStore';
+import type { RemoteLibraryIndex } from '@/services/sync/file/wire';
+
+/**
+ * Cover repair for rows that already exist locally (#5931).
+ *
+ * A book restored by Readest Cloud lands in the library as a metadata-only
+ * row: no book file, no cover. Being in `allBooksMap` used to be treated as
+ * proof that the local resources were complete, so the file-sync discovery
+ * pass skipped it and the push pass only ever tried to upload a cover this
+ * device didn't have. These tests pin the repair: when the remote holds a
+ * cover the local row is missing, sync pulls it down.
+ */
+
+const COVER_PATH_SUFFIX = 'cover.png';
+
+const makeBook = (overrides: Partial<Book> = {}): Book => ({
+  hash: 'h1',
+  format: 'EPUB',
+  title: 'Restored Book',
+  sourceTitle: 'Restored Book',
+  author: 'Author',
+  createdAt: 1,
+  updatedAt: 100,
+  ...overrides,
+});
+
+const makeIndex = (books: Book[]): RemoteLibraryIndex => ({
+  schemaVersion: 1,
+  updatedAt: 100,
+  books,
+  uploadedHashes: books.map((b) => b.hash),
+});
+
+/**
+ * Provider routed by path. `remoteCover` null models a remote that never
+ * received a cover for this hash, so both the HEAD probe and the GET 404.
+ */
+const makeProvider = (
+  index: RemoteLibraryIndex | null,
+  remoteCover: ArrayBuffer | null,
+): FileSyncProvider => ({
+  rootPath: '/',
+  readText: vi.fn(async (path: string) =>
+    path.endsWith('library.json') && index ? JSON.stringify(index) : null,
+  ),
+  readBinary: vi.fn(async (path: string) =>
+    path.endsWith(COVER_PATH_SUFFIX) ? remoteCover : null,
+  ),
+  head: vi.fn(async (path: string) =>
+    path.endsWith(COVER_PATH_SUFFIX) && remoteCover
+      ? { size: remoteCover.byteLength, etag: 'cover-etag' }
+      : null,
+  ),
+  list: vi.fn(async () => []),
+  writeText: vi.fn(async () => {}),
+  writeBinary: vi.fn(async () => {}),
+  ensureDir: vi.fn(async () => {}),
+  deleteDir: vi.fn(async () => {}),
+});
+
+const makeStore = (overrides: Partial<LocalStore> = {}): LocalStore => ({
+  loadConfig: async (): Promise<BookConfig> => ({ updatedAt: 50, booknotes: [] }),
+  saveBookConfig: async () => {},
+  loadBookFile: async () => null,
+  resolveLocalBookPath: async () => null,
+  saveBookFile: async () => {},
+  prepareLocalBookPath: async () => '/local/path',
+  // The defining state of the bug: the row is in the library, the cover file
+  // is not on disk.
+  loadBookCover: async () => null,
+  saveBookCover: async () => {},
+  addBookToLibrary: async () => {},
+  updateBookMetadata: async () => {},
+  deleteBookLocally: async () => {},
+  markBooksUploaded: async () => {},
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('FileSyncEngine cover repair for existing local rows (#5931)', () => {
+  test('full sync downloads a remote cover the local row is missing', async () => {
+    const book = makeBook();
+    const remoteCover = new ArrayBuffer(64);
+    const provider = makeProvider(makeIndex([book]), remoteCover);
+
+    const saveBookCover = vi.fn(async (_book: Book, _bytes: ArrayBuffer) => {});
+    const updateBookMetadata = vi.fn(async (_book: Book) => {});
+    const store = makeStore({ saveBookCover, updateBookMetadata });
+
+    const engine = new FileSyncEngine(provider, store);
+    const result = await engine.syncLibrary([book], {
+      strategy: 'silent',
+      syncBooks: false,
+      fullSync: true,
+      deviceId: 'phone',
+    });
+
+    expect(saveBookCover).toHaveBeenCalledTimes(1);
+    expect(saveBookCover.mock.calls[0]![0]!.hash).toBe('h1');
+    expect(saveBookCover.mock.calls[0]![1]!.byteLength).toBe(64);
+    expect(result.coversDownloaded).toBe(1);
+    expect(result.failures).toBe(0);
+
+    // Persisted through the store so the bookshelf regenerates the cover URL
+    // instead of showing the generated placeholder until the next reload.
+    expect(updateBookMetadata).toHaveBeenCalledTimes(1);
+    expect(updateBookMetadata.mock.calls[0]![0]!.coverDownloadedAt).toBeTruthy();
+  });
+
+  test('does not GET a cover the remote does not have', async () => {
+    const book = makeBook();
+    const provider = makeProvider(makeIndex([book]), null);
+    const saveBookCover = vi.fn(async (_book: Book, _bytes: ArrayBuffer) => {});
+    const store = makeStore({ saveBookCover });
+
+    const engine = new FileSyncEngine(provider, store);
+    const result = await engine.syncLibrary([book], {
+      strategy: 'silent',
+      syncBooks: false,
+      fullSync: true,
+      deviceId: 'phone',
+    });
+
+    const coverGets = (provider.readBinary as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call) => typeof call[0] === 'string' && (call[0] as string).endsWith(COVER_PATH_SUFFIX),
+    );
+    expect(coverGets).toHaveLength(0);
+    expect(saveBookCover).not.toHaveBeenCalled();
+    expect(result.coversDownloaded).toBe(0);
+  });
+
+  test('send-only never pulls a cover down', async () => {
+    const book = makeBook();
+    const provider = makeProvider(makeIndex([book]), new ArrayBuffer(64));
+    const saveBookCover = vi.fn(async (_book: Book, _bytes: ArrayBuffer) => {});
+    const store = makeStore({ saveBookCover });
+
+    const engine = new FileSyncEngine(provider, store);
+    const result = await engine.syncLibrary([book], {
+      strategy: 'send',
+      syncBooks: false,
+      fullSync: true,
+      deviceId: 'phone',
+    });
+
+    expect(saveBookCover).not.toHaveBeenCalled();
+    expect(result.coversDownloaded).toBe(0);
+  });
+
+  test('a book whose cover is already local is left alone', async () => {
+    const book = makeBook();
+    const localCover = new ArrayBuffer(64);
+    const provider = makeProvider(makeIndex([book]), localCover);
+    const saveBookCover = vi.fn(async (_book: Book, _bytes: ArrayBuffer) => {});
+    const store = makeStore({
+      loadBookCover: async () => ({ bytes: localCover, size: localCover.byteLength }),
+      saveBookCover,
+    });
+
+    const engine = new FileSyncEngine(provider, store);
+    const result = await engine.syncLibrary([book], {
+      strategy: 'silent',
+      syncBooks: false,
+      fullSync: true,
+      deviceId: 'phone',
+    });
+
+    // Same size as the remote copy: the existing HEAD short-circuit skips the
+    // upload, and the repair must not fire either.
+    expect(saveBookCover).not.toHaveBeenCalled();
+    expect(result.coversDownloaded).toBe(0);
+    expect(result.coversUploaded).toBe(0);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-cover-repair.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-cover-repair.test.ts
@@ -116,11 +116,12 @@ describe('FileSyncEngine cover repair for existing local rows (#5931)', () => {
     expect(updateBookMetadata.mock.calls[0]![0]!.coverDownloadedAt).toBeTruthy();
   });
 
-  test('does not GET a cover the remote does not have', async () => {
+  test('a cover the remote does not have costs one GET and saves nothing', async () => {
     const book = makeBook();
     const provider = makeProvider(makeIndex([book]), null);
     const saveBookCover = vi.fn(async (_book: Book, _bytes: ArrayBuffer) => {});
-    const store = makeStore({ saveBookCover });
+    const updateBookMetadata = vi.fn(async (_book: Book) => {});
+    const store = makeStore({ saveBookCover, updateBookMetadata });
 
     const engine = new FileSyncEngine(provider, store);
     const result = await engine.syncLibrary([book], {
@@ -130,12 +131,61 @@ describe('FileSyncEngine cover repair for existing local rows (#5931)', () => {
       deviceId: 'phone',
     });
 
+    // The repair is one probe per cover-less row, not a retry loop, and a 404
+    // must not write a row back (that would be a library write per book on
+    // every Full Sync).
+    const coverGets = (provider.readBinary as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call) => typeof call[0] === 'string' && (call[0] as string).endsWith(COVER_PATH_SUFFIX),
+    );
+    expect(coverGets).toHaveLength(1);
+    expect(saveBookCover).not.toHaveBeenCalled();
+    expect(updateBookMetadata).not.toHaveBeenCalled();
+    expect(result.coversDownloaded).toBe(0);
+  });
+
+  test('incremental sync leaves the repair to Full Sync', async () => {
+    const book = makeBook();
+    const provider = makeProvider(makeIndex([book]), new ArrayBuffer(64));
+    const saveBookCover = vi.fn(async (_book: Book, _bytes: ArrayBuffer) => {});
+    const store = makeStore({ saveBookCover });
+
+    const engine = new FileSyncEngine(provider, store);
+    const result = await engine.syncLibrary([book], {
+      strategy: 'silent',
+      syncBooks: false,
+      fullSync: false,
+      deviceId: 'phone',
+    });
+
+    // The default path is O(changed): a row whose clock matches the index is
+    // untouched, so a placeholder cover waits for the user's Full Sync.
     const coverGets = (provider.readBinary as ReturnType<typeof vi.fn>).mock.calls.filter(
       (call) => typeof call[0] === 'string' && (call[0] as string).endsWith(COVER_PATH_SUFFIX),
     );
     expect(coverGets).toHaveLength(0);
     expect(saveBookCover).not.toHaveBeenCalled();
     expect(result.coversDownloaded).toBe(0);
+  });
+
+  test('receive-only full sync repairs a missing local cover', async () => {
+    const book = makeBook();
+    const provider = makeProvider(makeIndex([book]), new ArrayBuffer(64));
+    const saveBookCover = vi.fn(async (_book: Book, _bytes: ArrayBuffer) => {});
+    const store = makeStore({ saveBookCover });
+
+    const engine = new FileSyncEngine(provider, store);
+    const result = await engine.syncLibrary([book], {
+      strategy: 'receive',
+      syncBooks: false,
+      fullSync: true,
+      deviceId: 'phone',
+    });
+
+    // Receive Only never enters the push pass, so the repair must not live
+    // there: pull-only is exactly the mode a secondary device restores in.
+    expect(saveBookCover).toHaveBeenCalledTimes(1);
+    expect(result.coversDownloaded).toBe(1);
+    expect(provider.writeBinary).not.toHaveBeenCalled();
   });
 
   test('send-only never pulls a cover down', async () => {

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-group-metadata-5911.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-group-metadata-5911.test.ts
@@ -414,6 +414,9 @@ describe('FileSyncEngine.syncLibrary — incremental stays O(changed)', () => {
     await new FileSyncEngine(
       provider,
       fakeStore({
+        // The cover is already on this device: only a row whose cover file is
+        // missing may cost a Full Sync cover GET (#5931), never a field repair.
+        loadBookCover: async () => ({ bytes: new ArrayBuffer(8), size: 8 }),
         updateBookMetadata: async (b) => {
           applied.push(b);
         },

--- a/apps/readest-app/src/services/sync/file/engine.ts
+++ b/apps/readest-app/src/services/sync/file/engine.ts
@@ -49,6 +49,13 @@ export interface PushBookFileResult {
   uploaded: boolean;
   /** Reason for the skip, when applicable — surfaced for diagnostics. */
   reason?: 'remote-matches' | 'no-source' | 'disabled';
+  /**
+   * Whether the HEAD probe found a remote copy. Only populated by
+   * {@link FileSyncEngine.pushBookCover}, whose caller uses it to decide
+   * whether a cover missing from this device is worth pulling back down —
+   * without paying a speculative GET for a book the remote has no cover for.
+   */
+  remoteExists?: boolean;
 }
 
 export interface DeleteRemoteBookDirResult {
@@ -77,6 +84,8 @@ export interface SyncLibraryResult {
   filesUploaded: number;
   filesAlreadyInSync: number;
   coversUploaded: number;
+  /** Covers pulled back down because this device's copy was missing (#5931). */
+  coversDownloaded: number;
   /** Remote-only books added to the local shelf without downloading their files (#5009). */
   booksAdded: number;
   /** Local books removed because a peer's tombstone propagated to this device (#4860). */
@@ -428,9 +437,9 @@ export class FileSyncEngine {
     }
 
     const local = await this.store.loadBookCover(book);
-    if (!local) return { uploaded: false, reason: 'no-source' };
+    if (!local) return { uploaded: false, reason: 'no-source', remoteExists: !!remoteHead };
     if (remoteHead && remoteHead.size === local.size) {
-      return { uploaded: false, reason: 'remote-matches' };
+      return { uploaded: false, reason: 'remote-matches', remoteExists: true };
     }
     await this.ensureDirs(dirs);
     try {
@@ -537,6 +546,7 @@ export class FileSyncEngine {
       filesUploaded: 0,
       filesAlreadyInSync: 0,
       coversUploaded: 0,
+      coversDownloaded: 0,
       booksAdded: 0,
       booksDeleted: 0,
       metadataUpdated: 0,
@@ -1145,6 +1155,33 @@ export class FileSyncEngine {
                 if (coverResult.uploaded) {
                   result.coversUploaded += 1;
                   syncedHashes.add(book.hash);
+                } else if (
+                  coverResult.reason === 'no-source' &&
+                  coverResult.remoteExists &&
+                  canPull
+                ) {
+                  // The row is in the library but its cover file isn't on this
+                  // device — the state a metadata-only Readest Cloud restore
+                  // leaves behind when the book files live in the file-sync
+                  // provider instead (#5931). Membership in `allBooksMap` only
+                  // proves the row exists, so discovery skips it and this push
+                  // has nothing to upload: repair the cover from the remote
+                  // rather than leaving a generated placeholder forever.
+                  // Gated on the HEAD probe pushBookCover already paid, so a
+                  // book with no remote cover costs no extra request.
+                  const coverBytes = await this.pullBookCover(book.hash);
+                  if (coverBytes) {
+                    const current = allBooksMap.get(book.hash) ?? book;
+                    const repaired: Book = { ...current, coverDownloadedAt: Date.now() };
+                    await this.store.saveBookCover(repaired, coverBytes);
+                    // Persist through the store, not just to disk: the shelf
+                    // renders a cached cover URL, so a row that isn't written
+                    // back keeps showing the placeholder until the next reload.
+                    await this.store.updateBookMetadata(repaired);
+                    allBooksMap.set(book.hash, repaired);
+                    result.coversDownloaded += 1;
+                    syncedHashes.add(book.hash);
+                  }
                 }
               } catch (e) {
                 console.warn('file sync: cover failed', book.hash, e);

--- a/apps/readest-app/src/services/sync/file/engine.ts
+++ b/apps/readest-app/src/services/sync/file/engine.ts
@@ -49,13 +49,6 @@ export interface PushBookFileResult {
   uploaded: boolean;
   /** Reason for the skip, when applicable — surfaced for diagnostics. */
   reason?: 'remote-matches' | 'no-source' | 'disabled';
-  /**
-   * Whether the HEAD probe found a remote copy. Only populated by
-   * {@link FileSyncEngine.pushBookCover}, whose caller uses it to decide
-   * whether a cover missing from this device is worth pulling back down —
-   * without paying a speculative GET for a book the remote has no cover for.
-   */
-  remoteExists?: boolean;
 }
 
 export interface DeleteRemoteBookDirResult {
@@ -437,9 +430,9 @@ export class FileSyncEngine {
     }
 
     const local = await this.store.loadBookCover(book);
-    if (!local) return { uploaded: false, reason: 'no-source', remoteExists: !!remoteHead };
+    if (!local) return { uploaded: false, reason: 'no-source' };
     if (remoteHead && remoteHead.size === local.size) {
-      return { uploaded: false, reason: 'remote-matches', remoteExists: true };
+      return { uploaded: false, reason: 'remote-matches' };
     }
     await this.ensureDirs(dirs);
     try {
@@ -859,6 +852,52 @@ export class FileSyncEngine {
       });
     }
 
+    // Cover repair (#5931). A row Readest Cloud restored as metadata-only is in
+    // the library but has no cover file on this device, and nothing above
+    // reconnects the two: discovery only materialises hashes the shelf lacks,
+    // the metadata pass only re-pulls a cover when the remote clock is newer,
+    // and the push pass has no local cover to upload. Membership in
+    // `allBooksMap` proves the row exists, not that its cover does. Full Sync
+    // is the audit pass, so this is where the shelf is repaired: pull the
+    // remote cover for every live indexed row whose local cover is missing.
+    // It sits on the pull side rather than in the push loop so Receive Only —
+    // exactly the mode a secondary device restores in — repairs too. One GET
+    // per cover-less row (404 = the remote has none either); the push pass's
+    // HEAD then matches the freshly written local copy and never bounces it
+    // back up. Never on the incremental path, which must stay O(changed).
+    if (fullSync && canPull && remoteIndex?.books) {
+      const liveIndexed = remoteIndex.books.filter((rb) => {
+        if (rb.deletedAt) return false;
+        const local = allBooksMap.get(rb.hash);
+        return !!local && !local.deletedAt;
+      });
+      await runPool(
+        liveIndexed,
+        concurrency,
+        async (rb) => {
+          const local = allBooksMap.get(rb.hash)!;
+          try {
+            if (await this.store.loadBookCover(local)) return;
+            const coverBytes = await this.pullBookCover(rb.hash);
+            if (!coverBytes) return;
+            const repaired: Book = { ...local, coverDownloadedAt: Date.now() };
+            await this.store.saveBookCover(repaired, coverBytes);
+            // Persist through the store, not just to disk: the shelf renders a
+            // cached cover URL, so a row that isn't written back keeps showing
+            // the placeholder until the next reload.
+            await this.store.updateBookMetadata(repaired);
+            allBooksMap.set(rb.hash, repaired);
+            result.coversDownloaded += 1;
+            syncedHashes.add(rb.hash);
+          } catch (e) {
+            noteAbort(e);
+            console.warn('file sync: cover repair failed', rb.hash, e);
+          }
+        },
+        aborted,
+      );
+    }
+
     // Revival stamp (#5900) — the send-mode dual of deletion propagation above.
     // 'send' keeps its live row and republishes it over the peer's tombstone,
     // but it republished the row's OLD `updatedAt`, and a peer only revives on
@@ -1155,33 +1194,6 @@ export class FileSyncEngine {
                 if (coverResult.uploaded) {
                   result.coversUploaded += 1;
                   syncedHashes.add(book.hash);
-                } else if (
-                  coverResult.reason === 'no-source' &&
-                  coverResult.remoteExists &&
-                  canPull
-                ) {
-                  // The row is in the library but its cover file isn't on this
-                  // device — the state a metadata-only Readest Cloud restore
-                  // leaves behind when the book files live in the file-sync
-                  // provider instead (#5931). Membership in `allBooksMap` only
-                  // proves the row exists, so discovery skips it and this push
-                  // has nothing to upload: repair the cover from the remote
-                  // rather than leaving a generated placeholder forever.
-                  // Gated on the HEAD probe pushBookCover already paid, so a
-                  // book with no remote cover costs no extra request.
-                  const coverBytes = await this.pullBookCover(book.hash);
-                  if (coverBytes) {
-                    const current = allBooksMap.get(book.hash) ?? book;
-                    const repaired: Book = { ...current, coverDownloadedAt: Date.now() };
-                    await this.store.saveBookCover(repaired, coverBytes);
-                    // Persist through the store, not just to disk: the shelf
-                    // renders a cached cover URL, so a row that isn't written
-                    // back keeps showing the placeholder until the next reload.
-                    await this.store.updateBookMetadata(repaired);
-                    allBooksMap.set(book.hash, repaired);
-                    result.coversDownloaded += 1;
-                    syncedHashes.add(book.hash);
-                  }
                 }
               } catch (e) {
                 console.warn('file sync: cover failed', book.hash, e);


### PR DESCRIPTION
## Problem

Fixes #5931.

When Readest Cloud holds only the library metadata and the book files live in an S3/WebDAV file-sync remote, a fresh install restores the books as metadata-only shelf rows: no book file, no cover. Running **Full Sync** against the provider that *does* have the covers never restores them, so the affected books keep showing generated placeholders.

## Root cause

Once the row exists locally, its presence in `allBooksMap` was treated as proof that the local resources were complete:

- **Discovery** only materialises hashes the library doesn't already have (`if ((!local || revivesLocalTombstone) && !rb.deletedAt)` and `if (!allBooksMap.has(entry.name))`), so it never looks at these rows and its cover pull never runs.
- **Metadata reconciliation** only fires when the indexed copy is strictly newer, which it usually isn't.
- The **push pass** calls `pushBookCover`, which finds no local cover and resolves to `no-source`. Nothing ever pulls.

So the cover exists on the remote, the row exists locally, and no code path connects them. As the issue puts it: being in the library only proves the *row* is there, not the cover.

## Fix

Full Sync now runs a pull-side **cover repair** pass (after deletion propagation, before the push pass): for every live row in the remote index whose local cover file is missing, pull the remote `cover.png`, save it, stamp `coverDownloadedAt`, and persist the row via `store.updateBookMetadata` so the bookshelf regenerates the cached cover URL immediately instead of showing the placeholder until the next reload.

It is gated on `fullSync && canPull`:

- **Receive Only heals too** — the repair does not depend on the push loop, which `'receive'` never enters.
- **The incremental path stays O(changed)** — Full Sync is the audit/repair pass in this engine.
- The push pass's HEAD then matches the freshly written local copy, so nothing is bounced back up.

Deliberately unchanged: book files stay remote/on-demand, and `'send'` (Send Only) still never pulls.

### Cost

One GET per cover-less row on Full Sync only; a row with a local cover costs nothing. A row the remote has no cover for either pays a single 404 GET per Full Sync.

## Tests

`src/__tests__/services/sync/file/engine-cover-repair.test.ts` (6 cases; the first written against unmodified `main` and confirmed failing — `saveBookCover` was called 0 times):

- Full Sync pulls a remote cover the local row is missing, and writes the row back.
- A cover the remote does not have costs one GET and writes nothing back.
- `'send'` never pulls a cover down.
- A book that already has its cover locally is untouched.
- Receive Only Full Sync repairs the cover (fails when the repair lives in the push loop).
- Incremental sync leaves the repair to Full Sync (fails if the `fullSync` gate is removed).

The #5911 field-repair test now gives its fake store a local cover so it keeps asserting what it meant: an index-field repair never pulls a cover that is already on the device.

## Checks

- `pnpm test` — clean
- `pnpm lint` (tsc + biome) — clean

## Note

Verified from source against the sync engine's test harness, not on a physical Android device; the reporter's S3 setup is what the fake provider models.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed full synchronization so missing local book covers are restored when available remotely.
  * Preserved send-only behavior by preventing remote covers from being downloaded in that mode.
  * Avoided unnecessary downloads when a local cover is already present.
  * Covers unavailable remotely are not saved locally.
  * Incremental synchronization continues to leave cover repair to full synchronization.
  * Added synchronization reporting for the number of covers restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
