### PR TITLE
fix(reader): sync reading progress on a first open in scrolled mode

### DIFF
--- a/apps/readest-app/.claude/memory/MEMORY.md
+++ b/apps/readest-app/.claude/memory/MEMORY.md
@@ -193,3 +193,5 @@ Index only — one line per memory. Detail lives in the topic files; do not rest
 - [stat_pages slow query + disk growth](stat-pages-slow-query-disk-growth.md) #5835+#5844 DEPLOYED; cron FLIPPED 3719ec648
 - [No prod metrics in public issues/PRs](feedback-no-prod-metrics-in-public.md) #5834 DELETED for exposing prod data
 - [KOReader emulator headless verify](koreader-emulator-headless-verify.md) HttpInspector recipe; never mv the stats DB
+- [Scrolled-mode cover never relocates = no progress sync](scrolled-cover-no-relocate-progress-sync.md) UNCOMMITTED foliate `#getVisibleRange` collapsed fallback + hook no-local-CFI; needs foliate PR + re-pin
+- [Chrome MCP tab hidden = no rAF/scroll](chrome-mcp-hidden-tab-no-raf.md) check visibilityState first; probe with renderer.goTo

--- a/apps/readest-app/.claude/memory/chrome-mcp-hidden-tab-no-raf.md
+++ b/apps/readest-app/.claude/memory/chrome-mcp-hidden-tab-no-raf.md
@@ -1,0 +1,15 @@
+---
+name: chrome-mcp-hidden-tab-no-raf
+description: "The Claude-in-Chrome MCP tab often reports visibilityState \"hidden\" (no rAF, no scroll events, AppleScript sees 0 Chrome windows); check before trusting a reader repro, and probe with renderer.goTo which needs neither"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 5f01dea0-ac7c-4ef2-8c5c-58a60be6cc8b
+  modified: 2026-09-07T17:52:11.603Z
+---
+
+On 2026-09-08 the MCP-controlled Chrome tab loaded the reader but `document.visibilityState` was `hidden`, `requestAnimationFrame` never fired, and programmatic `scrollTop` writes produced no `scroll` events. `osascript` reported 0 windows for Google Chrome and `resize_window` did not change `innerWidth`. Clicking in the tab, `activate`, and resizing did not help; the tab only became visible later (chrox brought the window forward).
+
+**Why:** readest's relocate commit runs in rAF unless hidden, and foliate's scrolled-mode relocate rides the container `scroll` event; both are dead in a hidden tab, so "no relocate / no progress" can be the tab, not the bug.
+
+**How to apply:** first thing in any reader repro, run `({v: document.visibilityState, raf: await Promise.race([...])})`. If hidden, either ask chrox to bring the window forward or probe with `foliate-view.renderer.goTo({index, anchor})` and read `view.lastLocation`, which are synchronous and need neither rAF nor scroll events. Remember every live `goTo` auto-pushes progress to the cloud after 3s.

