### PR TITLE
fix(library): keep the context menu actions wired to their items

### DIFF
--- a/apps/readest-app/package.json
+++ b/apps/readest-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readest/readest-app",
-  "version": "0.12.6",
+  "version": "0.12.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/readest-app/src/__tests__/app/library/book-context-menu-cache.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/book-context-menu-cache.test.tsx
@@ -17,9 +17,13 @@ import type { Book } from '@/types/book';
 const popupSpy = vi.hoisted(() => vi.fn(async () => {}));
 const closeSpy = vi.hoisted(() => vi.fn(async () => {}));
 const menuNew = vi.hoisted(() => vi.fn(async () => ({ popup: popupSpy, close: closeSpy })));
+const menuItemNew = vi.hoisted(() =>
+  vi.fn(async (options: { text: string }) => ({ ...options, close: vi.fn(async () => {}) })),
+);
 
 vi.mock('@tauri-apps/api/menu', () => ({
   Menu: { new: menuNew },
+  MenuItem: { new: menuItemNew },
 }));
 
 vi.mock('@tauri-apps/api/window', () => ({

--- a/apps/readest-app/src/__tests__/app/library/book-context-menu-item-channels.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/book-context-menu-item-channels.test.tsx
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import type { Book } from '@/types/book';
+
+/**
+ * Issue #6142 — every button in the library context menu did nothing on macOS
+ * and Windows.
+ *
+ * `Menu.new({ items: [{ text, action }] })` builds each inline item as a
+ * temporary on the Rust side: the action's channel is registered under the
+ * item id, an Arc clone goes into the menu, and `MenuBuilder::build` then drops
+ * the last clone because `Menu::append` keeps only muda's own item. Since
+ * tauri 2.11.5 that drop unregisters the channel again (upstream #15679, which
+ * Readest picked up in #6081), so the menu pops up but no click ever reaches
+ * JS. Items created through `MenuItem.new` are owned by the webview's resource
+ * table instead, so their channels outlive the build — and must be closed
+ * explicitly when the menu is released.
+ */
+
+type MockMenuItem = { text: string; action: () => void; close: ReturnType<typeof vi.fn> };
+
+const popupSpy = vi.hoisted(() => vi.fn(async () => {}));
+const closeSpy = vi.hoisted(() => vi.fn(async () => {}));
+const menuNew = vi.hoisted(() =>
+  vi.fn(async (_options: { items: MockMenuItem[] }) => ({ popup: popupSpy, close: closeSpy })),
+);
+const menuItemNew = vi.hoisted(() =>
+  vi.fn(async (options: { text: string; action: () => void }) => ({
+    ...options,
+    close: vi.fn(async () => {}),
+  })),
+);
+
+vi.mock('@tauri-apps/api/menu', () => ({
+  Menu: { new: menuNew },
+  MenuItem: { new: menuItemNew },
+}));
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  revealItemInDir: vi.fn(),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({
+    envConfig: {},
+    appService: { hasContextMenu: true, isAndroidApp: false, isMobileApp: false },
+  }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: { localBooksDir: '/books' } }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (text: string) => text,
+}));
+
+vi.mock('@/app/library/hooks/useOpenBook', () => ({
+  useOpenBook: () => ({ openBook: vi.fn() }),
+}));
+
+vi.mock('@/app/library/components/BookItem', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/library/components/GroupItem', () => ({
+  default: () => null,
+}));
+
+const BookshelfItem = (await import('@/app/library/components/BookshelfItem')).default;
+
+const book: Book = {
+  hash: 'hash-1',
+  format: 'EPUB',
+  title: 'Test Book',
+  author: 'Test Author',
+  createdAt: 0,
+  updatedAt: 0,
+  downloadedAt: 1,
+};
+
+const handleShowDetailsBook = vi.fn();
+
+const renderItem = (overrides: { itemSelected?: boolean } = {}) => {
+  const props = {
+    mode: 'grid' as const,
+    item: book,
+    coverFit: 'crop' as const,
+    isSelectMode: false,
+    itemSelected: false,
+    transferProgress: null,
+    setLoading: vi.fn(),
+    toggleSelection: vi.fn(),
+    handleGroupBooks: vi.fn(),
+    handleBookDownload: vi.fn(async () => true),
+    handleBookUpload: vi.fn(async () => true),
+    handleBookDelete: vi.fn(async () => true),
+    handleSetSelectMode: vi.fn(),
+    handleShowDetailsBook,
+    handleLibraryNavigation: vi.fn(),
+    handleUpdateReadingStatus: vi.fn(),
+    showTimeRemaining: false,
+    ...overrides,
+  };
+  const utils = render(<BookshelfItem {...props} />);
+  const rerenderItem = (nextOverrides: { itemSelected?: boolean }) =>
+    utils.rerender(<BookshelfItem {...props} {...nextOverrides} />);
+  return { ...utils, rerenderItem };
+};
+
+const openContextMenu = () =>
+  fireEvent.contextMenu(screen.getByRole('button', { name: 'Test Book' }), {
+    clientX: 10,
+    clientY: 20,
+  });
+
+describe('library context menu item ownership (issue #6142)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('builds the menu from owned MenuItem resources so the actions stay wired', async () => {
+    renderItem();
+
+    openContextMenu();
+    await waitFor(() => expect(popupSpy).toHaveBeenCalledTimes(1));
+
+    expect(menuItemNew).toHaveBeenCalled();
+    const built = await Promise.all(menuItemNew.mock.results.map((result) => result.value));
+    const passed = menuNew.mock.calls[0]![0]!.items;
+    // Every entry handed to Menu.new must be a MenuItem resource, in the same
+    // order the item list was built in — no inline `{ text, action }` payloads.
+    expect(passed).toEqual(built);
+    expect(passed.map((item) => item.text)).toEqual(built.map((item) => item.text));
+
+    const details = passed.find((item) => item.text === 'Show Book Details');
+    expect(details).toBeDefined();
+    details!.action();
+    expect(handleShowDetailsBook).toHaveBeenCalledWith(book);
+  });
+
+  it('closes the item resources along with the menu it released', async () => {
+    const { rerenderItem } = renderItem();
+
+    openContextMenu();
+    await waitFor(() => expect(popupSpy).toHaveBeenCalledTimes(1));
+    const items = await Promise.all(menuItemNew.mock.results.map((result) => result.value));
+    expect(items.length).toBeGreaterThan(0);
+
+    rerenderItem({ itemSelected: true });
+    await waitFor(() => expect(closeSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      for (const item of items) expect(item.close).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/readest-app/src/__tests__/app/library/book-context-menu-linux-inapp.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/book-context-menu-linux-inapp.test.tsx
@@ -18,6 +18,7 @@ const menuNew = vi.hoisted(() => vi.fn(async () => ({ popup: popupSpy, close: cl
 
 vi.mock('@tauri-apps/api/menu', () => ({
   Menu: { new: menuNew },
+  MenuItem: { new: vi.fn(async (options: { text: string }) => ({ ...options, close: vi.fn() })) },
 }));
 
 vi.mock('@tauri-apps/api/window', () => ({

--- a/apps/readest-app/src/__tests__/app/library/book-context-menu-popup-position.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/book-context-menu-popup-position.test.tsx
@@ -20,6 +20,7 @@ const menuNew = vi.hoisted(() => vi.fn(async () => ({ popup: popupSpy, close: vi
 
 vi.mock('@tauri-apps/api/menu', () => ({
   Menu: { new: menuNew },
+  MenuItem: { new: vi.fn(async (options: { text: string }) => ({ ...options, close: vi.fn() })) },
 }));
 
 vi.mock('@tauri-apps/plugin-opener', () => ({

--- a/apps/readest-app/src/__tests__/app/library/bookshelf-item-longpress-select.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/bookshelf-item-longpress-select.test.tsx
@@ -18,6 +18,7 @@ import type { Book } from '@/types/book';
 
 vi.mock('@tauri-apps/api/menu', () => ({
   Menu: { new: vi.fn(async () => ({ popup: vi.fn(), close: vi.fn() })) },
+  MenuItem: { new: vi.fn(async (options: { text: string }) => ({ ...options, close: vi.fn() })) },
 }));
 
 vi.mock('@tauri-apps/plugin-opener', () => ({

--- a/apps/readest-app/src/app/library/components/BookshelfItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookshelfItem.tsx
@@ -4,7 +4,7 @@ import { useEnv } from '@/context/EnvContext';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useLongPress } from '@/hooks/useLongPress';
-import { Menu } from '@tauri-apps/api/menu';
+import { Menu, MenuItem } from '@tauri-apps/api/menu';
 import { LogicalPosition } from '@tauri-apps/api/dpi';
 import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import { eventDispatcher } from '@/utils/event';
@@ -108,13 +108,38 @@ const trackPopup = async (popup: Promise<void>) => {
   if (openPopup === settled) openPopup = null;
 };
 
-const releaseMenu = (menu: Promise<Menu>) => {
+interface NativeMenu {
+  menu: Menu;
+  items: MenuItem[];
+}
+
+// Menu.new({ items: [{ text, action }] }) builds each inline item as a Rust
+// temporary: the action's channel is registered under the item id and then
+// unregistered again the moment the built menu drops the last reference to
+// that wrapper, so the menu pops up with every entry dead (issue #6142, from
+// the tauri 2.11.5 bump in #6081). Items created through MenuItem.new are
+// owned by the webview's resource table, so their channels outlive the build.
+const buildNativeMenu = async (items: BookContextMenuItem[]): Promise<NativeMenu> => {
+  // Create every item before the single Menu.new({ items }) call so the order
+  // is whatever the list says — see the Menu.append() IPC race in #4389.
+  const menuItems = await Promise.all(items.map((item) => MenuItem.new(item)));
+  return { menu: await Menu.new({ items: menuItems }), items: menuItems };
+};
+
+const releaseMenu = (built: Promise<NativeMenu>) => {
   const close = () => {
     if (openPopup) {
       void openPopup.then(close);
       return;
     }
-    void menu.then((m) => m.close()).catch(() => {});
+    // The items are owned separately from the menu, so closing the menu alone
+    // would leak one resource per entry on every rebuild.
+    void built
+      .then(async ({ menu, items }) => {
+        await menu.close();
+        await Promise.all(items.map((item) => item.close()));
+      })
+      .catch(() => {});
   };
   close();
 };
@@ -350,11 +375,11 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
   // that the popup visibly lags the right-click (issue #5181). Cache the
   // built menu so popup() fires immediately; hovering the item prewarms the
   // cache so even the first opening is instant.
-  const cachedMenuRef = useRef<Promise<Menu> | null>(null);
+  const cachedMenuRef = useRef<Promise<NativeMenu> | null>(null);
 
   const ensureMenu = () => {
     if (!cachedMenuRef.current) {
-      const building = Menu.new({ items: buildMenuItems() });
+      const building = buildNativeMenu(buildMenuItems());
       building.catch(() => {
         // A failed build must not poison the cache with a rejected promise.
         if (cachedMenuRef.current === building) cachedMenuRef.current = null;
@@ -415,7 +440,7 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
         setInAppMenuPosition(position);
         return;
       }
-      const menu = await ensureMenu();
+      const { menu } = await ensureMenu();
       // Pop up at an explicit position so keyboard invocation (ContextMenu /
       // Shift+F10) anchors the menu to the item instead of wherever the mouse
       // happens to sit. On macOS and Windows — the only platforms still on the


### PR DESCRIPTION
Closes #6142.

## The bug

Every button in the bookshelf context menu became a no-op on macOS and Windows in 0.12.8. The menu pops up correctly, the click dismisses it, and nothing runs. Reported on Windows 11, confirmed on macOS, reproduced here with `pnpm tauri dev`.

## Root cause

`Menu.new({ items: [{ text, action }] })` builds each inline item as a Rust temporary. `MenuItemPayload::create_item` registers the action's channel under the item id and hands an `Arc` clone to `MenuBuilder`; `Menu::append` keeps only muda's own item, so `MenuBuilder::build()` drops the last clone as soon as the menu is built.

Since the tauri 2.11.5 bump in #6081 — which picked up upstream [tauri-apps/tauri#15679](https://github.com/tauri-apps/tauri/pull/15679), *"menu channels are never cleaned up"* — that drop calls `remove_menu_channel` and unregisters the channel that was just registered. The `RunEvent::MenuEvent` for a click then finds nothing to dispatch to, so the action never crosses back into JS.

Verified the commit is absent from the old submodule pin (`61a041281`) and present in the new one (`3156d92b7`). Upstream has no follow-up fix on `dev` yet; this breaks every `Menu.new({items: [{action}]})` caller, not just Readest. The library menu hits it because #4389 consolidated it into a single `Menu.new({ items })` call.

## The fix

Build the items with `MenuItem.new` first, then hand the resolved list to a single `Menu.new({ items })`. Items created that way are added to the webview's resource table, so they are owned and their channels outlive the build. Passing the whole list at once still keeps the order deterministic (#4389), and the hover prewarm keeps the extra IPC round-trips off the right-click path.

The items are owned separately from the menu, so `releaseMenu` now closes them alongside it — otherwise every rebuild would leak one resource per entry, which is exactly the leak upstream #15679 set out to fix.

## Tests

- New `book-context-menu-item-channels.test.tsx` pins both halves: `Menu.new` must receive `MenuItem` resources in list order (no inline `{ text, action }` payloads), and releasing a menu must close every item resource with it. Both cases fail on `main`.
- Existing menu tests needed a `MenuItem` entry in their `@tauri-apps/api/menu` mocks.
- `pnpm test` 919 files / 11071 tests pass, `pnpm lint` and `pnpm format:check` clean.
- Manually verified on macOS: before the change "Show Book Details" did nothing; after it opens the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where actions in native library context menus could become unresponsive.
  * Improved cleanup of context-menu resources to prevent lingering menu items.

* **Tests**
  * Added coverage for context-menu actions, ownership, cleanup, popup positioning, and long-press selection behavior.

* **Chores**
  * Updated the application version to 0.12.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->