### PR TITLE
fix(ci): use CEF bundler with deployment array quoting fix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -134,8 +134,8 @@ jobs:
 
       # The npm cli-cef bundles the AppImage with a broken quick-sharun fork
       # and cannot be pointed elsewhere. Build the CLI from readest/tauri
-      # instead: its sharun_cef.rs pins a pkgforge revision (the one
-      # tauri-apps/tauri#12491 uses) and runs the tooling with bash and
+      # instead: its sharun_cef.rs pins pkgforge's deployment-array quoting
+      # fix (Anylinux-AppImages#855) and runs the tooling with bash and
       # streamed output. Rev-pinned; the marker skips the rebuild while
       # rust-cache keeps ~/.cargo/bin. scripts/tauri.mjs runs `cargo tauri`
       # when TAURI_CEF_CARGO=1.
@@ -143,7 +143,7 @@ jobs:
         if: matrix.config.release == 'linux'
         run: |
           set -euo pipefail
-          rev=c62e9f90c1f5759a4e3795cc56b0b9a1273a5773
+          rev=2b8315bd14882471b6567b1ceba84c0c0238f156
           marker="$HOME/.cargo/bin/.cargo-tauri-rev"
           if [ -x "$HOME/.cargo/bin/cargo-tauri" ] && [ "$(cat "$marker" 2>/dev/null)" = "$rev" ]; then
             echo "cargo-tauri at $rev already installed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,8 +362,8 @@ jobs:
 
       # The npm cli-cef bundles the AppImage with a broken quick-sharun fork
       # and cannot be pointed elsewhere. Build the CLI from readest/tauri
-      # instead: its sharun_cef.rs pins a pkgforge revision (the one
-      # tauri-apps/tauri#12491 uses) and runs the tooling with bash and
+      # instead: its sharun_cef.rs pins pkgforge's deployment-array quoting
+      # fix (Anylinux-AppImages#855) and runs the tooling with bash and
       # streamed output. Rev-pinned; the marker skips the rebuild while
       # rust-cache keeps ~/.cargo/bin. scripts/tauri.mjs runs `cargo tauri`
       # when TAURI_CEF_CARGO=1.
@@ -371,7 +371,7 @@ jobs:
         if: matrix.config.release == 'linux'
         run: |
           set -euo pipefail
-          rev=c62e9f90c1f5759a4e3795cc56b0b9a1273a5773
+          rev=2b8315bd14882471b6567b1ceba84c0c0238f156
           marker="$HOME/.cargo/bin/.cargo-tauri-rev"
           if [ -x "$HOME/.cargo/bin/cargo-tauri" ] && [ "$(cat "$marker" 2>/dev/null)" = "$rev" ]; then
             echo "cargo-tauri at $rev already installed"

--- a/.github/workflows/try-appimage.yml
+++ b/.github/workflows/try-appimage.yml
@@ -58,15 +58,15 @@ jobs:
 
       # The npm cli-cef bundles the AppImage with a broken quick-sharun fork
       # and cannot be pointed elsewhere. Build the CLI from readest/tauri
-      # instead: its sharun_cef.rs pins a pkgforge revision (the one
-      # tauri-apps/tauri#12491 uses) and runs the tooling with bash and
+      # instead: its sharun_cef.rs pins pkgforge's deployment-array quoting
+      # fix (Anylinux-AppImages#855) and runs the tooling with bash and
       # streamed output. Rev-pinned; the marker skips the rebuild while
       # rust-cache keeps ~/.cargo/bin. scripts/tauri.mjs runs `cargo tauri`
       # when TAURI_CEF_CARGO=1.
       - name: install the CEF tauri CLI from readest/tauri (linux only)
         run: |
           set -euo pipefail
-          rev=c62e9f90c1f5759a4e3795cc56b0b9a1273a5773
+          rev=2b8315bd14882471b6567b1ceba84c0c0238f156
           marker="$HOME/.cargo/bin/.cargo-tauri-rev"
           if [ -x "$HOME/.cargo/bin/cargo-tauri" ] && [ "$(cat "$marker" 2>/dev/null)" = "$rev" ]; then
             echo "cargo-tauri at $rev already installed"


### PR DESCRIPTION
Update the CEF `tauri-cli` pin to `readest/tauri@2b8315bd14882471b6567b1ceba84c0c0238f156` in the nightly, release, and AppImage trial workflows. This revision includes the quick-sharun deployment-array quoting fix from [pkgforge-dev/Anylinux-AppImages#855](https://github.com/pkgforge-dev/Anylinux-AppImages/pull/855).

Validation:
- YAML parsing and `bash -n` passed for all three installer steps; verified that all three use the same pinned revision.
- Repository formatting and lint/type checks passed.
- Full unit suite passed: 11,058 tests passed, 16 skipped.

A Linux AppImage build was not run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Linux AppImage build workflows to include a fix for deployment-array quoting, improving reliability of generated packages.

* **Chores**
  * Synchronized the pinned build tooling revision across nightly, release, and test AppImage workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->