### PR TITLE
fix(android): follow system theme in reading widget

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/androidTest/java/ReadingWidgetThemeTest.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/androidTest/java/ReadingWidgetThemeTest.kt
@@ -1,0 +1,44 @@
+package com.readest.native_bridge
+
+import android.content.res.Configuration
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.view.ContextThemeWrapper
+import android.widget.FrameLayout
+import android.widget.RemoteViews
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReadingWidgetThemeTest {
+    @Test
+    fun backgroundFollowsNightModeRegardlessOfHostTheme() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        // Launchers can use a fixed theme even when the system configuration changes.
+        for (hostTheme in listOf(android.R.style.Theme_Material_Light, android.R.style.Theme_Material)) {
+            for (night in listOf(false, true, false)) {
+                val config = Configuration(context.resources.configuration).apply {
+                    uiMode = (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or
+                        if (night) Configuration.UI_MODE_NIGHT_YES else Configuration.UI_MODE_NIGHT_NO
+                }
+                val host = ContextThemeWrapper(context.createConfigurationContext(config), hostTheme)
+                val view = RemoteViews(context.packageName, R.layout.widget_reading)
+                    .apply(host, FrameLayout(host))
+                val bitmap = Bitmap.createBitmap(40, 40, Bitmap.Config.ARGB_8888)
+                view.background.setBounds(0, 0, 40, 40)
+                view.background.draw(Canvas(bitmap))
+                val color = bitmap.getPixel(20, 20)
+                bitmap.recycle()
+                val brightness = (Color.red(color) + Color.green(color) + Color.blue(color)) / 3
+                assertTrue(
+                    "night=$night hostTheme=$hostTheme background=${Integer.toHexString(color)}",
+                    if (night) brightness < 128 else brightness > 128
+                )
+            }
+        }
+    }
+}

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/layout/widget_reading.xml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/layout/widget_reading.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:theme="@style/ReadingWidgetTheme"
   android:layout_width="match_parent" android:layout_height="match_parent"
   android:orientation="vertical" android:background="@drawable/widget_card_bg"
   android:padding="6dp">

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/values-night/widget_theme.xml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/values-night/widget_theme.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <style name="ReadingWidgetTheme" parent="android:style/Theme.Material.NoActionBar" />
+</resources>

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/values/widget_theme.xml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/values/widget_theme.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- RemoteViews must not inherit the launcher's theme. Resource qualifiers
+       select the system appearance without an AppCompatDelegate. -->
+  <style name="ReadingWidgetTheme" parent="android:style/Theme.Material.Light.NoActionBar" />
+</resources>


### PR DESCRIPTION
The Android reading widget could keep a light background when the system switched to dark mode because its RemoteViews layout inherited the host theme. Apply an explicit widget theme with light and night platform styles so the background and theme-based foreground colors follow the system configuration.

Verification:
- Added a regression test for light → dark → light rendering under both light and dark host themes; it failed before the fix and passes afterward.
- All 9 widget instrumentation tests passed on Xiaomi 2211133C (Android 16).
- Installed the fixed build on Xiaomi and verified the existing home-screen widget through dark → light → dark without opening Readest or re-adding the widget.
- Android debug APK build, Rust formatting, Clippy, and all 149 Rust tests passed.
- TypeScript and Biome checks passed in the isolated PR worktree.
- Full unit suite passed in the isolated PR worktree: 917 files, 11,059 tests passed (4 files and 16 tests skipped).
- Independent review found no blocking issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Android reading widgets now correctly match the device’s light or dark system appearance, regardless of the launcher’s theme.
- **Tests**
  - Added coverage to verify widget background brightness in both light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->