### PR TITLE
feat: support authenticated web novel imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
  "pdf",
  "pem",
  "percent-encoding",
+ "psl",
  "quick-xml",
  "rand 0.8.8",
  "read-progress-stream",
@@ -5882,6 +5883,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "psl"
+version = "2.1.231"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62697aa3f75e221e1ecfa35146237f7a3fa7f234b523816734deb198a1b23418"
+dependencies = [
+ "psl-types",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 | **File Association and Open With**         | Quickly open files in Readest in your file browser with one-click.                                                     | ✅         |
 | **Library Management**                     | Organize, sort, and manage your entire ebook library.                                                                  | ✅         |
 | **OPDS/Calibre Integration**               | Integrate OPDS/Calibre to access online libraries and catalogs.                                                        | ✅         |
-| **Web Page Clipping**                      | Open websites, sign in, and clip the displayed page into your library using **From Web Browser** on desktop and mobile. | ✅         |
+| **Web Page Clipping**                      | Open websites, sign in, and clip pages with **From Web Browser**. **From Web Novel** can reuse your browser session to import selected chapters and their images. | ✅         |
 | **Translate with DeepL and Yandex**        | From a single sentence to the entire book—translate instantly.                                                         | ✅         |
 | **Audiobook Support**                      | Extend functionality to play and manage audiobooks.                                                        | ✅           |
 | **Text-to-Speech (TTS) Support**           | Enjoy smooth, multilingual narration—even within a single book.                                                        | ✅         |

--- a/apps/readest-app/docs/architecture.md
+++ b/apps/readest-app/docs/architecture.md
@@ -527,7 +527,9 @@ is small and focused:
 ```
 lib.rs              -> command registration, scope grants, deep links, builder
 main.rs             -> entrypoint
-clip_url.rs         -> clipboard URL extraction
+clip_url.rs         -> rendered web-page capture
+browser_fetch.rs    -> resource requests using the browser session
+browser_cookies_macos.rs -> access to the WebKit cookie store
 dir_scanner.rs      -> recursive directory scan (used by library import)
 transfer_file.rs    -> chunked upload/download for big files
 discord_rpc.rs      -> Discord Rich Presence (desktop only)

--- a/apps/readest-app/docs/architecture.md
+++ b/apps/readest-app/docs/architecture.md
@@ -537,6 +537,14 @@ android/, macos/,
 windows/            -> per-platform glue
 ```
 
+Novel imports and browser-session resource requests reject explicit private IPs
+and local hostnames; native HTTP redirects are checked again before fetching.
+This is a URL guard, not a network sandbox: DNS/proxy resolution and browser
+navigation redirects remain platform-managed. Cancelling a novel import returns
+to its preview immediately; an in-flight rendered capture finishes its bounded
+native cleanup before the next queued capture starts. Desktop capture listeners
+are owned by the command and released on completion, cancellation, or timeout.
+
 Everything else is delegated to **Tauri plugins**, mostly the published
 `tauri-plugin-*` crates:
 

--- a/apps/readest-app/src-tauri/Cargo.toml
+++ b/apps/readest-app/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 semver = "1"
 base64 = "0.22"
+psl = "2" # Validate response cookie domains before updating the browser session.
 minisign-verify = "0.2"
 log = "0.4"
 thiserror = "2"

--- a/apps/readest-app/src-tauri/build.rs
+++ b/apps/readest-app/src-tauri/build.rs
@@ -51,6 +51,7 @@ fn main() {
             "clear_book_presence",
             "clip_url",
             "open_web_browser",
+            "fetch_web_browser_resource",
             "set_web_browser_status",
             "spawn_fresh_browser",
             "verify_update_signature",

--- a/apps/readest-app/src-tauri/capabilities/default.json
+++ b/apps/readest-app/src-tauri/capabilities/default.json
@@ -237,6 +237,7 @@
     "allow-clear-book-presence",
     "allow-clip-url",
     "allow-open-web-browser",
+    "allow-fetch-web-browser-resource",
     "allow-set-web-browser-status",
     "allow-spawn-fresh-browser",
     "allow-verify-update-signature",

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/build.gradle.kts
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 
     defaultConfig {
         minSdk = 21
+        targetSdk = 36 // Keep the instrumented test APK aligned with the app.
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
@@ -49,6 +50,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.browser:browser:1.8.0")
+    implementation("androidx.webkit:webkit:1.14.0")
     implementation("com.google.android.material:material:1.7.0")
     // EncryptedSharedPreferences (sync passphrase keychain backing).
     // Stays on the 1.1.0-alpha line because the stable 1.0.x release

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/androidTest/AndroidManifest.xml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity android:name="com.readest.native_bridge.ClipUrlTestActivity" android:exported="true" />
+    </application>
+</manifest>

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/androidTest/java/ClipUrlDocumentStartTest.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/androidTest/java/ClipUrlDocumentStartTest.kt
@@ -1,0 +1,71 @@
+package com.readest.native_bridge
+
+import android.app.Activity
+import android.content.Intent
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.webkit.WebViewFeature
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+class ClipUrlTestActivity : Activity()
+
+@RunWith(AndroidJUnit4::class)
+class ClipUrlDocumentStartTest {
+    class Probe {
+        val values = LinkedBlockingQueue<String>()
+
+        @JavascriptInterface
+        fun record(value: String) {
+            values.put(value)
+        }
+    }
+
+    @Test
+    fun fingerprintMaskRunsBeforePageScriptsAcrossNavigations() {
+        assumeTrue(WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT))
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = instrumentation.startActivitySync(
+            Intent(instrumentation.targetContext, ClipUrlTestActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+        val probe = Probe()
+        lateinit var webView: WebView
+        instrumentation.runOnMainSync {
+            webView = WebView(activity)
+            activity.setContentView(webView)
+            val controller = ClipUrlController(activity, ClipUrlArgs().apply { interactive = true }) {}
+            // Exercise the controller's actual WebView setup without presenting UI.
+            val configure = ClipUrlController::class.java.getDeclaredMethod("configureWebView", WebView::class.java)
+            configure.isAccessible = true
+            configure.invoke(controller, webView)
+            webView.addJavascriptInterface(probe, "CaptureProbe")
+        }
+        try {
+            for (page in listOf("first", "after-login")) {
+                instrumentation.runOnMainSync {
+                    webView.loadDataWithBaseURL(
+                        "https://readest.example/$page",
+                        "<script>CaptureProbe.record(typeof navigator.webdriver + ':' + location.pathname)</script>",
+                        "text/html", "UTF-8", null,
+                    )
+                }
+                val observed = probe.values.poll(10, TimeUnit.SECONDS)
+                assertTrue("Page script must execute", observed != null)
+                assertEquals("undefined:/$page", observed)
+            }
+        } finally {
+            instrumentation.runOnMainSync {
+                webView.destroy()
+                activity.finish()
+            }
+        }
+    }
+}

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/ClipUrlController.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/ClipUrlController.kt
@@ -49,6 +49,7 @@ class ClipUrlArgs {
     // Interactive mode: show the page with a Cancel/Capture bar instead
     // of the opaque overlay so the user can sign in before capturing.
     var interactive: Boolean? = null
+    var backgroundCapture: Boolean? = null
     var signInHint: String? = null
     var captureLabel: String? = null
     var cancelLabel: String? = null
@@ -143,6 +144,7 @@ class ClipUrlController(
     private var statusLabel: TextView? = null
     private var didFinishOrFail = false
     private var captureFired = false
+    private var completed = false
     private var settled = false
     private val timeoutRunnable = Runnable { onTimeout() }
 
@@ -161,6 +163,23 @@ class ClipUrlController(
     }
 
     private fun presentDialog(act: Activity, urlStr: String) {
+        if (args.backgroundCapture == true && !interactiveMode) {
+            // Keep a real viewport behind the app for layout and lazy loading.
+            // The React import sheet stays visible, focused, and interactive.
+            val wv = WebView(act)
+            configureWebView(wv)
+            wv.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+            wv.isFocusable = false
+            val host = act.findViewById<ViewGroup>(android.R.id.content)
+            host.addView(wv, 0, ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT,
+            ))
+            webView = wv
+            wv.evaluateJavascript(FINGERPRINT_MASK_JS, null)
+            wv.loadUrl(urlStr)
+            mainHandler.postDelayed(timeoutRunnable, HARD_TIMEOUT_MS)
+            return
+        }
         val bg = parseHexColor(args.background ?: DEFAULT_BACKGROUND) ?: Color.BLACK
         val fg = parseHexColor(args.foreground ?: DEFAULT_FOREGROUND) ?: Color.WHITE
 
@@ -439,7 +458,7 @@ class ClipUrlController(
     }
 
     private fun captureOuterHtml() {
-        if (captureFired) return
+        if (captureFired || completed) return
         captureFired = true
         settled = true
         val wv = webView ?: return finish(ClipUrlResult.Failure("WebView vanished before capture"))
@@ -469,6 +488,8 @@ class ClipUrlController(
     }
 
     private fun finish(result: ClipUrlResult) {
+        if (completed) return
+        completed = true
         mainHandler.removeCallbacks(timeoutRunnable)
         try {
             // Persist any session the page established (interactive
@@ -481,6 +502,10 @@ class ClipUrlController(
             webView?.stopLoading()
             webView?.webViewClient = WebViewClient()  // detach our delegate
             dialog?.dismiss()
+            webView?.let { wv ->
+                (wv.parent as? ViewGroup)?.removeView(wv)
+                wv.destroy()
+            }
         } catch (e: Exception) {
             Log.w(TAG, "error tearing down clip_url dialog", e)
         }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/ClipUrlController.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/ClipUrlController.kt
@@ -26,6 +26,8 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
 import app.tauri.annotation.InvokeArg
 import org.json.JSONObject
 import java.lang.ref.WeakReference
@@ -175,7 +177,6 @@ class ClipUrlController(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT,
             ))
             webView = wv
-            wv.evaluateJavascript(FINGERPRINT_MASK_JS, null)
             wv.loadUrl(urlStr)
             mainHandler.postDelayed(timeoutRunnable, HARD_TIMEOUT_MS)
             return
@@ -206,7 +207,6 @@ class ClipUrlController(
 
         val root: View
         if (interactiveMode) {
-            dlg.setOnCancelListener { finish(ClipUrlResult.Failure(CANCELLED_MESSAGE)) }
             dlg.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
             // Back navigates the page history first — sign-in flows hop
             // through several redirects — and only cancels once exhausted.
@@ -272,10 +272,6 @@ class ClipUrlController(
         dialog = dlg
         webView = wv
 
-        // Inject the fingerprint mask before the first navigation so
-        // navigator.webdriver and friends look right when the page's
-        // own scripts run.
-        wv.evaluateJavascript(FINGERPRINT_MASK_JS, null)
         wv.loadUrl(urlStr)
 
         // Interactive capture waits for the user's tap — no deadline.
@@ -294,6 +290,11 @@ class ClipUrlController(
         settings.mediaPlaybackRequiresUserGesture = true
         settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
         wv.setBackgroundColor(parseHexColor(args.background ?: DEFAULT_BACKGROUND) ?: Color.BLACK)
+        // Register for every document, including login redirects. Evaluating on
+        // the initial about:blank page loses the mask at the first navigation.
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
+            WebViewCompat.addDocumentStartJavaScript(wv, FINGERPRINT_MASK_JS, setOf("*"))
+        }
 
         // The CookieManager is app-wide and persistent, so a session the
         // user establishes in the interactive capture flow authenticates

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/ClipUrlController.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/ClipUrlController.kt
@@ -21,6 +21,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.ProgressBar
@@ -174,7 +175,8 @@ class ClipUrlController(
             android.R.style.Theme_Black_NoTitleBar_Fullscreen
         }
         val dlg = Dialog(act, theme)
-        dlg.setCancelable(interactiveMode)
+        dlg.setCancelable(true)
+        dlg.setOnCancelListener { finish(ClipUrlResult.Failure(CANCELLED_MESSAGE)) }
         dlg.setCanceledOnTouchOutside(false)
         dlg.window?.also { window ->
             window.setBackgroundDrawable(ColorDrawable(bg))
@@ -421,6 +423,17 @@ class ClipUrlController(
         status.layoutParams = statusParams
         column.addView(status)
         statusLabel = status
+        val cancel = Button(act)
+        cancel.text = args.cancelLabel ?: "Cancel"
+        cancel.setTextColor(fg)
+        cancel.background = GradientDrawable().apply {
+            setColor(bg)
+            setStroke(dp(act, 1), fg)
+            cornerRadius = dp(act, 6).toFloat()
+        }
+        cancel.minHeight = dp(act, 44)
+        cancel.setOnClickListener { finish(ClipUrlResult.Failure(CANCELLED_MESSAGE)) }
+        column.addView(cancel)
 
         return column
     }
@@ -430,7 +443,7 @@ class ClipUrlController(
         captureFired = true
         settled = true
         val wv = webView ?: return finish(ClipUrlResult.Failure("WebView vanished before capture"))
-        wv.evaluateJavascript("document.documentElement.outerHTML") { result ->
+        wv.evaluateJavascript("(function() { var root = document.documentElement.cloneNode(true); root.setAttribute('data-readest-url', location.href); return root.outerHTML; })()") { result ->
             // `evaluateJavascript` returns the value JSON-encoded, so
             // an HTML string comes back wrapped in quotes with escapes.
             // Parse via JSONObject to recover the raw HTML.

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -1918,6 +1918,31 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
         controller.show()
     }
 
+    /** Called only from Rust. The WebView owns cookie scoping, HttpOnly and persistence. */
+    @Command
+    fun web_browser_cookies(invoke: Invoke) {
+        val args = invoke.parseArgs(WebBrowserCookiesArgs::class.java)
+        activity.runOnUiThread {
+            val manager = android.webkit.CookieManager.getInstance()
+            val updates = args.setCookies ?: emptyArray()
+            fun resolve() {
+                val result = JSObject()
+                result.put("cookies", manager.getCookie(args.url) ?: "")
+                invoke.resolve(result)
+            }
+            if (updates.isEmpty()) resolve()
+            else {
+                var pending = updates.size
+                updates.forEach { cookie ->
+                    manager.setCookie(args.url, cookie) {
+                        pending--
+                        if (pending == 0) resolve()
+                    }
+                }
+            }
+        }
+    }
+
     /** Push an import status into the open browser's banner. */
     @Command
     fun set_web_browser_status(invoke: Invoke) {
@@ -2043,4 +2068,10 @@ class SecureItemSetArgs {
 @app.tauri.annotation.InvokeArg
 class SecureItemGetArgs {
     lateinit var key: String
+}
+
+@InvokeArg
+class WebBrowserCookiesArgs {
+    lateinit var url: String
+    var setCookies: Array<String>? = null
 }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/ClipUrlController.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/ClipUrlController.swift
@@ -288,6 +288,21 @@ final class ClipUrlController: UIViewController, WKNavigationDelegate {
       status.leadingAnchor.constraint(greaterThanOrEqualTo: overlay.leadingAnchor, constant: 24),
       status.trailingAnchor.constraint(lessThanOrEqualTo: overlay.trailingAnchor, constant: -24),
     ])
+    let cancel = UIButton(type: .system)
+    cancel.setTitle(args.resolvedCancelLabel, for: .normal)
+    cancel.setTitleColor(fg, for: .normal)
+    cancel.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+    cancel.translatesAutoresizingMaskIntoConstraints = false
+    cancel.layer.borderWidth = 1
+    cancel.layer.borderColor = fg.cgColor
+    cancel.layer.cornerRadius = 6
+    overlay.addSubview(cancel)
+    NSLayoutConstraint.activate([
+      cancel.widthAnchor.constraint(greaterThanOrEqualToConstant: 96),
+      cancel.topAnchor.constraint(equalTo: status.bottomAnchor, constant: 16),
+      cancel.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
+      cancel.heightAnchor.constraint(greaterThanOrEqualToConstant: 44),
+    ])
     self.overlayView = overlay
   }
 
@@ -362,7 +377,7 @@ final class ClipUrlController: UIViewController, WKNavigationDelegate {
   private func captureOuterHtml() {
     guard !captureFired else { return }
     captureFired = true
-    webView.evaluateJavaScript("document.documentElement.outerHTML") { [weak self] result, error in
+    webView.evaluateJavaScript("(function() { var root = document.documentElement.cloneNode(true); root.setAttribute('data-readest-url', location.href); return root.outerHTML; })()") { [weak self] result, error in
       guard let self = self else { return }
       if let html = result as? String, !html.isEmpty {
         clipLogger.log("clip_url: captured \(html.count, privacy: .public) chars")

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/ClipUrlController.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/ClipUrlController.swift
@@ -21,6 +21,7 @@ class ClipUrlArgs: Decodable {
   // Interactive mode: show the page with a Cancel/Capture bar instead of
   // the opaque overlay so the user can sign in before capturing.
   let interactive: Bool?
+  let backgroundCapture: Bool?
   let signInHint: String?
   let captureLabel: String?
   let cancelLabel: String?
@@ -91,9 +92,10 @@ final class ClipUrlController: UIViewController, WKNavigationDelegate {
 
   private var webView: WKWebView!
   private var overlayView: UIView!
-  private var statusLabel: UILabel!
+  private var statusLabel: UILabel?
   private var didFinishOrFail = false
   private var captureFired = false
+  private var completed = false
   private var timeoutWorkItem: DispatchWorkItem?
 
   init(args: ClipUrlArgs, completion: @escaping (Result<String, ClipUrlError>) -> Void) {
@@ -123,7 +125,7 @@ final class ClipUrlController: UIViewController, WKNavigationDelegate {
       setUpWebView(below: bar)
     } else {
       setUpWebView(below: nil)
-      setUpOverlay()
+      if args.backgroundCapture != true { setUpOverlay() }
     }
     startCapture()
   }
@@ -343,7 +345,7 @@ final class ClipUrlController: UIViewController, WKNavigationDelegate {
     guard !interactiveMode else { return }
     guard !didFinishOrFail else { return }
     didFinishOrFail = true
-    statusLabel.text = args.resolvedCapturingStatus
+    statusLabel?.text = args.resolvedCapturingStatus
     // Settle then capture. Matches the 3 s post-load delay in the
     // desktop init script — long enough for in-flight asset fetches
     // and lazy-load IntersectionObservers to fire.
@@ -375,7 +377,7 @@ final class ClipUrlController: UIViewController, WKNavigationDelegate {
   }
 
   private func captureOuterHtml() {
-    guard !captureFired else { return }
+    guard !captureFired && !completed else { return }
     captureFired = true
     webView.evaluateJavaScript("(function() { var root = document.documentElement.cloneNode(true); root.setAttribute('data-readest-url', location.href); return root.outerHTML; })()") { [weak self] result, error in
       guard let self = self else { return }
@@ -390,6 +392,8 @@ final class ClipUrlController: UIViewController, WKNavigationDelegate {
   }
 
   private func finish(_ result: Result<String, ClipUrlError>) {
+    guard !completed else { return }
+    completed = true
     timeoutWorkItem?.cancel()
     timeoutWorkItem = nil
     // Stop the WebView before dismissing — otherwise its JS keeps
@@ -398,6 +402,13 @@ final class ClipUrlController: UIViewController, WKNavigationDelegate {
     webView?.stopLoading()
     webView?.navigationDelegate = nil
 
+    if args.backgroundCapture == true && !interactiveMode {
+      willMove(toParent: nil)
+      view.removeFromSuperview()
+      removeFromParent()
+      completion(result)
+      return
+    }
     dismiss(animated: true) { [completion] in
       completion(result)
     }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
@@ -1645,7 +1645,17 @@ class NativeBridgePlugin: Plugin {
           invoke.reject(err.message)
         }
       }
-      presenter.present(controller, animated: true)
+      if args.backgroundCapture == true && args.interactive != true {
+        presenter.addChild(controller)
+        controller.view.frame = presenter.view.bounds
+        controller.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        controller.view.isUserInteractionEnabled = false
+        controller.view.accessibilityElementsHidden = true
+        presenter.view.insertSubview(controller.view, at: 0)
+        controller.didMove(toParent: presenter)
+      } else {
+        presenter.present(controller, animated: true)
+      }
     }
   }
 

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
@@ -1692,6 +1692,44 @@ class NativeBridgePlugin: Plugin {
     }
   }
 
+  /// Native-only exchange; session cookies never reach the frontend.
+  @objc public func web_browser_cookies(_ invoke: Invoke) {
+    struct Args: Decodable { let url: String; let setCookies: [String] }
+    let args: Args
+    do { args = try invoke.parseArgs(Args.self) }
+    catch { invoke.reject(error.localizedDescription); return }
+    guard let url = URL(string: args.url), let host = url.host,
+      url.scheme == "https" || url.scheme == "http" else { invoke.reject("Invalid URL"); return }
+    func matchesDomain(_ domain: String) -> Bool {
+      if domain.hasPrefix(".") {
+        return host == String(domain.dropFirst()) || host.hasSuffix(domain)
+      }
+      return domain == host
+    }
+    DispatchQueue.main.async {
+      let store = WKWebsiteDataStore.default().httpCookieStore
+      let group = DispatchGroup()
+      for header in args.setCookies {
+        for cookie in HTTPCookie.cookies(withResponseHeaderFields: ["Set-Cookie": header], for: url) where matchesDomain(cookie.domain) {
+          group.enter()
+          store.setCookie(cookie) { group.leave() }
+        }
+      }
+      group.notify(queue: .main) {
+        store.getAllCookies { cookies in
+          let matching = cookies.filter { cookie in
+            let path = cookie.path
+            let requestPath = url.path.isEmpty ? "/" : url.path
+            return matchesDomain(cookie.domain) && (!cookie.isSecure || url.scheme == "https")
+              && (cookie.expiresDate == nil || cookie.expiresDate! > Date())
+              && (requestPath == path || (requestPath.hasPrefix(path) && (path.hasSuffix("/") || requestPath.dropFirst(path.count).hasPrefix("/"))))
+          }.sorted { $0.path.count > $1.path.count }
+          invoke.resolve(["cookies": matching.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")])
+        }
+      }
+    }
+  }
+
   /// Push an import status (importing / added / failed / unsupported) into
   /// the open browser's banner. No-op when no browser is presented.
   @objc public func set_web_browser_status(_ invoke: Invoke) {

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/mobile.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/mobile.rs
@@ -438,6 +438,10 @@ impl<R: Runtime> NativeBridge<R> {
             .map_err(Into::into)
     }
 
+    pub fn web_browser_cookies(&self, payload: WebBrowserCookiesRequest) -> crate::Result<WebBrowserCookiesResponse> {
+        self.0.run_mobile_plugin("web_browser_cookies", payload).map_err(Into::into)
+    }
+
     /// Push an import status into the open browser's banner.
     pub fn set_web_browser_status(&self, payload: WebBrowserStatusRequest) -> crate::Result<()> {
         self.0

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
@@ -400,6 +400,8 @@ pub struct ClipUrlRequest {
     #[serde(default)]
     pub interactive: Option<bool>,
     #[serde(default)]
+    pub background_capture: Option<bool>,
+    #[serde(default)]
     pub sign_in_hint: Option<String>,
     #[serde(default)]
     pub capture_label: Option<String>,

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
@@ -620,3 +620,15 @@ pub struct ICloudEnsureDownloadedResponse {
     /// "ready" | "notFound" | "timeout"
     pub status: String,
 }
+
+/// Native-only cookie exchange for Android, whose Tauri cookie API is unsupported.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebBrowserCookiesRequest {
+    pub url: String,
+    pub set_cookies: Vec<String>,
+}
+#[derive(Debug, Deserialize)]
+pub struct WebBrowserCookiesResponse {
+    pub cookies: String,
+}

--- a/apps/readest-app/src-tauri/src/browser_cookies_macos.rs
+++ b/apps/readest-app/src-tauri/src/browser_cookies_macos.rs
@@ -1,0 +1,116 @@
+//! Use WebKit directly: Wry's cookie conversion drops the leading dot that
+//! distinguishes a domain cookie from a host-only cookie.
+use cocoa::base::id;
+use objc::{class, msg_send, sel, sel_impl};
+use std::ffi::CStr;
+use tauri::Url;
+
+unsafe fn string(value: id) -> String {
+    let ptr: *const std::os::raw::c_char = unsafe { msg_send![value, UTF8String] };
+    if ptr.is_null() {
+        String::new()
+    } else {
+        unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+pub fn cookies<R: tauri::Runtime>(
+    webview: &tauri::Webview<R>,
+    url: &Url,
+    updates: Vec<String>,
+) -> Result<String, String> {
+    if !updates.is_empty() {
+        let (updated_tx, updated_rx) = std::sync::mpsc::channel();
+        let update_url = url.clone();
+        webview.with_webview(move |native| unsafe {
+            let configuration: id = msg_send![native.inner() as id, configuration];
+            let data_store: id = msg_send![configuration, websiteDataStore];
+            let store: id = msg_send![data_store, httpCookieStore];
+            let url = update_url;
+            let pending = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(1));
+            // Native cookie parsing preserves domain/host-only semantics and expiry.
+            use cocoa::foundation::NSString;
+            let url_string = NSString::alloc(cocoa::base::nil).init_str(url.as_str());
+            let native_url: id = msg_send![class!(NSURL), URLWithString: url_string];
+            let key = NSString::alloc(cocoa::base::nil).init_str("Set-Cookie");
+            for header in updates {
+                let value = NSString::alloc(cocoa::base::nil).init_str(&header);
+                let fields: id = msg_send![class!(NSDictionary), dictionaryWithObject: value forKey: key];
+                let cookies: id = msg_send![class!(NSHTTPCookie), cookiesWithResponseHeaderFields: fields forURL: native_url];
+                let count: usize = msg_send![cookies, count];
+                for index in 0..count {
+                    let cookie: id = msg_send![cookies, objectAtIndex: index];
+                    let domain: id = msg_send![cookie, domain];
+                    if super::browser_fetch::cookie_domain_matches(&string(domain), url.host_str().unwrap_or_default()) {
+                        pending.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        let count = pending.clone();
+                        let done = updated_tx.clone();
+                        let completion = block::ConcreteBlock::new(move || {
+                            if count.fetch_sub(1, std::sync::atomic::Ordering::SeqCst) == 1 { let _ = done.send(()); }
+                        }).copy();
+                        let _: () = msg_send![store, setCookie: cookie completionHandler: &*completion];
+                    }
+                }
+                let _: () = msg_send![value, release];
+            }
+            let _: () = msg_send![key, release];
+            let _: () = msg_send![url_string, release];
+
+            if pending.fetch_sub(1, std::sync::atomic::Ordering::SeqCst) == 1 { let _ = updated_tx.send(()); }
+        }).map_err(|e| e.to_string())?;
+        updated_rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .map_err(|_| "Could not update browser session")?;
+    }
+    let (tx, rx) = std::sync::mpsc::channel();
+    let url = url.clone();
+    webview
+        .with_webview(move |native| unsafe {
+            let configuration: id = msg_send![native.inner() as id, configuration];
+            let data_store: id = msg_send![configuration, websiteDataStore];
+            let store: id = msg_send![data_store, httpCookieStore];
+            let callback = block::ConcreteBlock::new(move |cookies: id| {
+                let count: usize = msg_send![cookies, count];
+                let mut values = Vec::new();
+                for index in 0..count {
+                    let cookie: id = msg_send![cookies, objectAtIndex: index];
+                    let domain: id = msg_send![cookie, domain];
+                    let path: id = msg_send![cookie, path];
+                    let secure: bool = msg_send![cookie, isSecure];
+                    let expires: id = msg_send![cookie, expiresDate];
+                    let expired = !expires.is_null() && {
+                        let remaining: f64 = msg_send![expires, timeIntervalSinceNow];
+                        remaining <= 0.0
+                    };
+                    let path = string(path);
+                    if !expired
+                        && super::browser_fetch::cookie_scope_matches(
+                            &string(domain),
+                            &path,
+                            secure,
+                            &url,
+                        )
+                    {
+                        let name: id = msg_send![cookie, name];
+                        let value: id = msg_send![cookie, value];
+                        values.push((path.len(), format!("{}={}", string(name), string(value))));
+                    }
+                }
+                values.sort_by_key(|(length, _)| std::cmp::Reverse(*length));
+                let _ = tx.send(
+                    values
+                        .into_iter()
+                        .map(|(_, value)| value)
+                        .collect::<Vec<_>>()
+                        .join("; "),
+                );
+            })
+            .copy();
+            let _: () = msg_send![store, getAllCookies: &*callback];
+        })
+        .map_err(|e| e.to_string())?;
+    rx.recv_timeout(std::time::Duration::from_secs(10))
+        .map_err(|_| "Could not read browser session".into())
+}

--- a/apps/readest-app/src-tauri/src/browser_fetch.rs
+++ b/apps/readest-app/src-tauri/src/browser_fetch.rs
@@ -28,7 +28,49 @@ fn resource_url(value: &str) -> Result<Url, String> {
     {
         return Err("Invalid URL".into());
     }
+    // Reject explicit private destinations, including redirect targets. DNS and
+    // proxy resolution are unchanged; this is not a DNS-rebinding defense.
+    let host = url.host_str().unwrap_or_default();
+    let host = host.trim_end_matches('.');
+    let blocked = match host
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .parse::<std::net::IpAddr>()
+    {
+        Ok(std::net::IpAddr::V4(ip)) => blocked_ipv4(ip),
+        Ok(std::net::IpAddr::V6(ip)) => ip.to_ipv4().map(blocked_ipv4).unwrap_or_else(|| {
+            let first = ip.segments()[0];
+            ip.is_unspecified()
+                || ip.is_loopback()
+                || ip.is_multicast()
+                || first & 0xfe00 == 0xfc00
+                || first & 0xffc0 == 0xfe80
+                || first & 0xffc0 == 0xfec0
+        }),
+        Err(_) => {
+            !host.contains('.')
+                || ["localhost", "local", "internal", "lan"]
+                    .iter()
+                    .any(|suffix| host == *suffix || host.ends_with(&format!(".{suffix}")))
+        }
+    };
+    if blocked {
+        return Err("Cannot import from a private network URL".into());
+    }
     Ok(url)
+}
+
+fn blocked_ipv4(ip: std::net::Ipv4Addr) -> bool {
+    let [a, b, c, _] = ip.octets();
+    ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_documentation()
+        || a == 0
+        || a >= 224
+        || (a == 100 && (64..=127).contains(&b))
+        || (a == 192 && b == 0 && c == 0)
+        || (a == 198 && (b == 18 || b == 19))
 }
 
 #[cfg(any(desktop, test))]
@@ -301,6 +343,43 @@ mod tests {
         assert!(resource_url("https://example.org/chapter").is_ok());
     }
     #[test]
+    fn disallows_explicit_private_network_targets() {
+        for url in [
+            "http://localhost/",
+            "http://localhost./",
+            "http://site.local/",
+            "http://intranet/",
+            "http://127.1/",
+            "http://0x7f000001/",
+            "http://10.0.0.1/",
+            "http://172.16.0.1/",
+            "http://192.168.1.1/",
+            "http://169.254.169.254/",
+            "http://100.64.0.1/",
+            "http://198.18.0.1/",
+            "http://224.0.0.1/",
+            "http://240.0.0.1/",
+            "http://[::]/",
+            "http://[::1]/",
+            "http://[fd00::1]/",
+            "http://[fe80::1]/",
+            "http://[ff02::1]/",
+            "http://[::ffff:127.0.0.1]/",
+            "http://[::127.0.0.1]/",
+        ] {
+            assert!(resource_url(url).is_err(), "accepted {url}");
+        }
+        for url in [
+            "https://example.org/",
+            "https://example.org./",
+            "https://1.1.1.1/",
+            "https://[2606:4700:4700::1111]/",
+        ] {
+            assert!(resource_url(url).is_ok(), "rejected {url}");
+        }
+    }
+
+    #[test]
     fn response_cookies_cannot_write_other_sites_or_public_suffixes() {
         let url = Url::parse("https://www.example.co.uk/novel").unwrap();
         assert!(valid_response_cookie(
@@ -339,7 +418,7 @@ mod tests {
                     }
                     1 => {
                         assert!(request.contains("cookie: session=renewed"));
-                        format!("HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{port}/image\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                        format!("HTTP/1.1 302 Found\r\nLocation: http://images.example.org:{port}/image\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
                     }
                     _ => {
                         assert!(!request.contains("cookie:"));
@@ -354,21 +433,23 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(
             "referer",
-            HeaderValue::from_static("http://localhost/private"),
+            HeaderValue::from_static("http://novels.example.org/private"),
         );
         let client = reqwest::Client::builder()
+            .resolve("novels.example.org", ([127, 0, 0, 1], port).into())
+            .resolve("images.example.org", ([127, 0, 0, 1], port).into())
             .no_proxy()
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .unwrap();
         let result = fetch_resource(
             &client,
-            Url::parse(&format!("http://localhost:{port}/chapter")).unwrap(),
+            Url::parse(&format!("http://novels.example.org:{port}/chapter")).unwrap(),
             headers,
             move |url, updated| {
                 let session = session.clone();
                 async move {
-                    if url.host_str() != Some("localhost") {
+                    if url.host_str() != Some("novels.example.org") {
                         return Ok(String::new());
                     }
                     let mut session = session.lock().unwrap();
@@ -385,6 +466,38 @@ mod tests {
         assert_eq!(result.status, 200);
         assert_eq!(result.content_type, "image/png");
         assert_eq!(result.body, "aW1hZ2U=");
+    }
+
+    #[tokio::test]
+    async fn rejects_redirects_to_private_network_targets() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut bytes = [0; 4096];
+            stream.read(&mut bytes).await.unwrap();
+            stream.write_all(b"HTTP/1.1 302 Found\r\nLocation: http://169.254.169.254/latest/meta-data/\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").await.unwrap();
+        });
+        let client = reqwest::Client::builder()
+            .resolve("novels.example.org", address)
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap();
+        let result = fetch_resource(
+            &client,
+            resource_url(&format!(
+                "http://novels.example.org:{}/chapter",
+                address.port()
+            ))
+            .unwrap(),
+            HeaderMap::new(),
+            |_, _| async { Ok(String::new()) },
+        )
+        .await;
+        server.await.unwrap();
+        assert!(matches!(result, Err(message) if message.contains("private network")));
     }
 
     #[test]

--- a/apps/readest-app/src-tauri/src/browser_fetch.rs
+++ b/apps/readest-app/src-tauri/src/browser_fetch.rs
@@ -64,6 +64,16 @@ fn valid_response_cookie(header: &str, url: &Url) -> bool {
         && (host == domain || host.ends_with(&format!(".{domain}")))
 }
 
+#[cfg(any(target_os = "windows", test))]
+fn preserve_windows_cookie_domain(cookie: &mut tauri::webview::Cookie<'_>) {
+    // Wry passes Cookie::domain() to WebView2, but that getter strips one dot.
+    // Keep a dot at the native boundary so explicit Domain cookies retain
+    // subdomain scope. This in-memory adapter is never serialized as a header.
+    if let Some(domain) = cookie.domain() {
+        cookie.set_domain(format!("..{}", domain.trim_start_matches('.')));
+    }
+}
+
 async fn browser_cookies<R: tauri::Runtime>(
     webview: tauri::Webview<R>,
     url: Url,
@@ -97,6 +107,8 @@ async fn browser_cookies<R: tauri::Runtime>(
                         if host != domain && !host.ends_with(&format!(".{domain}")) {
                             continue;
                         }
+                        #[cfg(target_os = "windows")]
+                        preserve_windows_cookie_domain(&mut cookie);
                     } else {
                         cookie.set_domain(host.to_string());
                     }
@@ -259,6 +271,24 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn windows_cookie_renewal_preserves_domain_scope_at_the_wry_boundary() {
+        for header in [
+            "session=renewed; Domain=.example.org",
+            "session=renewed; Domain=example.org",
+        ] {
+            let mut cookie = tauri::webview::Cookie::parse(header).unwrap();
+            preserve_windows_cookie_domain(&mut cookie);
+            // Wry passes domain() directly to WebView2 CreateCookie.
+            assert_eq!(cookie.domain(), Some(".example.org"));
+        }
+        let mut host_only = tauri::webview::Cookie::parse("session=renewed; Path=/").unwrap();
+        preserve_windows_cookie_domain(&mut host_only);
+        assert_eq!(host_only.domain(), None);
+        host_only.set_domain("www.example.org");
+        assert_eq!(host_only.domain(), Some("www.example.org"));
+    }
+
     #[test]
     fn disallows_non_http_and_embedded_credentials() {
         for url in [

--- a/apps/readest-app/src-tauri/src/browser_fetch.rs
+++ b/apps/readest-app/src-tauri/src/browser_fetch.rs
@@ -1,0 +1,399 @@
+//! Native GETs share the browser session without exposing cookies to the frontend.
+use base64::Engine;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, COOKIE, LOCATION, SET_COOKIE};
+use serde::Serialize;
+use std::collections::HashMap;
+#[cfg(mobile)]
+use tauri::Manager;
+use tauri::Url;
+
+const MAX_BYTES: usize = 20 * 1024 * 1024;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserResource {
+    url: String,
+    status: u16,
+    content_type: String,
+    body: String,
+}
+
+// Accept only HTTP(S), also on every redirect. No credentials embedded in URLs.
+fn resource_url(value: &str) -> Result<Url, String> {
+    let url = Url::parse(value).map_err(|_| "Invalid URL")?;
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return Err("Invalid URL".into());
+    }
+    Ok(url)
+}
+
+#[cfg(any(desktop, test))]
+pub(crate) fn cookie_domain_matches(domain: &str, host: &str) -> bool {
+    if domain.is_empty() {
+        return false;
+    }
+    if let Some(domain) = domain.strip_prefix('.') {
+        host == domain || host.ends_with(&format!(".{domain}"))
+    } else {
+        host == domain
+    }
+}
+
+#[cfg(any(desktop, test))]
+pub(crate) fn cookie_scope_matches(domain: &str, path: &str, secure: bool, url: &Url) -> bool {
+    cookie_domain_matches(domain, url.host_str().unwrap_or_default())
+        && (!secure || url.scheme() == "https")
+        && (url.path() == path
+            || (url.path().starts_with(path)
+                && (path.ends_with('/') || url.path()[path.len()..].starts_with('/'))))
+}
+
+fn valid_response_cookie(header: &str, url: &Url) -> bool {
+    let Ok(cookie) = tauri::webview::Cookie::parse(header) else {
+        return false;
+    };
+    let Some(domain) = cookie.domain() else {
+        return true;
+    };
+    let host = url.host_str().unwrap_or_default();
+    psl::domain(domain.as_bytes()).is_some()
+        && (host == domain || host.ends_with(&format!(".{domain}")))
+}
+
+async fn browser_cookies<R: tauri::Runtime>(
+    webview: tauri::Webview<R>,
+    url: Url,
+    set_cookies: Vec<String>,
+) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        #[cfg(mobile)]
+        {
+            use tauri_plugin_native_bridge::{NativeBridgeExt, WebBrowserCookiesRequest};
+            webview
+                .app_handle()
+                .native_bridge()
+                .web_browser_cookies(WebBrowserCookiesRequest {
+                    url: url.to_string(),
+                    set_cookies,
+                })
+                .map(|r| r.cookies)
+                .map_err(|e| e.to_string())
+        }
+        #[cfg(target_os = "macos")]
+        {
+            crate::browser_cookies_macos::cookies(&webview, &url, set_cookies)
+        }
+        #[cfg(all(desktop, not(target_os = "macos")))]
+        {
+            for header in set_cookies {
+                if let Ok(mut cookie) = tauri::webview::Cookie::parse(header) {
+                    let host = url.host_str().unwrap_or_default();
+                    if let Some(domain) = cookie.domain() {
+                        let domain = domain.trim_start_matches('.');
+                        if host != domain && !host.ends_with(&format!(".{domain}")) {
+                            continue;
+                        }
+                    } else {
+                        cookie.set_domain(host.to_string());
+                    }
+                    if cookie.path().is_none() {
+                        let path = url
+                            .path()
+                            .rsplit_once('/')
+                            .map(|(p, _)| p)
+                            .filter(|p| !p.is_empty())
+                            .unwrap_or("/");
+                        cookie.set_path(path.to_string());
+                    }
+                    webview.set_cookie(cookie).map_err(|e| e.to_string())?;
+                }
+            }
+            let cookies = webview
+                .cookies_for_url(url.clone())
+                .map_err(|e| e.to_string())?;
+            Ok(cookies
+                .iter()
+                .filter(|c| {
+                    cookie_scope_matches(
+                        url.host_str().unwrap_or_default(),
+                        c.path().unwrap_or("/"),
+                        c.secure() == Some(true),
+                        &url,
+                    )
+                })
+                .map(|c| format!("{}={}", c.name(), c.value()))
+                .collect::<Vec<_>>()
+                .join("; "))
+        }
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn fetch_web_browser_resource<R: tauri::Runtime>(
+    webview: tauri::Webview<R>,
+    url: String,
+    headers: HashMap<String, String>,
+) -> Result<BrowserResource, String> {
+    let target = resource_url(&url)?;
+    let mut request_headers = HeaderMap::new();
+    for (name, value) in headers {
+        let name = HeaderName::from_bytes(name.as_bytes()).map_err(|e| e.to_string())?;
+        // Only browser-shaped request metadata. Never allow caller-provided credentials.
+        if matches!(
+            name.as_str(),
+            "accept" | "accept-language" | "user-agent" | "referer" | "range"
+        ) || name.as_str().starts_with("sec-")
+        {
+            request_headers.insert(
+                name,
+                HeaderValue::from_str(&value).map_err(|e| e.to_string())?,
+            );
+        }
+    }
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| e.to_string())?;
+    fetch_resource(&client, target, request_headers, move |url, updated| {
+        browser_cookies(webview.clone(), url, updated)
+    })
+    .await
+}
+
+async fn fetch_resource<F, Fut>(
+    client: &reqwest::Client,
+    mut target: Url,
+    mut request_headers: HeaderMap,
+    exchange: F,
+) -> Result<BrowserResource, String>
+where
+    F: Fn(Url, Vec<String>) -> Fut,
+    Fut: std::future::Future<Output = Result<String, String>>,
+{
+    tokio::time::timeout(std::time::Duration::from_secs(15), async {
+        for _ in 0..10 {
+            let cookies = exchange(target.clone(), vec![]).await?;
+            let mut request = client.get(target.clone()).headers(request_headers.clone());
+            if !cookies.is_empty() {
+                request = request.header(COOKIE, cookies);
+            }
+            let mut response = request
+                .send()
+                .await
+                .map_err(|e| e.without_url().to_string())?;
+            let updated = response
+                .headers()
+                .get_all(SET_COOKIE)
+                .iter()
+                .filter_map(|v| v.to_str().ok())
+                .filter(|value| valid_response_cookie(value, &target))
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            if !updated.is_empty() {
+                exchange(target.clone(), updated).await?;
+            }
+            if matches!(response.status().as_u16(), 301 | 302 | 303 | 307 | 308) {
+                let location = response
+                    .headers()
+                    .get(LOCATION)
+                    .and_then(|v| v.to_str().ok())
+                    .ok_or("Missing redirect URL")?;
+                let next = resource_url(
+                    target
+                        .join(location)
+                        .map_err(|_| "Invalid redirect URL")?
+                        .as_str(),
+                )?;
+                if target.scheme() == "https" && next.scheme() != "https" {
+                    return Err("Insecure redirect".into());
+                }
+                if next.origin() != target.origin() {
+                    request_headers.remove("referer");
+                }
+                target = next;
+                continue;
+            }
+            let status = response.status().as_u16();
+            let content_type = response
+                .headers()
+                .get("content-type")
+                .and_then(|h| h.to_str().ok())
+                .unwrap_or("application/octet-stream")
+                .to_string();
+            if response
+                .content_length()
+                .is_some_and(|len| len > MAX_BYTES as u64)
+            {
+                return Err("Resource is too large".into());
+            }
+            let mut bytes = Vec::new();
+            while let Some(chunk) = response
+                .chunk()
+                .await
+                .map_err(|e| e.without_url().to_string())?
+            {
+                if bytes.len() + chunk.len() > MAX_BYTES {
+                    return Err("Resource is too large".into());
+                }
+                bytes.extend_from_slice(&chunk);
+            }
+            return Ok(BrowserResource {
+                url: target.to_string(),
+                status,
+                content_type,
+                body: base64::engine::general_purpose::STANDARD.encode(bytes),
+            });
+        }
+        Err("Too many redirects".into())
+    })
+    .await
+    .map_err(|_| "Request timed out".to_string())?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn disallows_non_http_and_embedded_credentials() {
+        for url in [
+            "file:///secret",
+            "javascript:alert(1)",
+            "https://user:pass@example.org/",
+        ] {
+            assert!(resource_url(url).is_err());
+        }
+        assert!(resource_url("https://example.org/chapter").is_ok());
+    }
+    #[test]
+    fn response_cookies_cannot_write_other_sites_or_public_suffixes() {
+        let url = Url::parse("https://www.example.co.uk/novel").unwrap();
+        assert!(valid_response_cookie(
+            "session=next; HttpOnly; Path=/",
+            &url
+        ));
+        assert!(valid_response_cookie(
+            "session=next; Domain=.example.co.uk",
+            &url
+        ));
+        for cookie in [
+            "session=bad; Domain=.co.uk",
+            "session=bad; Domain=.uk",
+            "session=bad; Domain=other.co.uk",
+        ] {
+            assert!(!valid_response_cookie(cookie, &url));
+        }
+    }
+
+    #[tokio::test]
+    async fn authenticated_get_renews_session_and_does_not_forward_it_on_redirect() {
+        use std::sync::{Arc, Mutex};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            for step in 0..3 {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut bytes = vec![0; 4096];
+                let count = stream.read(&mut bytes).await.unwrap();
+                let request = String::from_utf8_lossy(&bytes[..count]).to_lowercase();
+                let response = match step {
+                    0 => {
+                        assert!(request.contains("cookie: session=original"));
+                        "HTTP/1.1 302 Found\r\nLocation: /renewed\r\nSet-Cookie: session=renewed; Path=/; HttpOnly\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_string()
+                    }
+                    1 => {
+                        assert!(request.contains("cookie: session=renewed"));
+                        format!("HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{port}/image\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                    }
+                    _ => {
+                        assert!(!request.contains("cookie:"));
+                        assert!(!request.contains("referer:"));
+                        "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: 5\r\nConnection: close\r\n\r\nimage".to_string()
+                    }
+                };
+                stream.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+        let session = Arc::new(Mutex::new("session=original".to_string()));
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "referer",
+            HeaderValue::from_static("http://localhost/private"),
+        );
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap();
+        let result = fetch_resource(
+            &client,
+            Url::parse(&format!("http://localhost:{port}/chapter")).unwrap(),
+            headers,
+            move |url, updated| {
+                let session = session.clone();
+                async move {
+                    if url.host_str() != Some("localhost") {
+                        return Ok(String::new());
+                    }
+                    let mut session = session.lock().unwrap();
+                    if let Some(cookie) = updated.first() {
+                        *session = cookie.split(';').next().unwrap().to_string();
+                    }
+                    Ok(session.clone())
+                }
+            },
+        )
+        .await
+        .unwrap();
+        server.await.unwrap();
+        assert_eq!(result.status, 200);
+        assert_eq!(result.content_type, "image/png");
+        assert_eq!(result.body, "aW1hZ2U=");
+    }
+
+    #[test]
+    fn cookies_are_scoped_to_domain_path_and_transport() {
+        for url in [
+            "https://example.org/novel/1",
+            "https://www.example.org/novel",
+        ] {
+            assert!(cookie_scope_matches(
+                ".example.org",
+                "/novel",
+                true,
+                &Url::parse(url).unwrap()
+            ));
+        }
+        for url in [
+            "https://other.org/novel",
+            "https://example.org.evil.org/novel",
+            "https://example.org/novella",
+            "http://example.org/novel",
+        ] {
+            assert!(!cookie_scope_matches(
+                ".example.org",
+                "/novel",
+                true,
+                &Url::parse(url).unwrap()
+            ));
+        }
+        assert!(!cookie_scope_matches(
+            "example.org",
+            "/",
+            false,
+            &Url::parse("https://sub.example.org/").unwrap()
+        ));
+        assert!(!cookie_scope_matches(
+            "",
+            "/",
+            false,
+            &Url::parse("https://example.org/").unwrap()
+        ));
+    }
+}

--- a/apps/readest-app/src-tauri/src/clip_url.rs
+++ b/apps/readest-app/src-tauri/src/clip_url.rs
@@ -49,8 +49,6 @@ use tauri::{Url, WebviewUrl, WebviewWindowBuilder};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 #[cfg(desktop)]
 use tokio::net::TcpListener;
-#[cfg(desktop)]
-use tokio::sync::oneshot;
 
 /// Localised strings and theme colours supplied by the JS caller. Defaults
 /// are English / Readest's dark palette so a caller that omits a field
@@ -180,18 +178,16 @@ fn parse_content_length(headers: &str) -> usize {
 /// `GET /clip/{token}?d={base64-HTML}` — top-level navigation isn't
 /// governed by CSP `connect-src` / `form-action`, and the URL itself
 /// carries the data (so we don't need any cross-origin storage trick).
-/// Server decodes the base64, signals the oneshot, returns a tiny
+/// Server decodes the base64, returns the HTML and a tiny
 /// "captured" page so the user can see the round-trip worked.
 #[cfg(desktop)]
 async fn capture_one(
     listener: TcpListener,
     token: String,
-    tx: oneshot::Sender<String>,
     saved_title: String,
     background: String,
     foreground: String,
-) {
-    let mut tx = Some(tx);
+) -> Option<String> {
     let expected_prefix = format!("/clip/{}", token);
     let saved_title_safe = escape_html(&saved_title);
     // CSS-context escape: the caller-provided colour goes into a
@@ -312,11 +308,9 @@ stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points
         response.extend_from_slice(confirmation.as_bytes());
         let _ = stream.write_all(&response).await;
 
-        if let Some(tx) = tx.take() {
-            let _ = tx.send(html);
-        }
-        break;
+        return Some(html);
     }
+    None
 }
 
 /// Decode a URL-safe base64 string (the JS side uses `btoa` which
@@ -515,22 +509,19 @@ pub async fn clip_url<R: tauri::Runtime>(
         .port();
 
     let token = next_token();
-    let (tx, rx) = oneshot::channel::<String>();
     let token_for_server = token.clone();
     let saved_title_for_server = options.saved_title().to_string();
     let bg_for_server = options.background().to_string();
     let fg_for_server = options.foreground().to_string();
-    tokio::spawn(async move {
-        capture_one(
-            listener,
-            token_for_server,
-            tx,
-            saved_title_for_server,
-            bg_for_server,
-            fg_for_server,
-        )
-        .await;
-    });
+    // Keep the listener owned by this command. Dropping the future on any
+    // early error, cancellation, or timeout closes it instead of detaching it.
+    let capture = capture_one(
+        listener,
+        token_for_server,
+        saved_title_for_server,
+        bg_for_server,
+        fg_for_server,
+    );
 
     let label = format!("clip-{}", token);
     let token_json = serde_json::to_string(&token).map_err(|e| e.to_string())?;
@@ -694,7 +685,7 @@ pub async fn clip_url<R: tauri::Runtime>(
         }
     });
     let result = tokio::select! {
-        result = tokio::time::timeout(Duration::from_secs(30), rx) => result,
+        result = tokio::time::timeout(Duration::from_secs(30), capture) => result,
         _ = cancel_rx => return Err("Capture cancelled".into()),
     };
 
@@ -705,8 +696,8 @@ pub async fn clip_url<R: tauri::Runtime>(
     let _ = webview.close();
 
     match result {
-        Ok(Ok(html)) => Ok(html),
-        Ok(Err(_)) => Err("Webview closed before capture".into()),
+        Ok(Some(html)) => Ok(html),
+        Ok(None) => Err("Webview closed before capture".into()),
         Err(_) => Err("Page took too long to load".into()),
     }
 }
@@ -750,4 +741,68 @@ pub async fn clip_url(
         .clip_url(request)
         .map(|r| r.html)
         .map_err(|e| e.to_string())
+}
+
+#[cfg(all(test, desktop))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn capture_server_releases_its_port_on_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let result = tokio::time::timeout(
+            Duration::from_millis(10),
+            capture_one(
+                listener,
+                "token".into(),
+                "Saved".into(),
+                "#000".into(),
+                "#fff".into(),
+            ),
+        )
+        .await;
+        assert!(result.is_err());
+        // A timed-out capture must not leave a detached accept task holding the port.
+        assert!(TcpListener::bind(address).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn capture_server_releases_its_port_when_cancelled() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::select! {
+            _ = capture_one(listener, "token".into(), "Saved".into(), "#000".into(), "#fff".into()) => panic!("capture should wait for a page"),
+            _ = tokio::task::yield_now() => {},
+        }
+        assert!(TcpListener::bind(address).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn capture_server_returns_html_and_releases_its_port() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let request = async {
+            let mut stream = tokio::net::TcpStream::connect(address).await.unwrap();
+            stream
+                .write_all(b"GET /clip/token?d=aHRtbA== HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                .await
+                .unwrap();
+            let mut response = Vec::new();
+            stream.read_to_end(&mut response).await.unwrap();
+            assert!(response.starts_with(b"HTTP/1.1 200"));
+        };
+        let (html, ()) = tokio::join!(
+            capture_one(
+                listener,
+                "token".into(),
+                "Saved".into(),
+                "#000".into(),
+                "#fff".into()
+            ),
+            request,
+        );
+        assert_eq!(html.as_deref(), Some("html"));
+        assert!(TcpListener::bind(address).await.is_ok());
+    }
 }

--- a/apps/readest-app/src-tauri/src/clip_url.rs
+++ b/apps/readest-app/src-tauri/src/clip_url.rs
@@ -71,6 +71,8 @@ pub struct ClipOptions {
     /// Cancel/Capture bar instead of the opaque overlay so the user can
     /// sign in before capturing. Desktop ignores it.
     pub interactive: Option<bool>,
+    /// Render behind the app while its existing import UI shows progress.
+    pub background_capture: Option<bool>,
     pub sign_in_hint: Option<String>,
     pub capture_label: Option<String>,
     pub cancel_label: Option<String>,
@@ -493,6 +495,7 @@ fn fingerprint_mask_script() -> String {
 #[tauri::command]
 pub async fn clip_url<R: tauri::Runtime>(
     app: AppHandle<R>,
+    _caller: tauri::Window<R>,
     url: String,
     options: Option<ClipOptions>,
 ) -> Result<String, String> {
@@ -603,19 +606,14 @@ pub async fn clip_url<R: tauri::Runtime>(
     const BROWSER_UA: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
                               (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
-    // macOS doesn't honour `.visible(false)` for a WKWebView that needs
-    // its JS timers to keep firing — the public Tauri API can't reach
-    // the private NSWindow flags that would hide it without freezing
-    // scripts. The window IS going to be on screen briefly. Match the
-    // chrome style Readest's main/reader windows use so it doesn't read
-    // as a foreign popup: on macOS the standard window frame with an
-    // overlay (transparent) title bar; on other desktops, decorationless
-    // with a drop shadow. The loading overlay (injected via initialization
-    // script) covers the article render so the user sees a deliberate
-    // "Saving…" state rather than the article flashing by.
+    // macOS novel captures are ordered beneath the caller below, keeping
+    // animation frames active. Other desktops retain visible capture until
+    // their background rendering can be verified as well.
+    let background_capture = cfg!(target_os = "macos") && options.background_capture == Some(true);
     let win_builder = WebviewWindowBuilder::new(&app, &label, WebviewUrl::External(parsed))
         .title(options.window_title())
-        .visible(true)
+        .visible(!background_capture)
+        .focused(!background_capture)
         .center()
         .resizable(false)
         .inner_size(640.0, 480.0)
@@ -661,6 +659,28 @@ pub async fn clip_url<R: tauri::Runtime>(
         Ok(w) => w,
         Err(e) => return Err(format!("Could not create clip webview: {}", e)),
     };
+
+    #[cfg(target_os = "macos")]
+    if options.background_capture == Some(true) {
+        let capture = webview.clone();
+        app.run_on_main_thread(move || {
+            use cocoa::appkit::{NSWindow, NSWindowOrderingMode};
+            use cocoa::base::{id, NO};
+            use cocoa::foundation::NSInteger;
+            use objc::{msg_send, sel, sel_impl};
+            let (Ok(capture), Ok(caller)) = (capture.ns_window(), _caller.ns_window()) else {
+                return;
+            };
+            unsafe {
+                let capture = capture as id;
+                let caller = caller as id;
+                let number: NSInteger = msg_send![caller, windowNumber];
+                capture.setFrame_display_(caller.frame(), NO);
+                capture.orderFrontWindow_relativeTo_(NSWindowOrderingMode::NSWindowBelow, number);
+            }
+        })
+        .map_err(|e| e.to_string())?;
+    }
 
     // 30 s covers a slow page load and a Cloudflare-style JS challenge
     // (5–15 s on bad networks) with margin for the settle delay.
@@ -721,6 +741,7 @@ pub async fn clip_url(
         background: options.background,
         foreground: options.foreground,
         interactive: options.interactive,
+        background_capture: options.background_capture,
         sign_in_hint: options.sign_in_hint,
         capture_label: options.capture_label,
         cancel_label: options.cancel_label,

--- a/apps/readest-app/src-tauri/src/clip_url.rs
+++ b/apps/readest-app/src-tauri/src/clip_url.rs
@@ -549,7 +549,9 @@ pub async fn clip_url<R: tauri::Runtime>(
               if (window.__readest_setStatus__) {{
                 window.__readest_setStatus__(CAPTURING_STATUS);
               }}
-              var html = document.documentElement.outerHTML;
+              var root = document.documentElement.cloneNode(true);
+              root.setAttribute('data-readest-url', location.href);
+              var html = root.outerHTML;
               console.log('[readest-clip] capturing reason=' + reason +
                 ' bytes=' + html.length);
               // Transfer the HTML through the navigation URL itself —
@@ -662,7 +664,19 @@ pub async fn clip_url<R: tauri::Runtime>(
 
     // 30 s covers a slow page load and a Cloudflare-style JS challenge
     // (5–15 s on bad networks) with margin for the settle delay.
-    let result = tokio::time::timeout(Duration::from_secs(30), rx).await;
+    let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
+    let cancel_tx = std::sync::Mutex::new(Some(cancel_tx));
+    webview.on_window_event(move |event| {
+        if matches!(event, tauri::WindowEvent::Destroyed) {
+            if let Some(tx) = cancel_tx.lock().unwrap_or_else(|e| e.into_inner()).take() {
+                let _ = tx.send(());
+            }
+        }
+    });
+    let result = tokio::select! {
+        result = tokio::time::timeout(Duration::from_secs(30), rx) => result,
+        _ = cancel_rx => return Err("Capture cancelled".into()),
+    };
 
     // Always close the clip window after capture (or timeout) — the
     // window flashing on screen for a few seconds is the brief mode

--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -22,6 +22,9 @@ use tauri_plugin_fs::FsExt;
 
 #[cfg(desktop)]
 use tauri::{Listener, Url};
+#[cfg(target_os = "macos")]
+mod browser_cookies_macos;
+mod browser_fetch;
 mod clip_url;
 mod cover_thumbnail;
 mod dir_scanner;
@@ -516,6 +519,7 @@ pub fn run() {
             discord_rpc::clear_book_presence,
             clip_url::clip_url,
             web_browser::open_web_browser,
+            browser_fetch::fetch_web_browser_resource,
             web_browser::set_web_browser_status,
             localsend::commands::localsend_start,
             localsend::commands::localsend_stop,

--- a/apps/readest-app/src-tauri/src/web_browser.rs
+++ b/apps/readest-app/src-tauri/src/web_browser.rs
@@ -244,6 +244,8 @@ pub async fn open_web_browser<R: tauri::Runtime>(
 
     let builder = WebviewWindowBuilder::new(&app, &label, WebviewUrl::External(parsed))
         .title(&title)
+        // Match the session-backed HTTP and rendered chapter fetchers.
+        .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36")
         .inner_size(1100.0, 800.0)
         .min_inner_size(480.0, 360.0)
         .center()

--- a/apps/readest-app/src/__tests__/app/library/import-novel-dialog.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/import-novel-dialog.test.tsx
@@ -30,6 +30,13 @@ vi.mock('@/components/Dialog', () => ({
     ) : null,
 }));
 
+const openWebBrowserMock = vi.fn();
+vi.mock('@/services/webBrowser/webBrowser', () => ({
+  openWebBrowser: (...args: unknown[]) => openWebBrowserMock(...args),
+}));
+vi.mock('@/services/webBrowser/webBrowserOptions', () => ({
+  getWebBrowserOptions: () => ({ labels: {} }),
+}));
 const fetchNovelTocMock = vi.fn();
 const downloadNovelMock = vi.fn();
 vi.mock('@/services/novel/novelImport', () => ({
@@ -98,7 +105,10 @@ describe('ImportNovelDialog', () => {
   it('shows the detected novel in the preview phase', async () => {
     setup();
     await goToPreview();
-    expect(fetchNovelTocMock).toHaveBeenCalledWith('https://n.example.org/toc');
+    expect(fetchNovelTocMock).toHaveBeenCalledWith(
+      'https://n.example.org/toc',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(screen.getByText('Author X')).toBeTruthy();
     expect(screen.getByText('6 chapters')).toBeTruthy();
     expect(screen.getByText('Chapter 1')).toBeTruthy();
@@ -258,4 +268,42 @@ describe('ImportNovelDialog', () => {
     await screen.findByText('No chapters could be downloaded.');
     expect(onImport).not.toHaveBeenCalled();
   });
+});
+
+it('uses the signed-in chapter list and its navigated URL', async () => {
+  setup();
+  const page = { url: 'https://n.example.org/private/toc', html: '<main>Private chapters</main>' };
+  openWebBrowserMock.mockResolvedValue({ page });
+  fireEvent.change(screen.getByPlaceholderText('https://example.com/novel'), {
+    target: { value: 'https://n.example.org/login' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Sign in with Browser' }));
+  await screen.findByText('My Novel');
+  expect(openWebBrowserMock).toHaveBeenCalledWith(
+    'https://n.example.org/login',
+    expect.objectContaining({ labels: expect.objectContaining({ clipPage: 'Use Chapter List' }) }),
+  );
+  expect(fetchNovelTocMock).toHaveBeenCalledWith(
+    page.url,
+    expect.objectContaining({ page: { html: page.html, finalUrl: page.url } }),
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+  await waitFor(() =>
+    expect(downloadNovelMock).toHaveBeenCalledWith(expect.anything(), page.url, expect.anything()),
+  );
+});
+
+it('closing the sign-in browser without capturing does not fetch chapters', async () => {
+  setup();
+  openWebBrowserMock.mockResolvedValue({});
+  fireEvent.change(screen.getByPlaceholderText('https://example.com/novel'), {
+    target: { value: 'https://n.example.org/login' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Sign in with Browser' }));
+  await waitFor(() =>
+    expect(
+      (screen.getByRole('button', { name: 'Fetch Chapters' }) as HTMLButtonElement).disabled,
+    ).toBe(false),
+  );
+  expect(fetchNovelTocMock).not.toHaveBeenCalled();
 });

--- a/apps/readest-app/src/__tests__/app/library/import-novel-dialog.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/import-novel-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ImportNovelDialog from '@/app/library/components/ImportNovelDialog';
@@ -195,8 +195,14 @@ describe('ImportNovelDialog', () => {
     expect(titleInput.value).toBe('My Novel (2 chapters)');
   });
 
-  it('sets download progress to the selected chapter count', async () => {
-    downloadNovelMock.mockImplementation(() => new Promise(() => {}));
+  it('keeps one progress indicator as the selected chapters complete', async () => {
+    let report!: NonNullable<NovelDownloadOptions['onProgress']>;
+    downloadNovelMock.mockImplementation(
+      (_toc: NovelToc, _url: string, options: NovelDownloadOptions) => {
+        report = options.onProgress!;
+        return new Promise(() => {});
+      },
+    );
     setup();
     await goToPreview();
 
@@ -206,6 +212,13 @@ describe('ImportNovelDialog', () => {
 
     await screen.findByText('Downloading chapters…');
     expect(screen.getByText('0 / 4')).toBeTruthy();
+    const progress = screen.getByRole('progressbar', { name: 'Downloading chapters…' });
+    act(() => report(1, 4));
+    expect(screen.getByRole('progressbar')).toBe(progress);
+    expect(screen.getByText('1 / 4')).toBeTruthy();
+    expect(screen.getByText('25%')).toBeTruthy();
+    act(() => report(4, 4));
+    expect(screen.getByText('Preparing your book…')).toBeTruthy();
   });
 
   it('resets selection and title suggestions when reopened', async () => {

--- a/apps/readest-app/src/__tests__/services/novel/novel-import.test.ts
+++ b/apps/readest-app/src/__tests__/services/novel/novel-import.test.ts
@@ -523,7 +523,7 @@ it('uses a captured authenticated table of contents without refetching the login
     fetchPage,
   });
   expect(parsed.chapters[0]?.url).toBe(`${BASE}/novel/7/1`);
-  expect(fetchPage).not.toHaveBeenCalledWith(`${BASE}/login`, expect.anything());
+  expect(fetchPage.mock.calls.map(([url]) => url)).not.toContain(`${BASE}/login`);
 });
 
 it('renders a JavaScript-only chapter using the browser session', async () => {
@@ -607,4 +607,33 @@ it('resolves chapter images against the final website URL instead of the app ori
   );
   expect(html).toContain('src="https://members.example.org/private/cover.png"');
   expect(html).toContain('src="https://members.example.org/novel/figure.png"');
+});
+
+it.each([
+  false,
+  true,
+])('does not fetch or render private chapter URLs (signed in: %s)', async (renderChapters) => {
+  const fetchPage = vi.fn(makeFetchPage());
+  const renderPage = vi.fn(async (url: string) => ({ html: chapterPage(1), finalUrl: url }));
+  const chapters = [
+    'http://127.0.0.1/private',
+    'http://localhost./private',
+    'http://[::ffff:7f00:1]/private',
+  ].map((url) => ({ title: 'Chapter 1', url }));
+  const book = await downloadNovel(toc({ chapters }), TOC_URL, {
+    fetchPage,
+    renderPage,
+    renderChapters,
+  });
+  expect(book.failures).toBe(chapters.length);
+  expect(fetchPage).not.toHaveBeenCalled();
+  expect(renderPage).not.toHaveBeenCalled();
+});
+
+it('rejects a private table of contents before fetching', async () => {
+  const fetchPage = vi.fn(makeFetchPage());
+  await expect(fetchNovelToc('http://localhost./novel/7/', { fetchPage })).rejects.toThrow(
+    'private',
+  );
+  expect(fetchPage).not.toHaveBeenCalled();
 });

--- a/apps/readest-app/src/__tests__/services/novel/novel-import.test.ts
+++ b/apps/readest-app/src/__tests__/services/novel/novel-import.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { configureZip } from '@/utils/zip';
 import {
   decodeHtmlBody,
+  extractChapterHtml,
   downloadNovel,
   fetchNovelToc,
   isNovelImportCancelled,
@@ -145,7 +146,7 @@ describe('downloadNovel', () => {
     expect(stableIdentifier(firstIdentity)).not.toBe(stableIdentifier(secondIdentity));
   });
 
-  it('strips images from chapter content', async () => {
+  it('keeps failed images as placeholders without remote URLs', async () => {
     const page = chapterPage(1).replace(
       '<div id="content">',
       '<div id="content"><img src="https://cdn.example.org/x.jpg"/><figure><img src="/y.png"/></figure>',
@@ -154,7 +155,8 @@ describe('downloadNovel', () => {
       fetchPage: makeFetchPage({ [`${BASE}/novel/7/1`]: page }),
     });
     const files = await unzipEpub(book.file);
-    expect(files.get('OEBPS/chapter1.xhtml')).not.toContain('<img');
+    expect(files.get('OEBPS/chapter1.xhtml')).not.toContain('src="https://cdn.example.org');
+    expect(files.get('OEBPS/chapter1.xhtml')).not.toContain('src="/y.png');
   });
 
   it('keeps going when a chapter fails and inserts a placeholder', async () => {
@@ -503,13 +505,106 @@ describe('defaultFetchPage charset handling', () => {
     const tauriFetch = vi.fn(
       async () => new Response(page, { status: 200, headers: { 'content-type': 'text/html' } }),
     );
-    vi.doMock('@tauri-apps/plugin-http', () => ({ fetch: tauriFetch }));
+    vi.doMock('@/services/webBrowser/browserFetch', () => ({ browserFetch: tauriFetch }));
     try {
       const parsed = await fetchNovelToc('https://www.trxs.cc/tongren/11542.html');
       expect(parsed.title).toBe('福尔摩斯');
       expect(parsed.chapters[0]!.title).toBe('第 1 章');
     } finally {
-      vi.doUnmock('@tauri-apps/plugin-http');
+      vi.doUnmock('@/services/webBrowser/browserFetch');
     }
   });
+});
+
+it('uses a captured authenticated table of contents without refetching the login URL', async () => {
+  const fetchPage = vi.fn(makeFetchPage());
+  const parsed = await fetchNovelToc(`${BASE}/login`, {
+    page: { html: tocPage, finalUrl: TOC_URL },
+    fetchPage,
+  });
+  expect(parsed.chapters[0]?.url).toBe(`${BASE}/novel/7/1`);
+  expect(fetchPage).not.toHaveBeenCalledWith(`${BASE}/login`, expect.anything());
+});
+
+it('renders a JavaScript-only chapter using the browser session', async () => {
+  const renderPage = vi.fn(async (url: string) => ({ html: chapterPage(1), finalUrl: url }));
+  const book = await downloadNovel(toc({ chapters: toc().chapters.slice(0, 1) }), TOC_URL, {
+    fetchPage: async (url) => ({
+      html: '<html><body><div id="app"></div></body></html>',
+      finalUrl: url,
+    }),
+    renderPage,
+  });
+  expect(renderPage).toHaveBeenCalledTimes(1);
+  expect(book.failures).toBe(0);
+  const files = await unzipEpub(book.file);
+  expect([...files.values()].some((html) => html.includes('Chapter 1 paragraph'))).toBe(true);
+});
+
+it('renders a chapter when the HTTP client cannot pass the site challenge', async () => {
+  const renderPage = vi.fn(async (url: string) => ({ html: chapterPage(1), finalUrl: url }));
+  const book = await downloadNovel(toc({ chapters: toc().chapters.slice(0, 1) }), TOC_URL, {
+    fetchPage: async () => {
+      throw new ConversionError('Forbidden', 'fetch_failed');
+    },
+    renderPage,
+  });
+  expect(renderPage).toHaveBeenCalledTimes(1);
+  expect(book.failures).toBe(0);
+});
+
+it('cancels the whole import when a rendered chapter is cancelled', async () => {
+  await expect(
+    downloadNovel(toc(), TOC_URL, {
+      fetchPage: async () => {
+        throw new Error('Login required');
+      },
+      renderPage: async () => {
+        throw new DOMException('Capture cancelled', 'AbortError');
+      },
+    }),
+  ).rejects.toMatchObject({ name: 'AbortError' });
+});
+
+it('bundles chapter illustrations into the EPUB', async () => {
+  const page = chapterPage(1).replace(
+    '<div id="content">',
+    '<div id="content"><img src="data:image/png;base64,aW1hZ2U=" alt="Illustration"/>',
+  );
+  const book = await downloadNovel(toc({ chapters: toc().chapters.slice(0, 1) }), TOC_URL, {
+    fetchPage: makeFetchPage({ [`${BASE}/novel/7/1`]: page }),
+  });
+  const files = await unzipEpub(book.file);
+  expect(files.get('OEBPS/chapter1.xhtml')).toMatch(/src="images\/[a-f0-9]+\.png"/);
+  expect([...files.keys()].some((path) => /images\/[a-f0-9]+\.png$/.test(path))).toBe(true);
+});
+
+it('renders signed-in imports even when HTTP would return a long public preview', async () => {
+  const fetchPage = vi.fn(makeFetchPage());
+  const renderPage = vi.fn(async (url: string) => ({
+    html: chapterPage(1).replaceAll('paragraph', 'PRIVATE paragraph'),
+    finalUrl: url,
+  }));
+  const book = await downloadNovel(toc({ chapters: toc().chapters.slice(0, 1) }), TOC_URL, {
+    fetchPage,
+    renderPage,
+    renderChapters: true,
+  });
+  expect(fetchPage).not.toHaveBeenCalled();
+  const files = await unzipEpub(book.file);
+  expect(files.get('OEBPS/chapter1.xhtml')).toContain('PRIVATE paragraph');
+});
+
+it('resolves chapter images against the final website URL instead of the app origin', () => {
+  const page = chapterPage(1).replace(
+    '<div id="content">',
+    '<div id="content"><img src="/private/cover.png"/><img src="../figure.png"/>',
+  );
+  const html = extractChapterHtml(
+    page,
+    'Chapter 1',
+    'https://members.example.org/novel/chapters/1',
+  );
+  expect(html).toContain('src="https://members.example.org/private/cover.png"');
+  expect(html).toContain('src="https://members.example.org/novel/figure.png"');
 });

--- a/apps/readest-app/src/__tests__/services/novel/render-novel-page.test.ts
+++ b/apps/readest-app/src/__tests__/services/novel/render-novel-page.test.ts
@@ -23,6 +23,12 @@ describe('rendered chapters', () => {
     finish('<html data-readest-url="https://example.org/private/1"><body>signed in</body></html>');
     expect((await first).finalUrl).toBe('https://example.org/private/1');
     expect((await second).finalUrl).toBe('https://example.org/2');
+    expect(invoke).toHaveBeenCalledWith(
+      'clip_url',
+      expect.objectContaining({
+        options: expect.objectContaining({ backgroundCapture: true }),
+      }),
+    );
   });
 
   it('maps native cancellation and skips queued cancelled captures', async () => {
@@ -35,4 +41,27 @@ describe('rendered chapters', () => {
     ).rejects.toMatchObject({ name: 'AbortError' });
     expect(invoke).toHaveBeenCalledTimes(1);
   });
+});
+
+it('cancels promptly while keeping native captures serialized until cleanup', async () => {
+  let finish!: (html: string) => void;
+  invoke.mockImplementationOnce(
+    () =>
+      new Promise<string>((resolve) => {
+        finish = resolve;
+      }),
+  );
+  invoke.mockResolvedValueOnce('<html>next chapter</html>');
+  const controller = new AbortController();
+  const first = renderNovelPage('https://example.org/1', controller.signal);
+  await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(1));
+  const cancelled = expect(first).rejects.toMatchObject({ name: 'AbortError' });
+  controller.abort();
+  await cancelled;
+  const next = renderNovelPage('https://example.org/2');
+  await Promise.resolve();
+  expect(invoke).toHaveBeenCalledTimes(1);
+  finish('<html>cancelled chapter</html>');
+  await next;
+  expect(invoke).toHaveBeenCalledTimes(2);
 });

--- a/apps/readest-app/src/__tests__/services/novel/render-novel-page.test.ts
+++ b/apps/readest-app/src/__tests__/services/novel/render-novel-page.test.ts
@@ -65,3 +65,15 @@ it('cancels promptly while keeping native captures serialized until cleanup', as
   await next;
   expect(invoke).toHaveBeenCalledTimes(2);
 });
+
+it.each([
+  'http://127.0.0.1/chapter',
+  'http://localhost./chapter',
+  'http://[::ffff:7f00:1]/chapter',
+  'http://[::127.0.0.1]/chapter',
+  'http://[fec0::1]/chapter',
+  'http://[ff02::1]/chapter',
+])('rejects private capture targets without opening a native view: %s', async (url) => {
+  await expect(renderNovelPage(url)).rejects.toThrow('private');
+  expect(invoke).not.toHaveBeenCalled();
+});

--- a/apps/readest-app/src/__tests__/services/novel/render-novel-page.test.ts
+++ b/apps/readest-app/src/__tests__/services/novel/render-novel-page.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+const invoke = vi.hoisted(() => vi.fn());
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+vi.mock('@/services/send/clipOptions', () => ({ getClipOptions: () => ({}) }));
+import { renderNovelPage } from '@/services/novel/renderNovelPage';
+beforeEach(() => {
+  invoke.mockReset();
+});
+
+describe('rendered chapters', () => {
+  it('serializes native capture and preserves navigation', async () => {
+    let finish!: (html: string) => void;
+    invoke.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    invoke.mockResolvedValueOnce('<html><body>second</body></html>');
+    const first = renderNovelPage('https://example.org/1');
+    const second = renderNovelPage('https://example.org/2');
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(1));
+    finish('<html data-readest-url="https://example.org/private/1"><body>signed in</body></html>');
+    expect((await first).finalUrl).toBe('https://example.org/private/1');
+    expect((await second).finalUrl).toBe('https://example.org/2');
+  });
+
+  it('maps native cancellation and skips queued cancelled captures', async () => {
+    invoke.mockRejectedValueOnce('Capture cancelled');
+    await expect(renderNovelPage('https://example.org/1')).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+    await expect(
+      renderNovelPage('https://example.org/2', AbortSignal.abort()),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/webBrowser/browserFetch.test.ts
+++ b/apps/readest-app/src/__tests__/services/webBrowser/browserFetch.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const invoke = vi.hoisted(() => vi.fn());
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+import { browserFetch } from '@/services/webBrowser/browserFetch';
+
+beforeEach(() => {
+  invoke.mockReset();
+});
+
+describe('browser session requests', () => {
+  it('returns binary content and the final URL without exposing cookies', async () => {
+    invoke.mockResolvedValue({
+      url: 'https://example.org/chapter/1',
+      status: 200,
+      contentType: 'text/html; charset=gbk',
+      body: btoa('signed in'),
+    });
+    const response = await browserFetch('https://example.org/redirect', {
+      headers: { Referer: 'https://example.org/toc' },
+    });
+    expect(invoke).toHaveBeenCalledWith('fetch_web_browser_resource', {
+      url: 'https://example.org/redirect',
+      headers: { referer: 'https://example.org/toc' },
+    });
+    expect(response.url).toBe('https://example.org/chapter/1');
+    expect(response.headers.get('content-type')).toBe('text/html; charset=gbk');
+    expect(await response.text()).toBe('signed in');
+  });
+
+  it('preserves an authentication failure status for the importer', async () => {
+    invoke.mockResolvedValue({
+      url: 'https://example.org/private',
+      status: 401,
+      body: '',
+      contentType: 'text/html',
+    });
+    expect((await browserFetch('https://example.org/private')).status).toBe(401);
+  });
+
+  it('stops awaiting a request when cancelled', async () => {
+    invoke.mockReturnValue(new Promise(() => {}));
+    const controller = new AbortController();
+    const pending = browserFetch('https://example.org/private', { signal: controller.signal });
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('does not start an already cancelled request', async () => {
+    await expect(
+      browserFetch('https://example.org/private', { signal: AbortSignal.abort() }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/tauri/app-command-acl.test.ts
+++ b/apps/readest-app/src/__tests__/tauri/app-command-acl.test.ts
@@ -40,3 +40,16 @@ describe('cover thumbnail app-command ACL (#5632)', () => {
     expect(readCapabilityPermissions('webdriver-remote.json')).toContain(PERMISSION);
   });
 });
+
+it('allows browser-session requests only in local app windows', () => {
+  expect(manifestCommands).toContain('fetch_web_browser_resource');
+  expect(readCapabilityPermissions('default.json')).toContain('allow-fetch-web-browser-resource');
+  expect(readCapabilityPermissions('webdriver-remote.json')).not.toContain(
+    'allow-fetch-web-browser-resource',
+  );
+  const capability = JSON.parse(
+    readFileSync(resolve(process.cwd(), 'src-tauri/capabilities/default.json'), 'utf-8'),
+  ) as { windows: string[] };
+  expect(capability.windows).not.toContain('browser-*');
+  expect(capability.windows).not.toContain('*');
+});

--- a/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
@@ -1654,13 +1654,18 @@ describe('CapturedPageTurn two-column curl (browser)', () => {
     uncover.mockImplementation(async () => {
       clipAtUncover = overlay()?.style.clipPath ?? null;
     });
-    await makeController().turn(true, false, 'curl');
+    // Hold the leaf until uncover instead of racing the 40 ms turn against
+    // capture and paint frames on a loaded runner.
+    const turn = makeController();
+    expect(await turn.beginDrag(true, false, 'curl')).toBe(true);
     await vi.waitFor(() => expect(uncover).toHaveBeenCalledTimes(1));
 
     // The left (inner) column is cut away, the right leaf stays covered.
     expect(clipDuringCapture).toMatch(/^inset\(0(px)? 0(px)? 0(px)? 50%\)$/);
     // Restored before the native cover comes down.
     expect(clipAtUncover).toBe('');
+    await turn.endDrag(true);
+    expect(overlay()).toBeNull();
   });
 
   it('lands a backward leaf on the right column', async () => {

--- a/apps/readest-app/src/app/library/components/ImportNovelDialog.tsx
+++ b/apps/readest-app/src/app/library/components/ImportNovelDialog.tsx
@@ -385,28 +385,48 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
         )}
 
         {phase === 'downloading' && (
-          <>
-            <p className='text-base-content/60 text-sm leading-relaxed'>
-              {_('Downloading chapters…')}
-            </p>
-            <progress
-              className='progress eink-bordered w-full'
-              value={progress.done}
-              max={progress.total || 1}
-            />
-            <p className='text-base-content/60 text-sm'>
-              {progress.done} / {progress.total}
-            </p>
-            <div className='flex justify-end gap-2 pt-1'>
+          <div className='flex flex-col gap-8 py-6'>
+            <div className='flex items-start gap-4'>
+              <MdMenuBook
+                aria-hidden='true'
+                className='text-base-content/70 mt-1 h-8 w-8 shrink-0'
+              />
+              <div className='min-w-0 space-y-1'>
+                <p className='break-words text-lg font-semibold leading-snug'>{bookTitle}</p>
+                <p className='text-base-content/60 text-sm'>{_('Downloading chapters…')}</p>
+              </div>
+            </div>
+            <div className='space-y-3'>
+              <div className='flex justify-between gap-4 text-sm tabular-nums' role='status'>
+                <span className='text-base-content/70'>
+                  {progress.done} / {progress.total}
+                </span>
+                <span className='font-medium'>
+                  {Math.round((progress.done / (progress.total || 1)) * 100)}%
+                </span>
+              </div>
+              <progress
+                aria-label={_('Downloading chapters…')}
+                className='progress eink-bordered block h-2 w-full'
+                value={progress.done}
+                max={progress.total || 1}
+              />
+              <p className='text-base-content/60 text-sm leading-relaxed'>
+                {progress.done === progress.total
+                  ? _('Preparing your book…')
+                  : _('Keep Readest open until the import is complete.')}
+              </p>
+            </div>
+            <div className='flex justify-center'>
               <button
                 type='button'
-                className='btn btn-ghost btn-sm eink-bordered'
+                className='btn btn-ghost eink-bordered min-h-11 px-6'
                 onClick={() => abortRef.current?.abort()}
               >
                 {_('Cancel')}
               </button>
             </div>
-          </>
+          </div>
         )}
       </div>
     </Dialog>

--- a/apps/readest-app/src/app/library/components/ImportNovelDialog.tsx
+++ b/apps/readest-app/src/app/library/components/ImportNovelDialog.tsx
@@ -6,6 +6,9 @@ import Dialog from '@/components/Dialog';
 import { useTranslation } from '@/hooks/useTranslation';
 import { eventDispatcher } from '@/utils/event';
 import { downloadNovel, fetchNovelToc, isNovelImportCancelled } from '@/services/novel/novelImport';
+import { openWebBrowser } from '@/services/webBrowser/webBrowser';
+import { getWebBrowserOptions } from '@/services/webBrowser/webBrowserOptions';
+import type { WebBrowserPage } from '@/services/webBrowser/webBrowser';
 import type { NovelToc } from '@/services/novel/chapterList';
 
 interface ImportNovelDialogProps {
@@ -30,6 +33,7 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
   const [phase, setPhase] = useState<Phase>('url');
   const [toc, setToc] = useState<NovelToc | null>(null);
   const [sourceUrl, setSourceUrl] = useState('');
+  const [renderChapters, setRenderChapters] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [progress, setProgress] = useState({ done: 0, total: 0 });
@@ -39,6 +43,7 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
   const [bookTitle, setBookTitle] = useState('');
   const [titleEdited, setTitleEdited] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+  const requestRef = useRef(0);
 
   const chapters = toc?.chapters ?? [];
 
@@ -49,15 +54,21 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
     setPhase('url');
     setToc(null);
     setSourceUrl('');
+    setRenderChapters(false);
     setBusy(false);
     setError(null);
     setProgress({ done: 0, total: 0 });
     setSelectedChapterIndexes(new Set());
     setBookTitle('');
     setTitleEdited(false);
+    return () => {
+      requestRef.current++;
+      abortRef.current?.abort();
+    };
   }, [isOpen]);
 
   const close = () => {
+    requestRef.current++;
     abortRef.current?.abort();
     onClose();
   };
@@ -99,27 +110,63 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
     if (toc && !titleEdited) setBookTitle(suggestedBookTitle(toc, selected));
   };
 
-  const fetchToc = async () => {
-    const target = url.trim();
+  const fetchToc = async (page?: WebBrowserPage) => {
+    const target = page?.url ?? url.trim();
     if (!/^https?:\/\//i.test(target)) {
       setError(_('Enter a URL starting with http:// or https://'));
       return;
     }
+    const request = ++requestRef.current;
+    const controller = new AbortController();
+    abortRef.current = controller;
     setBusy(true);
     setError(null);
     try {
-      const parsed = await fetchNovelToc(target);
+      const parsed = await fetchNovelToc(target, {
+        signal: controller.signal,
+        ...(page ? { page: { html: page.html, finalUrl: page.url } } : {}),
+      });
+      if (request !== requestRef.current || controller.signal.aborted) return;
       const selected = new Set(parsed.chapters.map((_, index) => index));
       setToc(parsed);
       setSourceUrl(target);
+      setRenderChapters(!!page);
       setSelectedChapterIndexes(selected);
       setBookTitle(suggestedBookTitle(parsed, selected));
       setTitleEdited(false);
       setPhase('preview');
     } catch (e) {
-      surfaceError(e);
+      if (request === requestRef.current && !isNovelImportCancelled(e)) surfaceError(e);
     } finally {
-      setBusy(false);
+      if (request === requestRef.current) {
+        setBusy(false);
+        abortRef.current = null;
+      }
+    }
+  };
+
+  const signIn = async () => {
+    const target = url.trim();
+    if (busy || !/^https?:\/\//i.test(target)) {
+      if (!busy) setError(_('Enter a URL starting with http:// or https://'));
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    const request = ++requestRef.current;
+    try {
+      const options = getWebBrowserOptions(_, document.documentElement.dataset['eink'] === 'true');
+      options.labels.clipPage = _('Use Chapter List');
+      const result = await openWebBrowser(target, options);
+      if (request !== requestRef.current) return;
+      if (result.page) {
+        setUrl(result.page.url);
+        await fetchToc(result.page);
+      }
+    } catch (e) {
+      if (request === requestRef.current) surfaceError(e);
+    } finally {
+      if (request === requestRef.current) setBusy(false);
     }
   };
 
@@ -142,6 +189,7 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
       const book = await downloadNovel(selectedToc, sourceUrl, {
         signal: controller.signal,
         identityKey,
+        renderChapters,
         translate: _,
         onProgress: (done, total) => setProgress({ done, total }),
       });
@@ -150,6 +198,7 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
         setError(_('No chapters could be downloaded.'));
         return;
       }
+      if (controller.signal.aborted) return;
       await onImport(book.file);
       if (book.failures > 0) {
         eventDispatcher.dispatch('toast', {
@@ -193,7 +242,7 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
           <>
             <p className='text-base-content/60 text-sm leading-relaxed'>
               {_(
-                'Paste the link to a web novel’s chapter list. Readest downloads the chapters and saves them as a book.',
+                'Paste the link to a web novel’s chapter list. For members-only sites, sign in with Browser, open the chapter list, then choose Use Chapter List.',
               )}
             </p>
             <input
@@ -209,7 +258,7 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
               }}
             />
             {error && <p className='text-error text-sm leading-relaxed'>{error}</p>}
-            <div className='flex justify-end gap-2 pt-1'>
+            <div className='flex flex-wrap justify-end gap-2 pt-1'>
               <button
                 type='button'
                 className='btn btn-ghost btn-sm eink-bordered'
@@ -217,6 +266,14 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
                 disabled={busy}
               >
                 {_('Cancel')}
+              </button>
+              <button
+                type='button'
+                className='btn btn-ghost btn-sm eink-bordered'
+                onClick={() => void signIn()}
+                disabled={busy || !url.trim()}
+              >
+                {_('Sign in with Browser')}
               </button>
               <button
                 type='button'

--- a/apps/readest-app/src/services/novel/novelImport.ts
+++ b/apps/readest-app/src/services/novel/novelImport.ts
@@ -1,5 +1,5 @@
-import { renderNovelPage } from './renderNovelPage';
-import { bundleAssets } from '@/services/send/conversion/assetBundler';
+import { assertNovelUrlAllowed, renderNovelPage } from './renderNovelPage';
+import { bundleAssets, MAX_TOTAL_ASSET_BYTES } from '@/services/send/conversion/assetBundler';
 import { Readability } from '@mozilla/readability';
 import { sanitizeHtml } from '@/utils/sanitize';
 import { detectLanguage } from '@/utils/lang';
@@ -90,6 +90,7 @@ const TRANSIENT_BACKOFF_MS = 1000;
 const withTransientRetry =
   (fetchPage: FetchPage): FetchPage =>
   async (url, signal) => {
+    assertNovelUrlAllowed(url);
     for (let attempt = 0; ; attempt++) {
       const deadline = new AbortController();
       const onAbort = () => deadline.abort();
@@ -250,6 +251,7 @@ export async function fetchNovelToc(
 ): Promise<NovelToc> {
   const fetchPage = withTransientRetry(options.fetchPage ?? defaultFetchPage);
   const { html, finalUrl } = options.page ?? (await fetchPage(url, options.signal));
+  assertNovelUrlAllowed(finalUrl);
   const toc = parseChapterList(html, finalUrl);
   if (!toc) {
     throw new ConversionError(
@@ -384,7 +386,7 @@ export async function downloadNovel(
     const total = chapters.length;
     const results: EpubChapter[] = new Array(total);
     const images: EpubImage[][] = new Array(total);
-    let remainingAssetBytes = 30 * 1024 * 1024;
+    let remainingAssetBytes = MAX_TOTAL_ASSET_BYTES;
     let assetQueue: Promise<unknown> = Promise.resolve();
     const renderPage =
       options.renderPage ??
@@ -418,6 +420,7 @@ export async function downloadNovel(
         const link = chapters[index]!;
         let html: string | null = null;
         try {
+          assertNovelUrlAllowed(link.url);
           let page: FetchedPage;
           let rendered = false;
           try {
@@ -441,6 +444,7 @@ export async function downloadNovel(
           }
           html = extractChapterHtml(page.html, link.title, page.finalUrl);
           if (html === null && renderPage && !rendered) {
+            assertNovelUrlAllowed(page.finalUrl);
             page = await renderPage(page.finalUrl, signal);
             html = extractChapterHtml(page.html, link.title, page.finalUrl);
           }

--- a/apps/readest-app/src/services/novel/novelImport.ts
+++ b/apps/readest-app/src/services/novel/novelImport.ts
@@ -1,11 +1,14 @@
+import { renderNovelPage } from './renderNovelPage';
+import { bundleAssets } from '@/services/send/conversion/assetBundler';
 import { Readability } from '@mozilla/readability';
-import { sanitizeHtml, sanitizeForParsing } from '@/utils/sanitize';
+import { sanitizeHtml } from '@/utils/sanitize';
 import { detectLanguage } from '@/utils/lang';
 import { stubTranslation as _ } from '@/utils/misc';
 import { buildEpub } from '@/services/send/conversion/buildEpub';
 import { generateCoverSvg } from '@/services/send/conversion/coverGenerator';
 import { fetchAuthorImage } from '@/services/send/conversion/faviconFetcher';
 import {
+  parsePageDocument,
   safeFileName,
   stableIdentifier,
   stripTags,
@@ -54,6 +57,9 @@ export interface NovelDownloadOptions {
   identityKey?: string;
   fetchPage?: FetchPage;
   fetchCover?: FetchCover;
+  renderPage?: FetchPage;
+  /** Sign-in imports render every chapter, including sites with long public previews. */
+  renderChapters?: boolean;
   /** Runtime translator for text baked into the EPUB (failure placeholders).
    *  Strings are declared with `stubTranslation` so the i18n scanner sees
    *  them; pass the app's `_` to localize. */
@@ -195,13 +201,12 @@ export function decodeHtmlBody(bytes: Uint8Array, contentType: string | null): s
 }
 
 /**
- * Fetch a page over the Tauri HTTP client with browser-shaped headers.
- * Novel-site chapter pages are server-rendered, so plain HTTP is enough —
- * spawning a `clip_url` webview per chapter would never scale to hundreds
- * of requests.
+ * Fetch server-rendered chapters with the browser session and browser-shaped
+ * headers. JavaScript-only chapters fall back to the native renderer; imports
+ * started through sign-in render every chapter so public previews cannot win.
  */
 const defaultFetchPage: FetchPage = async (url, signal) => {
-  const { fetch: tauriFetch } = await import('@tauri-apps/plugin-http');
+  const { browserFetch: tauriFetch } = await import('@/services/webBrowser/browserFetch');
   const res = await tauriFetch(url, {
     headers: pageNavigateHeaders(),
     signal,
@@ -232,6 +237,8 @@ const defaultFetchCover: FetchCover = (url, referer) =>
   fetchAuthorImage(url, referer).catch(() => null);
 
 export interface FetchNovelTocOptions {
+  /** The chapter list captured after the user signs in and navigates. */
+  page?: FetchedPage;
   fetchPage?: FetchPage;
   signal?: AbortSignal;
 }
@@ -242,7 +249,7 @@ export async function fetchNovelToc(
   options: FetchNovelTocOptions = {},
 ): Promise<NovelToc> {
   const fetchPage = withTransientRetry(options.fetchPage ?? defaultFetchPage);
-  const { html, finalUrl } = await fetchPage(url, options.signal);
+  const { html, finalUrl } = options.page ?? (await fetchPage(url, options.signal));
   const toc = parseChapterList(html, finalUrl);
   if (!toc) {
     throw new ConversionError(
@@ -312,21 +319,24 @@ const normalizeTitle = (s: string): string => s.replace(/\s+/g, ' ').trim().toLo
 
 /**
  * Extract one chapter's prose. Readability first, known content selectors as
- * fallback; images are stripped (a novel EPUB stays self-contained without an
- * unbounded asset download) and the TOC's chapter title is prepended as the
+ * fallback; assets are bundled separately and the TOC's chapter title is prepended as the
  * canonical heading.
  */
-export function extractChapterHtml(pageHtml: string, chapterTitle: string): string | null {
+export function extractChapterHtml(
+  pageHtml: string,
+  chapterTitle: string,
+  pageUrl: string,
+): string | null {
   let content: string | null = null;
   try {
     // Readability mutates the document it scores, so give it its own parse.
-    const doc = new DOMParser().parseFromString(sanitizeForParsing(pageHtml), 'text/html');
+    const doc = parsePageDocument(pageHtml, pageUrl);
     content = new Readability(doc).parse()?.content ?? null;
   } catch {
     content = null;
   }
   if (!content || stripTags(content).length < CHAPTER_QUALITY_FLOOR) {
-    const doc = new DOMParser().parseFromString(sanitizeForParsing(pageHtml), 'text/html');
+    const doc = parsePageDocument(pageHtml, pageUrl);
     for (const selector of CHAPTER_CONTENT_SELECTORS) {
       const el = doc.querySelector(selector);
       if (el && stripTags(el.innerHTML).length >= CHAPTER_QUALITY_FLOOR) {
@@ -338,7 +348,7 @@ export function extractChapterHtml(pageHtml: string, chapterTitle: string): stri
   if (!content || stripTags(content).length < CHAPTER_QUALITY_FLOOR) return null;
 
   const body = new DOMParser().parseFromString(content, 'text/html').body;
-  body.querySelectorAll('img, picture, figure, svg, video, audio').forEach((el) => el.remove());
+  body.querySelectorAll('video, audio').forEach((el) => el.remove());
   // Drop a leading heading that duplicates the TOC title — the canonical
   // heading is prepended below.
   const heading = body.querySelector('h1, h2, h3');
@@ -361,98 +371,174 @@ export async function downloadNovel(
   const fetchPage = withTransientRetry(options.fetchPage ?? defaultFetchPage);
   const fetchCover = options.fetchCover ?? defaultFetchCover;
   const translate = options.translate ?? ((key: string) => key);
-  const { onProgress, signal, identityKey = sourceUrl } = options;
+  const { onProgress, identityKey = sourceUrl } = options;
+  const controller = new AbortController();
+  const signal = controller.signal;
+  const onAbort = () => controller.abort();
+  options.signal?.addEventListener('abort', onAbort, { once: true });
+  if (options.signal?.aborted) controller.abort();
+  try {
+    signal.throwIfAborted();
 
-  const chapters = toc.chapters.slice(0, MAX_NOVEL_CHAPTERS);
-  const total = chapters.length;
-  const results: EpubChapter[] = new Array(total);
-  let failures = 0;
-  let done = 0;
-  let cursor = 0;
+    const chapters = toc.chapters.slice(0, MAX_NOVEL_CHAPTERS);
+    const total = chapters.length;
+    const results: EpubChapter[] = new Array(total);
+    const images: EpubImage[][] = new Array(total);
+    let remainingAssetBytes = 30 * 1024 * 1024;
+    let assetQueue: Promise<unknown> = Promise.resolve();
+    const renderPage =
+      options.renderPage ??
+      (!options.fetchPage
+        ? (url: string, signal?: AbortSignal) => renderNovelPage(url, signal, translate)
+        : undefined);
+    let failures = 0;
+    let done = 0;
+    let cursor = 0;
 
-  const fetchChapter = async (url: string): Promise<FetchedPage> => {
-    try {
-      return await fetchPage(url, signal);
-    } catch (err) {
-      // One retry on transient network errors; user cancellation propagates.
-      if (isNovelImportCancelled(err) || signal?.aborted) throw abortError();
-      // A 52x has already been retried with backoff — don't double up.
-      if (isTransientFetchError(err)) throw err;
-      return await fetchPage(url, signal);
-    }
-  };
-
-  const worker = async () => {
-    while (true) {
-      if (signal?.aborted) throw abortError();
-      const index = cursor++;
-      if (index >= total) return;
-      const link = chapters[index]!;
-      let html: string | null = null;
+    const fetchChapter = async (url: string): Promise<FetchedPage> => {
       try {
-        const page = await fetchChapter(link.url);
-        html = extractChapterHtml(page.html, link.title);
+        return await fetchPage(url, signal);
       } catch (err) {
-        if (isNovelImportCancelled(err) || signal?.aborted) throw abortError();
-        html = null;
+        // One retry on transient network errors; user cancellation propagates.
+        if (isNovelImportCancelled(err) || signal.aborted) {
+          controller.abort();
+          throw abortError();
+        }
+        // A 52x has already been retried with backoff — don't double up.
+        if (isTransientFetchError(err)) throw err;
+        return await fetchPage(url, signal);
       }
-      if (html === null) {
-        failures++;
-        html =
-          `<h1>${escapeHtml(link.title)}</h1>` +
-          `<p>${escapeHtml(translate(_('This chapter could not be downloaded.')))}</p>` +
-          `<p><a href="${escapeHtml(link.url)}">${escapeHtml(link.url)}</a></p>`;
+    };
+
+    const worker = async () => {
+      while (true) {
+        if (signal?.aborted) throw abortError();
+        const index = cursor++;
+        if (index >= total) return;
+        const link = chapters[index]!;
+        let html: string | null = null;
+        try {
+          let page: FetchedPage;
+          let rendered = false;
+          try {
+            if (options.renderChapters && renderPage) {
+              page = await renderPage(link.url, signal);
+              rendered = true;
+            } else {
+              page = await fetchChapter(link.url);
+            }
+          } catch (err) {
+            if (
+              signal?.aborted ||
+              isNovelImportCancelled(err) ||
+              !renderPage ||
+              options.renderChapters ||
+              isTransientFetchError(err)
+            )
+              throw err;
+            page = await renderPage(link.url, signal);
+            rendered = true;
+          }
+          html = extractChapterHtml(page.html, link.title, page.finalUrl);
+          if (html === null && renderPage && !rendered) {
+            page = await renderPage(page.finalUrl, signal);
+            html = extractChapterHtml(page.html, link.title, page.finalUrl);
+          }
+          if (html !== null) {
+            const content = html;
+            const bundled = assetQueue.then(async () => {
+              if (signal?.aborted) throw abortError();
+              const bundle = await bundleAssets(content, page.finalUrl, {
+                maxBytes: remainingAssetBytes,
+                signal,
+              });
+              remainingAssetBytes -= bundle.images.reduce(
+                (sum, image) => sum + image.bytes.byteLength,
+                0,
+              );
+              return bundle;
+            });
+            assetQueue = bundled.catch(() => {});
+            const bundle = await bundled;
+            html = bundle.html;
+            images[index] = bundle.images;
+          }
+        } catch (err) {
+          if (isNovelImportCancelled(err) || signal.aborted) {
+            controller.abort();
+            throw abortError();
+          }
+          html = null;
+        }
+        if (html === null) {
+          failures++;
+          html =
+            `<h1>${escapeHtml(link.title)}</h1>` +
+            `<p>${escapeHtml(translate(_('This chapter could not be downloaded.')))}</p>` +
+            `<p><a href="${escapeHtml(link.url)}">${escapeHtml(link.url)}</a></p>`;
+        }
+        results[index] = { title: link.title, html };
+        done++;
+        onProgress?.(done, total);
+        // Extraction is main-thread CPU work (Tauri IPC can't run in a Worker) —
+        // yield between chapters so a long download doesn't freeze the UI.
+        await new Promise((resolve) => setTimeout(resolve, 0));
       }
-      results[index] = { title: link.title, html };
-      done++;
-      onProgress?.(done, total);
-      // Extraction is main-thread CPU work (Tauri IPC can't run in a Worker) —
-      // yield between chapters so a long download doesn't freeze the UI.
-      await new Promise((resolve) => setTimeout(resolve, 0));
+    };
+    await Promise.all(Array.from({ length: Math.min(CHAPTER_CONCURRENCY, total) }, worker));
+
+    let cover: EpubImage | undefined;
+    if (toc.coverUrl) {
+      const fetched = await fetchCover(toc.coverUrl, sourceUrl);
+      if (fetched) {
+        const ext = fetched.mime.split('/')[1]?.replace('jpeg', 'jpg') || 'jpg';
+        cover = { path: `cover.${ext}`, bytes: fetched.bytes, mime: fetched.mime };
+      }
     }
-  };
-  await Promise.all(Array.from({ length: Math.min(CHAPTER_CONCURRENCY, total) }, worker));
-
-  let cover: EpubImage | undefined;
-  if (toc.coverUrl) {
-    const fetched = await fetchCover(toc.coverUrl, sourceUrl);
-    if (fetched) {
-      const ext = fetched.mime.split('/')[1]?.replace('jpeg', 'jpg') || 'jpg';
-      cover = { path: `cover.${ext}`, bytes: fetched.bytes, mime: fetched.mime };
+    if (!cover) {
+      const siteName = (() => {
+        try {
+          return new URL(sourceUrl).hostname.replace(/^www\./, '');
+        } catch {
+          return '';
+        }
+      })();
+      cover = generateCoverSvg({ title: toc.title, author: toc.author, siteName });
     }
-  }
-  if (!cover) {
-    const siteName = (() => {
-      try {
-        return new URL(sourceUrl).hostname.replace(/^www\./, '');
-      } catch {
-        return '';
-      }
-    })();
-    cover = generateCoverSvg({ title: toc.title, author: toc.author, siteName });
-  }
 
-  // Sample prose (not placeholder text) for language detection.
-  let sample = '';
-  for (const chapter of results) {
-    sample += ` ${stripTags(chapter.html)}`;
-    if (sample.length >= 2048) break;
-  }
-  const language = detectLanguage(`${toc.title} ${sample}`.slice(0, 2048)) || 'en';
+    // Sample prose (not placeholder text) for language detection.
+    let sample = '';
+    for (const chapter of results) {
+      sample += ` ${stripTags(chapter.html)}`;
+      if (sample.length >= 2048) break;
+    }
+    const language = detectLanguage(`${toc.title} ${sample}`.slice(0, 2048)) || 'en';
 
-  const blob = await buildEpub(
-    results,
-    {
-      title: toc.title,
-      author: toc.author,
-      language,
-      identifier: stableIdentifier(identityKey),
-    },
-    [],
-    cover,
-  );
-  const file = new File([blob], `${safeFileName(toc.title)}.epub`, {
-    type: 'application/epub+zip',
-  });
-  return { file, title: toc.title, author: toc.author, chapterCount: total, failures };
+    signal.throwIfAborted();
+    const blob = await buildEpub(
+      results,
+      {
+        title: toc.title,
+        author: toc.author,
+        language,
+        identifier: stableIdentifier(identityKey),
+      },
+      [
+        ...new Map(
+          images
+            .flat()
+            .filter(Boolean)
+            .map((image) => [image.path, image]),
+        ).values(),
+      ],
+      cover,
+    );
+    const file = new File([blob], `${safeFileName(toc.title)}.epub`, {
+      type: 'application/epub+zip',
+    });
+    signal.throwIfAborted();
+    return { file, title: toc.title, author: toc.author, chapterCount: total, failures };
+  } finally {
+    options.signal?.removeEventListener('abort', onAbort);
+  }
 }

--- a/apps/readest-app/src/services/novel/renderNovelPage.ts
+++ b/apps/readest-app/src/services/novel/renderNovelPage.ts
@@ -1,0 +1,40 @@
+import { invoke } from '@tauri-apps/api/core';
+import { stubTranslation as _ } from '@/utils/misc';
+import { getClipOptions } from '@/services/send/clipOptions';
+import type { FetchedPage } from './novelImport';
+
+// Mobile can present only one capture controller at a time. Keep fallback
+// rendering serialized while ordinary HTTP chapter requests stay concurrent.
+let pending: Promise<unknown> = Promise.resolve();
+
+export function renderNovelPage(
+  url: string,
+  signal?: AbortSignal,
+  translate: (key: string) => string = (key) => key,
+): Promise<FetchedPage> {
+  const result = pending.then(async () => {
+    signal?.throwIfAborted();
+    let html: string;
+    try {
+      html = await invoke<string>('clip_url', {
+        url,
+        options: {
+          ...getClipOptions(translate),
+          windowTitle: translate(_('Import Web Novel')),
+          overlayTitle: translate(_('Import Web Novel')),
+          loadingStatus: translate(_('Loading chapter…')),
+        },
+      });
+    } catch (error) {
+      if (error === 'Capture cancelled') throw new DOMException('Capture cancelled', 'AbortError');
+      throw error;
+    }
+    signal?.throwIfAborted();
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const capturedUrl = doc.documentElement.getAttribute('data-readest-url');
+    const finalUrl = capturedUrl && /^https?:\/\//i.test(capturedUrl) ? capturedUrl : url;
+    return { html, finalUrl };
+  });
+  pending = result.catch(() => {});
+  return result;
+}

--- a/apps/readest-app/src/services/novel/renderNovelPage.ts
+++ b/apps/readest-app/src/services/novel/renderNovelPage.ts
@@ -20,6 +20,7 @@ export function renderNovelPage(
         url,
         options: {
           ...getClipOptions(translate),
+          backgroundCapture: true,
           windowTitle: translate(_('Import Web Novel')),
           overlayTitle: translate(_('Import Web Novel')),
           loadingStatus: translate(_('Loading chapter…')),
@@ -36,5 +37,13 @@ export function renderNovelPage(
     return { html, finalUrl };
   });
   pending = result.catch(() => {});
-  return result;
+  if (!signal) return result;
+  // Return to the chapter list immediately on cancel. Keep the native render
+  // in the queue until it has cleaned up, so a retry cannot overlap it.
+  return new Promise<FetchedPage>((resolve, reject) => {
+    const abort = () => reject(new DOMException('Capture cancelled', 'AbortError'));
+    signal.addEventListener('abort', abort, { once: true });
+    result.then(resolve, reject).finally(() => signal.removeEventListener('abort', abort));
+    if (signal.aborted) abort();
+  });
 }

--- a/apps/readest-app/src/services/novel/renderNovelPage.ts
+++ b/apps/readest-app/src/services/novel/renderNovelPage.ts
@@ -1,7 +1,24 @@
 import { invoke } from '@tauri-apps/api/core';
 import { stubTranslation as _ } from '@/utils/misc';
 import { getClipOptions } from '@/services/send/clipOptions';
+import { isBlockedHost } from '@/utils/network';
 import type { FetchedPage } from './novelImport';
+
+// This rejects explicit private hosts; DNS and browser redirect resolution remain native.
+export function assertNovelUrlAllowed(value: string): void {
+  const url = new URL(value);
+  const host = url.hostname.replace(/\.+$/, '').replace(/^\[|\]$/g, '');
+  // Feed IPv4-compatible literals through the shared IPv4-mapped guard too.
+  const compatible = host.match(/^::(?:([a-f0-9]{1,4}):)?([a-f0-9]{1,4})$/i);
+  const checkedHost = compatible ? `::ffff:${compatible[1] ?? '0'}:${compatible[2]}` : host;
+  if (
+    !['http:', 'https:'].includes(url.protocol) ||
+    isBlockedHost(checkedHost) ||
+    /^(?:ff[0-9a-f]{2}|fe[c-f][0-9a-f]):/i.test(host)
+  ) {
+    throw new Error('Cannot import from a private or unsupported URL');
+  }
+}
 
 // Mobile can present only one capture controller at a time. Keep fallback
 // rendering serialized while ordinary HTTP chapter requests stay concurrent.
@@ -14,6 +31,7 @@ export function renderNovelPage(
 ): Promise<FetchedPage> {
   const result = pending.then(async () => {
     signal?.throwIfAborted();
+    assertNovelUrlAllowed(url);
     let html: string;
     try {
       html = await invoke<string>('clip_url', {

--- a/apps/readest-app/src/services/send/conversion/assetBundler.ts
+++ b/apps/readest-app/src/services/send/conversion/assetBundler.ts
@@ -1,4 +1,4 @@
-import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
+import { browserFetch as tauriFetch } from '@/services/webBrowser/browserFetch';
 import { isTauriAppPlatform } from '@/services/environment';
 import { imageFetchHeaders } from './httpHeaders';
 import type { EpubImage } from './types';
@@ -11,10 +11,11 @@ import type { EpubImage } from './types';
 // paywalled / member-only CDN hosts — without that, an authenticated
 // Substack image returns a placeholder. In Tauri we also fold in the
 // full image-fetch header set (UA + Sec-Ch-Ua + Sec-Fetch-* + Referer)
+// and use the browser's native cookie store, including HttpOnly cookies,
 // so CDNs that gate images on the browser shape — NYT, WSJ, paywalled
 // CDNs — cooperate.
 const httpFetch = (url: string, referer: string | null, init?: RequestInit): Promise<Response> => {
-  if (!isTauriAppPlatform()) {
+  if (!isTauriAppPlatform() || url.startsWith('data:')) {
     return globalThis.fetch(url, { credentials: 'include', ...init });
   }
   const baseHeaders = imageFetchHeaders(referer);
@@ -222,8 +223,15 @@ interface FetchedAsset {
   mime: string;
 }
 
-async function fetchAsset(url: string, referer: string | null): Promise<FetchedAsset | null> {
+async function fetchAsset(
+  url: string,
+  referer: string | null,
+  signal?: AbortSignal,
+): Promise<FetchedAsset | null> {
+  signal?.throwIfAborted();
   const ac = new AbortController();
+  const onAbort = () => ac.abort();
+  signal?.addEventListener('abort', onAbort, { once: true });
   const timer = setTimeout(() => ac.abort(), FETCH_TIMEOUT_MS);
   try {
     const res = await httpFetch(url, referer, { signal: ac.signal, redirect: 'follow' });
@@ -239,6 +247,7 @@ async function fetchAsset(url: string, referer: string | null): Promise<FetchedA
     return { url, path, bytes, mime };
   } finally {
     clearTimeout(timer);
+    signal?.removeEventListener('abort', onAbort);
   }
 }
 
@@ -265,7 +274,10 @@ export interface BundleAssetsResult {
 export async function bundleAssets(
   contentHtml: string,
   pageUrl: string,
+  options: { maxBytes?: number; signal?: AbortSignal } = {},
 ): Promise<BundleAssetsResult> {
+  const maxBytes = Math.min(options.maxBytes ?? MAX_TOTAL_ASSET_BYTES, MAX_TOTAL_ASSET_BYTES);
+  options.signal?.throwIfAborted();
   const doc = new DOMParser().parseFromString(`<div id="root">${contentHtml}</div>`, 'text/html');
   const root = doc.getElementById('root');
   if (!root) return { html: contentHtml, images: [], missing: 0 };
@@ -374,11 +386,12 @@ export async function bundleAssets(
   let cursor = 0;
   const worker = async () => {
     while (cursor < uniqueUrls.length) {
+      options.signal?.throwIfAborted();
       const i = cursor++;
       const url = uniqueUrls[i]!;
-      if (isFetchableAssetUrl(url, pageUrl) && settledPrefixBytes() < MAX_TOTAL_ASSET_BYTES) {
+      if (isFetchableAssetUrl(url, pageUrl) && settledPrefixBytes() < maxBytes) {
         try {
-          settled[i] = await fetchAsset(url, pageUrl);
+          settled[i] = await fetchAsset(url, pageUrl, options.signal);
         } catch (err) {
           console.warn('[clip/bundle] image fetch failed', {
             url,
@@ -391,10 +404,11 @@ export async function bundleAssets(
   };
   await Promise.all(Array.from({ length: MAX_CONCURRENCY }, worker));
 
+  options.signal?.throwIfAborted();
   // Apply the budget strictly in document order.
   for (let i = 0; i < uniqueUrls.length; i++) {
     const asset = settled[i];
-    if (!asset || totalBytes + asset.bytes.byteLength > MAX_TOTAL_ASSET_BYTES) {
+    if (!asset || totalBytes + asset.bytes.byteLength > maxBytes) {
       missing++;
       continue;
     }

--- a/apps/readest-app/src/services/send/conversion/conversionWorker.ts
+++ b/apps/readest-app/src/services/send/conversion/conversionWorker.ts
@@ -65,7 +65,7 @@ async function convertInWorker(input: ConvertInput, timeoutMs: number): Promise<
  * conversion when Web Workers are unavailable or the worker fails.
  *
  * `kind: 'page'` is the exception — its asset bundler uses the
- * `@tauri-apps/plugin-http` fetch to bypass CORS, and that binding lives on
+ * native browser-session fetch to bypass CORS, and that binding lives on
  * `window.__TAURI_INTERNALS__` which a Web Worker can't reach. So page
  * clips always run on the main thread.
  */

--- a/apps/readest-app/src/services/send/conversion/convertToEpub.ts
+++ b/apps/readest-app/src/services/send/conversion/convertToEpub.ts
@@ -171,7 +171,7 @@ async function htmlToBook(
  * `sanitizeForParsing` strips any `<base>` the page itself shipped, so
  * there is never an author-supplied one to preserve.
  */
-function parsePageDocument(html: string, pageUrl: string): Document {
+export function parsePageDocument(html: string, pageUrl: string): Document {
   const doc = new DOMParser().parseFromString(sanitizeForParsing(html), 'text/html');
   const base = doc.createElement('base');
   base.setAttribute('href', pageUrl);

--- a/apps/readest-app/src/services/send/conversion/faviconFetcher.ts
+++ b/apps/readest-app/src/services/send/conversion/faviconFetcher.ts
@@ -1,4 +1,4 @@
-import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
+import { browserFetch as tauriFetch } from '@/services/webBrowser/browserFetch';
 import { isTauriAppPlatform } from '@/services/environment';
 import { imageFetchHeaders } from './httpHeaders';
 

--- a/apps/readest-app/src/services/webBrowser/browserFetch.ts
+++ b/apps/readest-app/src/services/webBrowser/browserFetch.ts
@@ -1,0 +1,32 @@
+import { invoke } from '@tauri-apps/api/core';
+
+interface BrowserResource {
+  url: string;
+  status: number;
+  contentType: string;
+  body: string;
+}
+
+/** Native GET using the browser's persistent cookie store. Cookies never cross IPC. */
+export async function browserFetch(url: string, init?: RequestInit): Promise<Response> {
+  const signal = init?.signal;
+  signal?.throwIfAborted();
+  const resource = await new Promise<BrowserResource>((resolve, reject) => {
+    const abort = () => reject(new DOMException('Request cancelled', 'AbortError'));
+    signal?.addEventListener('abort', abort, { once: true });
+    invoke<BrowserResource>('fetch_web_browser_resource', {
+      url,
+      headers: Object.fromEntries(new Headers(init?.headers).entries()),
+    })
+      .then(resolve, reject)
+      .finally(() => signal?.removeEventListener('abort', abort));
+  });
+  signal?.throwIfAborted();
+  const bytes = Uint8Array.from(atob(resource.body), (c) => c.charCodeAt(0));
+  const response = new Response([204, 205, 304].includes(resource.status) ? null : bytes, {
+    status: resource.status,
+    headers: { 'content-type': resource.contentType },
+  });
+  Object.defineProperty(response, 'url', { value: resource.url });
+  return response;
+}


### PR DESCRIPTION
Closes #6082.

From Web Novel now lets readers sign in with the built-in browser and use the current page as the chapter list. Signed-in imports render chapters in the same browser session, including JavaScript content, and reuse native cookies when fetching covers and chapter illustrations. The same session-backed asset fetching also applies to clipped web pages.

Cookies stay in native storage. Redirects re-evaluate cookie scope, response cookies renew the browser session, and Windows renewal preserves domain-cookie scope. Chapter capture is serialized on mobile and can be cancelled and restarted. Relative image URLs resolve against the captured page’s final URL before assets are bundled into the EPUB.

Chapter downloads now use one persistent progress view with the book title, chapter count, percentage, and a centered Cancel button. Android, iOS, and macOS render chapters behind the app so native loading screens no longer flash between chapters. Cancellation returns to the preview immediately while native capture cleanup stays serialized. Windows and Linux retain their existing visible capture behavior.

Review follow-up: native resource requests reject explicit private IPs/local hostnames and recheck HTTP redirects; novel imports apply the same host restriction before browser fallback. DNS/proxy resolution and WebView redirects remain platform-managed. Desktop capture listeners are scoped to the command, and Android fingerprint scripts run at document start across navigations.

Validation:

- Xiaomi: signed in to a local fixture with an HttpOnly cookie, cancelled and restarted capture, then imported all six private chapters, including a JavaScript-only chapter. Inspected the saved EPUB and verified the protected cover and embedded illustrations. Confirmed the same progress element, stable layout, and app focus across all six chapters; cancellation returned to the preview in 0.13 seconds. Verified the centered button in normal and e-ink modes. Removed test data afterward.
- Full frontend suite: 11,034 passed, 16 skipped; formatting, lint, and production build passed.
- Browser suite: 459 passed, 1 skipped. Fixed a pre-existing two-column curl test race by holding the drag open until capture restoration is checked; reproduced the CI failure with a delayed mock capture and verified the fix under the same delay.
- Rust: 149 tests passed; formatting and Clippy passed.
- Android release APK and iOS native bridge builds passed during implementation. Review fixes also passed Kotlin compilation/unit tests and an Android 15 instrumented regression across two navigations. The separate Xiaomi test-activity launch timed out after installation, so that later device check is unverified.

Real Patreon/SubscribeStar accounts and Windows runtime behavior have not been tested. Updated the README and native architecture reference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Sign in with Browser” support for importing chapters from members-only web novels.
  - Reuses the browser session to fetch authenticated chapter lists, pages, and images.
  - Supports JavaScript-rendered pages and access-challenged sites.
  - Bundles eligible chapter images into imported EPUBs.
  - Added clearer chapter download progress and completion guidance.

- **Bug Fixes**
  - Improved image URL handling and preserved unavailable images as placeholders.
  - Added cancellation controls for web-page capture and interrupted imports.
  - Blocks imports from private or unsafe network addresses.

- **Documentation**
  - Updated web clipping and architecture documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