--- a/apps/readest-app/.claude/memory/scrolled-cover-no-relocate-progress-sync.md
+++ b/apps/readest-app/.claude/memory/scrolled-cover-no-relocate-progress-sync.md
@@ -1,0 +1,21 @@
+---
+name: scrolled-cover-no-relocate-progress-sync
+description: "First open in scrolled mode on an image-only (SVG) cover never emits a relocate, so no progress is recorded and the cloud pull never starts; fix = collapsed-range fallback in foliate paginator #getVisibleRange (scrolled branch)"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 5f01dea0-ac7c-4ef2-8c5c-58a60be6cc8b
+  modified: 2026-09-07T18:07:28.954Z
+---
+
+Reported by chrox 2026-09-08 (no issue number): a book opened for the first time on a device in scrolled mode "cannot sync progress". Repro book: Holy Bible Recovery Version, hash 86d1b704a563b035e79bc73b40aa4841 on the web dev server (port 3001).
+
+**Root cause (foliate-js `paginator.js`, `#getVisibleRange`, scrolled branch):** the scrolled branch skips every view whose visible range is collapsed (`if (!range || range.collapsed) continue`, added for readest#4436 to prefer the view covering the viewport centre). An SVG-only cover (and the img-only page after it) yields no accepted node in the tree walk because the scrolled rect mapper subtracts the page margin, so the only in-view elements straddle the viewport and the range collapses onto `<body>`. With no other loaded view overlapping the viewport the method returns `undefined`, `#afterScroll` bails before dispatching, and NO `relocate` ever fires on open. Readest's `useProgressSync` gates the initial cloud pull on `progress`, which only exists after a relocate, and the auto-push needs `progress.location`, so neither pull nor push happens until the user scrolls into text. Paginated mode never had this: its branch returns the collapsed range and relocates on `epubcfi(/6/2!/4)`.
+
+**Fix:** keep the collapsed range (preferring the centre view) as a last resort, `return fallback ?? collapsed`. Regression browser test: `src/__tests__/document/paginator-scrolled-cover-relocate.browser.test.ts` (synthetic book, oversized `<svg>` cover). Complement in readest `useProgressSync.ts` (chrox's own diff): apply the remote CFI when the local config has no location at all (`remoteIsAhead = !configCFI || compare < 0`), covered by the "no location yet" case in `src/__tests__/hooks/useProgressSync.test.tsx`; this also fixes the manual Sync button path before any relocate.
+
+**Status 2026-09-08:** PRs opened. foliate: readest/foliate-js#93 (branch `fix/scrolled-collapsed-visible-range`, commit 6eb3bc1); readest: `chrox:fix/scrolled-cover-relocate-progress-sync` pinning that commit. foliate PRs are SQUASH-merged, so the readest submodule pin MUST be re-pointed at the merged main commit before the readest PR merges, or the pin orphans. Live-verified in Chrome with the local config's location/xpointer/progress deleted from IndexedDB (`AppFileSystem` > `files` > `Readest/Books/<hash>/config.json`) and the serwist SW unregistered: cover relocate at 3.6s, pull, jump to the remote position at 5.6s. NOTE: a tab that loads with NO dev server on 3001 is served by the serwist cache (old code) and looks alive.
+
+**Side effects of the probe:** navigating the live reader with `renderer.goTo` auto-pushes within 3s (`SYNC_PROGRESS_INTERVAL_SEC`) and OVERWRITES the cloud position; I restored chrox's Ephesians 3:11-19 position afterwards. Pre-existing quirk noticed, NOT fixed: the paginator swallows the first debounced scroll after a navigation (`#justAnchored`), so the first scroll gesture after open never relocates.
+
+See also [[chrome-mcp-hidden-tab-no-raf]] for why the first repro attempt was confounded.

--- a/apps/readest-app/src/__tests__/document/paginator-scrolled-cover-relocate.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/paginator-scrolled-cover-relocate.browser.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import type { Renderer } from '@/types/view';
+
+// In scrolled mode the paginator picks the visible range from the view that
+// covers the viewport centre and skips views whose visible range is collapsed.
+// A cover section made of one oversized <svg><image/> (or any section whose
+// in-view elements are all partially clipped) has no accepted nodes, so its
+// range collapses onto <body>. When no other loaded view overlaps the viewport
+// the walk returns nothing, #afterScroll bails, and no `relocate` is ever
+// dispatched — the host never learns the book's position, so reading progress
+// is never recorded or synced until the user scrolls into text. Paginated mode
+// relocates on the same collapsed range, so the two modes must agree.
+
+const COVER_HTML = `<!doctype html><html><head><style>
+  html, body { margin: 0; }
+</style></head><body><div><svg xmlns="http://www.w3.org/2000/svg" width="400" height="2000" viewBox="0 0 400 2000">
+  <rect width="400" height="2000" fill="#48c" />
+</svg></div></body></html>`;
+
+const TEXT_HTML = `<!doctype html><html><head><style>
+  html, body { margin: 0; }
+  p { margin: 0 0 24px; line-height: 24px; }
+</style></head><body>${Array.from({ length: 60 }, (_, i) => `<p>Paragraph ${i + 1} of the first chapter.</p>`).join('')}</body></html>`;
+
+const blobUrl = (html: string) => URL.createObjectURL(new Blob([html], { type: 'text/html' }));
+
+const makeBook = () => ({
+  dir: 'ltr',
+  sections: [
+    { id: 'cover', linear: 'yes', size: COVER_HTML.length, load: async () => blobUrl(COVER_HTML) },
+    { id: 'ch1', linear: 'yes', size: TEXT_HTML.length, load: async () => blobUrl(TEXT_HTML) },
+  ],
+});
+
+type RelocateDetail = { reason: string; index: number; range: Range; fraction: number };
+
+const waitForRelocate = (el: HTMLElement, timeout = 3000) =>
+  new Promise<RelocateDetail | null>((resolve) => {
+    const timer = setTimeout(() => resolve(null), timeout);
+    el.addEventListener(
+      'relocate',
+      (e) => {
+        clearTimeout(timer);
+        resolve((e as CustomEvent<RelocateDetail>).detail);
+      },
+      { once: true },
+    );
+  });
+
+describe('Paginator scrolled mode relocates on an image-only cover', () => {
+  let paginator: Renderer;
+
+  beforeAll(async () => {
+    await import('foliate-js/paginator.js');
+  }, 30000);
+
+  const createPaginator = () => {
+    const el = document.createElement('foliate-paginator') as Renderer;
+    Object.assign(el.style, {
+      width: '800px',
+      height: '600px',
+      position: 'absolute',
+      left: '0',
+      top: '0',
+    });
+    el.setAttribute('flow', 'scrolled');
+    document.body.appendChild(el);
+    return el;
+  };
+
+  afterEach(() => {
+    if (paginator) {
+      try {
+        paginator.destroy();
+      } catch {
+        /* iframe body may already be torn down */
+      }
+      paginator.remove();
+    }
+  });
+
+  it('dispatches a relocate for the cover section on open', async () => {
+    paginator = createPaginator();
+    paginator.open(makeBook() as unknown as Parameters<Renderer['open']>[0]);
+
+    const relocated = waitForRelocate(paginator);
+    await paginator.goTo({ index: 0, anchor: 0 });
+    const detail = await relocated;
+
+    expect(detail).not.toBeNull();
+    expect(detail!.index).toBe(0);
+    expect(detail!.fraction).toBe(0);
+  });
+
+  it('still prefers a view with visible text over a collapsed cover range', async () => {
+    paginator = createPaginator();
+    paginator.open(makeBook() as unknown as Parameters<Renderer['open']>[0]);
+
+    await paginator.goTo({ index: 0, anchor: 0 });
+    // Let the fill pass load the text chapter below the cover.
+    const start = Date.now();
+    while (paginator.getContents().length < 2 && Date.now() - start < 5000) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(paginator.getContents().length).toBe(2);
+
+    // Scroll so the cover's tail sits in the top of the viewport and the text
+    // chapter covers the centre: the relocate must report the chapter. The
+    // paginator swallows the first debounced scroll after a navigation (it is
+    // normally the anchoring scroll itself) and skips scrolls while the fill
+    // pass is still stabilizing, so nudge until a relocate arrives.
+    const container = paginator.shadowRoot!.getElementById('container')!;
+    let detail: RelocateDetail | null = null;
+    for (let nudge = 0; nudge < 6 && !detail; nudge++) {
+      const relocated = waitForRelocate(paginator, 500);
+      container.scrollTop = 1900 + nudge;
+      detail = await relocated;
+    }
+
+    expect(detail).not.toBeNull();
+    expect(detail!.index).toBe(1);
+    expect(detail!.range.collapsed).toBe(false);
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
@@ -313,6 +313,28 @@ describe('useProgressSync', () => {
     expect(h.view.goTo).toHaveBeenCalledWith('epubcfi(/6/24!/4/20/1:58)');
   });
 
+  test('navigates to the synced location when the local config has no location yet', async () => {
+    // First open on this device: nothing has been read here, so the local
+    // config carries no CFI. The remote position is trivially ahead and must
+    // move the reader without consulting CFI.compare.
+    const config = h.config as { location?: string };
+    const savedLocation = config.location;
+    config.location = undefined;
+    h.cfiCompareMock.mockReturnValue(1);
+    h.state.syncedConfigs = [
+      { bookHash: 'h1', metaHash: 'm1', location: 'epubcfi(/6/24!/4/20/1:58)', updatedAt: 3000 },
+    ];
+    try {
+      renderHook(() => useProgressSync('h1-view1'));
+      await advance(0);
+
+      expect(h.view.goTo).toHaveBeenCalledWith('epubcfi(/6/24!/4/20/1:58)');
+      expect(h.cfiCompareMock).not.toHaveBeenCalled();
+    } finally {
+      config.location = savedLocation;
+    }
+  });
+
   test('sync-book-progress event resets and re-runs the pull chain', async () => {
     h.state.syncedConfigs = null;
     renderHook(() => useProgressSync('h1-view1'));

--- a/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
@@ -315,12 +315,13 @@ export const useProgressSync = (bookKey: string) => {
         // Reading progress applies below. Proofread (find/replace) rules merge
         // separately just after; other config fields remain device-local.
         // TODO: general config sync via a more robust profile-based solution.
-        if (remoteCFILocation && configCFI) {
+        if (remoteCFILocation) {
+          const remoteIsAhead = !configCFI || CFI.compare(configCFI, remoteCFILocation) < 0;
           // While previewing a deep-link target, do NOT yank the view to the
           // remote position — the user came here to look at a specific
           // annotation. The local config still gets updated; the next open
           // resolves to the synced position normally.
-          if (CFI.compare(configCFI, remoteCFILocation) < 0 && view && !isPreviewing()) {
+          if (remoteIsAhead && view && !isPreviewing()) {
             view.goTo(remoteCFILocation);
             announceSynced();
           }


### PR DESCRIPTION
## Summary

A book opened for the first time on a device in scrolled mode could not sync its reading progress: the reader stayed on the cover, the cloud pull never ran, and nothing was pushed until the user scrolled into text. Paginated mode was unaffected.

## Root cause

foliate's scrolled-mode `#getVisibleRange` skipped every view whose visible range was collapsed (a rule added to prefer the section covering the viewport centre). An image-only cover collapses onto `<body>`, so with no other loaded view overlapping the viewport the method returned nothing and no `relocate` was dispatched on open. `useProgressSync` gates the initial pull on `progress` and the auto-push on `progress.location`, both of which only exist after that first relocate.

## Changes

- Pin `foliate-js` to the merged readest/foliate-js#93 (`98b82a5`), which keeps the collapsed range as a last resort so the cover relocates (paginated mode already did).
- `useProgressSync`: apply the synced location when the local config has no location at all, so a pull that lands before any relocate (e.g. the manual Sync button) still moves the reader.
- Tests: `paginator-scrolled-cover-relocate.browser.test.ts` (synthetic oversized-SVG cover; fails on the old paginator) and a `useProgressSync` unit case for the no-local-location pull (fails without the hook change).

## Verification

- `pnpm test`, `pnpm lint`, `pnpm format:check` clean; the new browser test passes with the pinned foliate commit.
- Live on the web dev server with a Bible EPUB (SVG cover) after deleting the book's local location/xpointer/progress: the cover relocates at ~3.6s, the pull runs, and the reader jumps to the remote position at ~5.6s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
