### PR TITLE
fix(tts): keep mini player above navigation panels

### DIFF
--- a/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => (key: string, opts?: Record<string, unknown>) =>
@@ -15,6 +15,9 @@ vi.mock('@/context/EnvContext', () => ({
     appService: { isMobile: false, hasSafeAreaInset: false },
   }),
 }));
+
+let resizeCallback: ResizeObserverCallback;
+const disconnectObserver = vi.fn();
 
 let viewSettingsOverride: Record<string, unknown> = {};
 const readerState = {
@@ -71,6 +74,16 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
 
 describe('TTSMiniPlayer', () => {
   beforeEach(() => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallback = callback;
+        }
+        observe = vi.fn();
+        disconnect = disconnectObserver;
+      },
+    );
     viewSettingsOverride = {};
     readerState.hoveredBookKey = '';
     readerState.bottomBarTab = '';
@@ -81,6 +94,7 @@ describe('TTSMiniPlayer', () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   // #5310: the minimal card is down to one time. Elapsed is the half nobody
@@ -327,22 +341,59 @@ describe('TTSMiniPlayer', () => {
     expect(card.className).not.toContain('pointer-events-none');
   });
 
-  test('rides above an expanded action panel while one is open', () => {
+  test.each([
+    { initialTab: '', cellTop: 0 },
+    { initialTab: 'progress', cellTop: 0 },
+    { initialTab: 'progress', cellTop: 100 },
+  ])('stacks above sliding chrome ($initialTab, cell top $cellTop), then follows folding and resizing', ({
+    initialTab,
+    cellTop,
+  }) => {
+    readerState.bottomBarTab = initialTab;
     readerState.hoveredBookKey = 'b1';
-    readerState.bottomBarTab = 'font';
     const cell = document.createElement('div');
     cell.id = 'gridcell-b1';
+    const footer = document.createElement('div');
+    footer.className = 'footer-bar';
+    footer.style.translate = '0 100%';
     const panel = document.createElement('div');
-    panel.className = 'footerbar-font-mobile';
-    cell.appendChild(panel);
+    panel.className = 'footerbar-progress-mobile';
+    panel.style.translate = '0 100%';
+    footer.appendChild(panel);
+    cell.appendChild(footer);
     document.body.appendChild(cell);
-    cell.getBoundingClientRect = () => ({ bottom: 800, top: 0, height: 800 }) as DOMRect;
-    // Panel settled at 600..736 above the nav bar; no transform in jsdom.
-    panel.getBoundingClientRect = () => ({ top: 600, bottom: 736, height: 136 }) as DOMRect;
+    cell.getBoundingClientRect = () =>
+      ({ bottom: cellTop + 800, top: cellTop, height: 800 }) as DOMRect;
+    Object.defineProperty(footer, 'offsetParent', { value: cellTop ? cell : null });
+    // Fixed footer: offsetTop ignores its own slide. Its 84px height includes
+    // the Android system navigation inset rather than the assumed 64px.
+    Object.defineProperty(footer, 'offsetTop', { value: 716 });
+    footer.getBoundingClientRect = () => ({ top: 800, height: 84 }) as DOMRect;
+    let panelHeight = 200;
+    Object.defineProperty(panel, 'offsetTop', { get: () => -panelHeight });
+    panel.getBoundingClientRect = () => ({ top: 800, height: panelHeight }) as DOMRect;
     try {
-      render(<TTSMiniPlayer {...makeProps()} />);
-      // 800 - 600 + 8px gap; beats the plain above-the-bar offset.
-      expect(screen.getByRole('status').style.bottom).toBe('208px');
+      const { rerender, unmount } = render(<TTSMiniPlayer {...makeProps()} />);
+      expect(screen.getByRole('status').style.bottom).toBe(initialTab ? '292px' : '92px');
+      readerState.bottomBarTab = 'progress';
+      rerender(<TTSMiniPlayer {...makeProps()} />);
+      expect(screen.getByRole('status').style.bottom).toBe('292px');
+
+      // Content/font-size changes can resize the open panel without a tab change.
+      panelHeight = 240;
+      act(() => resizeCallback([], {} as ResizeObserver));
+      expect(screen.getByRole('status').style.bottom).toBe('332px');
+
+      readerState.bottomBarTab = '';
+      rerender(<TTSMiniPlayer {...makeProps()} />);
+      expect(screen.getByRole('status').style.bottom).toBe('92px');
+      readerState.hoveredBookKey = '';
+      rerender(<TTSMiniPlayer {...makeProps()} />);
+      expect(screen.getByRole('status').style.bottom).toBe(
+        `${DEFAULT_BOOK_LAYOUT.marginBottomPx}px`,
+      );
+      unmount();
+      expect(disconnectObserver).toHaveBeenCalled();
     } finally {
       cell.remove();
     }

--- a/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
@@ -137,12 +137,6 @@ const TTSMiniPlayer = ({
   const forceMobileLayout = isForcedMobileLayout(appService?.isMobile);
   const usesMobileBar = forceMobileLayout || window.innerWidth < 640 || window.innerHeight < 640;
 
-  // Distance from the bottom edge (safe-area margin excluded) to the top of
-  // the expanded action panel, so the card rides above it. Measured from the
-  // DOM because panel heights are content-driven and their anchor differs per
-  // platform. The panels' paddings are constant and the slide is
-  // transform-only, so subtracting the in-flight translate yields the settled
-  // top edge even mid-animation.
   // A book can carry a coverImageUrl that no longer resolves (cover never
   // extracted, file pruned). Showing the browser's broken-image glyph in the
   // card is worse than showing no cover at all.
@@ -151,19 +145,34 @@ const TTSMiniPlayer = ({
   const [panelTopOffset, setPanelTopOffset] = useState(0);
   useLayoutEffect(() => {
     const cell = document.getElementById(`gridcell-${bookKey}`);
-    const panel =
-      barVisible && bottomBarTab ? cell?.querySelector(`.footerbar-${bottomBarTab}-mobile`) : null;
-    const rect = panel?.getBoundingClientRect();
-    if (!cell || !panel || !rect || rect.height === 0) {
+    const footer = barVisible ? cell?.querySelector<HTMLElement>('.footer-bar') : null;
+    if (!cell || !footer) {
       setPanelTopOffset(0);
       return;
     }
-    const transform = getComputedStyle(panel).transform;
-    const translateY = transform && transform !== 'none' ? new DOMMatrixReadOnly(transform).m42 : 0;
-    const settledTop = rect.top - translateY;
-    setPanelTopOffset(
-      Math.max(0, Math.round(cell.getBoundingClientRect().bottom - settledTop - safeAreaMargin)),
-    );
+    const panel = bottomBarTab
+      ? footer.querySelector<HTMLElement>(`.footerbar-${bottomBarTab}-mobile`)
+      : null;
+    const measure = () => {
+      // offsetTop ignores both the footer's slide and the panel's CSS translate.
+      // A fixed footer uses viewport coordinates; an absolute footer is relative
+      // to its offset parent (the book cell, including when a sidebar is pinned).
+      const parent = footer.offsetParent;
+      const footerTop =
+        footer.offsetTop + (parent ? parent.getBoundingClientRect().top + parent.clientTop : 0);
+      const settledTop = panel?.getBoundingClientRect().height
+        ? footerTop + footer.clientTop + panel.offsetTop
+        : footerTop;
+      setPanelTopOffset(
+        Math.max(0, Math.round(cell.getBoundingClientRect().bottom - settledTop - safeAreaMargin)),
+      );
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(cell);
+    observer.observe(footer);
+    if (panel) observer.observe(panel);
+    return () => observer.disconnect();
   }, [barVisible, bottomBarTab, bookKey, safeAreaMargin]);
 
   const bottomOffset = viewSettings


### PR DESCRIPTION
Opening a bottom navigation panel could leave the Read Aloud mini player overlapping its controls. The positioning code measured the animated rectangle but only removed `transform`, while Tailwind slides the panels with CSS `translate`.

Measure settled footer and panel layout offsets and observe resizing so the player clears both the folded navigation bar and expanded panels, including taller Android navigation bars. Add regression coverage for opening during the slide, folding, resizing, dismissal, and cell-relative positioning.

## Validation

- Installed and verified on Xiaomi 13: Reading Progress, Font & Layout, and Color expanded/folded; toolbar hidden and reopened with a panel open. Measured approximately 8px clearance in every state.
- Fresh PR-branch checks: 50 focused tests passed; `pnpm lint` passed.
- Full pre-push unit suite on the PR branch: 10,985 passed, 16 skipped. Formatting and lint hooks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the text-to-speech mini-player’s positioning above expanded bottom panels.
  - The player now adjusts automatically when panels resize, fold, or slide across different reader layouts.
  - Improved positioning when optional panels are absent or have no height.
  - Ensured layout tracking is properly cleaned up when the player is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->