### PR TITLE
fix(reader): draw the selection toolbar above the footnote popup

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/components/footnote-popup-toolbar-stacking.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/footnote-popup-toolbar-stacking.browser.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * Stacking order of the selection toolbar over the footnote popup (#6145).
+ *
+ * Text inside the footnote popup is selectable, so the selection toolbar opens
+ * against a selection that lives *in* the popup — the toolbar and its lookup
+ * buttons must own those pixels, exactly like they do over the book page.
+ *
+ * BooksGrid already renders FootnotePopup before Annotator so DOM order put
+ * the toolbar on top while both surfaces sat at z-50. #6036 moved the toolbar
+ * into its own `z-[43]` band (below the range handles) and the tie stopped
+ * being broken by DOM order: the footnote popup's z-50 buried the toolbar, and
+ * the dictionary button under it could not be seen or tapped.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+
+import '@/styles/globals.css';
+
+const h = vi.hoisted(() => ({
+  viewSettings: { vertical: false, rtl: false, scrolled: false },
+  dispatchFootnote: (() => {}) as (detail: unknown) => void,
+  handlers: [] as EventTarget[],
+}));
+
+vi.mock('@/context/EnvContext', () => ({ useEnv: () => ({ appService: { isMobile: false } }) }));
+vi.mock('@/hooks/useTranslation', () => ({ useTranslation: () => (s: string) => s }));
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    getView: () => ({ goTo: () => {} }),
+    getViewSettings: () => h.viewSettings,
+  }),
+}));
+vi.mock('@/store/bookDataStore', () => {
+  const store = (selector?: (s: unknown) => unknown) =>
+    selector ? selector({ booksData: {} }) : { getBookData: () => ({ book: {} }) };
+  store.getState = () => ({ booksData: {} });
+  return { useBookDataStore: store };
+});
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: { getState: () => ({ settings: {} }) },
+}));
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: { getState: () => ({ isDarkMode: false }) },
+  getThemeCode: () => ({}),
+}));
+vi.mock('@/store/customFontStore', () => ({
+  useCustomFontStore: () => ({ getLoadedFonts: () => [] }),
+}));
+vi.mock('@/app/reader/hooks/useFoliateEvents', () => ({ useFoliateEvents: () => {} }));
+vi.mock('@/app/reader/utils/footnoteHeuristics', () => ({
+  shouldCheckAsFootnote: () => false,
+  isLinkTargetVisible: () => true,
+}));
+vi.mock('@/app/reader/utils/annotatorUtil', () => ({
+  drawAnnotationOverlay: () => {},
+  getHighlightColorLabel: (color: string) => color,
+}));
+vi.mock('@/utils/style', () => ({
+  getStyles: () => '',
+  getFootnoteStyles: () => '',
+  getThemeCode: () => ({ bg: '#fff', fg: '#000' }),
+}));
+vi.mock('@/styles/fonts', () => ({
+  mountAdditionalFonts: () => {},
+  mountCustomFont: () => {},
+}));
+vi.mock('foliate-js/footnotes.js', () => {
+  class FootnoteHandler extends EventTarget {
+    constructor() {
+      super();
+      h.handlers.push(this);
+    }
+    handle() {
+      return Promise.resolve();
+    }
+  }
+  return { FootnoteHandler };
+});
+vi.mock('@/utils/event', () => ({
+  eventDispatcher: {
+    on: (name: string, cb: (e: CustomEvent) => void) => {
+      if (name === 'footnote-popup') h.dispatchFootnote = (detail) => cb({ detail } as CustomEvent);
+    },
+    off: () => {},
+    dispatch: () => {},
+  },
+}));
+
+import FootnotePopup from '@/app/reader/components/FootnotePopup';
+import AnnotationPopup from '@/app/reader/components/annotator/AnnotationPopup';
+import { BookDoc } from '@/libs/document';
+
+const NOTE =
+  'nota 3 - Orme di Dante in Italia, tradotto da Egidio Gorra, con una lunga ' +
+  'appendice sulle fonti manoscritte e sulle varianti raccolte dal curatore.';
+
+/** The band a surface actually sits in: the nearest ancestor that sets one. */
+const layerOf = (el: Element | null) => {
+  for (let node = el?.parentElement; node; node = node.parentElement) {
+    const z = getComputedStyle(node).zIndex;
+    if (z !== 'auto') return Number(z);
+  }
+  return null;
+};
+
+let cell: HTMLElement;
+let anchor: HTMLElement;
+
+beforeEach(() => {
+  h.viewSettings = { vertical: false, rtl: false, scrolled: false };
+  h.handlers.length = 0;
+  cell = document.createElement('div');
+  cell.id = 'gridcell-book-1';
+  cell.style.cssText = 'position:fixed;inset:0;';
+  anchor = document.createElement('a');
+  anchor.textContent = 'nota 3';
+  anchor.style.cssText = 'position:absolute;left:40px;top:120px;';
+  cell.appendChild(anchor);
+  document.body.appendChild(cell);
+});
+
+afterEach(() => {
+  cell.remove();
+  cleanup();
+});
+
+/** The footnote popup's own container, never the toolbar's. */
+const footnoteContainer = () =>
+  document.querySelector<HTMLElement>('#popup-container:not(.selection-popup)')!;
+
+/** Open the toolbar on a selection inside the already-open footnote popup. */
+const openToolbarOver = (rect: DOMRect) => {
+  const point = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  render(
+    <AnnotationPopup
+      bookKey='book-1'
+      dir='ltr'
+      isVertical={false}
+      buttons={[
+        {
+          tooltipText: 'Dictionary',
+          Icon: () => <span>D</span>,
+          onClick: () => {},
+        },
+      ]}
+      notes={[]}
+      position={{ point }}
+      trianglePosition={{ point, dir: 'up' }}
+      highlightOptionsVisible={false}
+      selectedStyle='highlight'
+      selectedColor='yellow'
+      popupWidth={240}
+      popupHeight={44}
+      onHighlight={() => {}}
+      onDismiss={() => {}}
+    />,
+  );
+  return document.querySelector<HTMLElement>('.selection-popup')!;
+};
+
+describe('selection toolbar over the footnote popup (#6145)', () => {
+  test('the toolbar owns the pixels it overlaps in the footnote popup', () => {
+    // Mounted in BooksGrid's order: the footnote popup first, the annotator's
+    // toolbar after it.
+    render(<FootnotePopup bookKey='book-1' bookDoc={{} as BookDoc} />);
+    act(() => {
+      h.dispatchFootnote({ bookKey: 'book-1', element: anchor, footnote: NOTE });
+    });
+
+    const footnote = footnoteContainer();
+    expect(footnote.getAttribute('aria-hidden')).toBe('false');
+
+    const toolbar = openToolbarOver(footnote.getBoundingClientRect());
+
+    // Premise: the two boxes really do overlap, so the hit test below means
+    // something.
+    const noteBox = footnote.getBoundingClientRect();
+    const toolBox = toolbar.getBoundingClientRect();
+    const overlap = {
+      left: Math.max(noteBox.left, toolBox.left),
+      top: Math.max(noteBox.top, toolBox.top),
+      right: Math.min(noteBox.right, toolBox.right),
+      bottom: Math.min(noteBox.bottom, toolBox.bottom),
+    };
+    expect(overlap.right).toBeGreaterThan(overlap.left);
+    expect(overlap.bottom).toBeGreaterThan(overlap.top);
+
+    const hit = document.elementFromPoint(
+      (overlap.left + overlap.right) / 2,
+      (overlap.top + overlap.bottom) / 2,
+    );
+    expect(toolbar.contains(hit)).toBe(true);
+  });
+
+  test('the footnote popup sits below the selection toolbar band', () => {
+    render(<FootnotePopup bookKey='book-1' bookDoc={{} as BookDoc} />);
+    act(() => {
+      h.dispatchFootnote({ bookKey: 'book-1', element: anchor, footnote: NOTE });
+    });
+
+    const footnote = footnoteContainer();
+    const toolbar = openToolbarOver(footnote.getBoundingClientRect());
+
+    const footnoteLayer = layerOf(footnote);
+    const toolbarLayer = layerOf(toolbar);
+    expect(footnoteLayer).not.toBeNull();
+    expect(toolbarLayer).not.toBeNull();
+    expect(footnoteLayer!).toBeLessThan(toolbarLayer!);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/BooksGrid.tsx
+++ b/apps/readest-app/src/app/reader/components/BooksGrid.tsx
@@ -265,9 +265,10 @@ const BookCellInner: React.FC<BookCellProps> = ({
       <SearchResultsNav bookKey={bookKey} gridInsets={gridInsets} />
       <BooknotesNav bookKey={bookKey} gridInsets={gridInsets} toc={bookDoc.toc || []} />
       <FootnotePopup bookKey={bookKey} bookDoc={bookDoc} />
-      {/* After FootnotePopup so the selection toolbar and lookup popups stack
-          above the footnote popup (and its dismiss overlay) when the user
-          selects text inside it. */}
+      {/* After FootnotePopup so the lookup popups stack above the footnote
+          popup (and its dismiss overlay) when the user selects text inside it.
+          The selection toolbar no longer rides on this order — it has its own
+          z-[43] band, above the footnote popup's z-[42] (#6145). */}
       <Annotator bookKey={bookKey} contentInsets={contentInsets} />
       <FooterBar
         bookKey={bookKey}

--- a/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
+++ b/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
@@ -698,70 +698,88 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
   return (
     <div ref={containerRef} role='toolbar' tabIndex={-1}>
       {showPopup && <Overlay onDismiss={handleDismissPopup} />}
-      <Popup
-        isOpen={showPopup}
-        width={responsiveWidth}
-        height={responsiveHeight}
-        position={showPopup ? popupPosition! : undefined}
-        trianglePosition={showPopup ? trianglePosition! : undefined}
-        // Scroll along the note's block axis and clip the other one. A note
-        // that wraps can never need a horizontal scrollbar, but leaving that
-        // axis `visible` promotes it to `auto` (CSS resolves `visible` to
-        // `auto` next to a non-`visible` value), so any stray pixel of
-        // cross-axis overflow bought a second scrollbar (#5999).
-        className={clsx(
-          'select-text',
-          viewSettings.vertical
-            ? 'overflow-x-auto overflow-y-hidden'
-            : 'overflow-y-auto overflow-x-hidden',
-        )}
-        onDismiss={handleDismissPopup}
-      >
-        {canGoBack && (
-          // The chrome floats over the text rather than pushing it down, so
-          // the strip must not swallow taps meant for the words beneath it.
-          <div
-            className={clsx(
-              'pointer-events-none absolute z-10 flex gap-1',
-              viewSettings.vertical
-                ? 'bottom-2 end-2 top-2 w-8 flex-col items-end'
-                : 'end-2 start-2 top-2 h-8 flex-row items-start',
-            )}
-          >
+      {/* The note's text is selectable, so the selection toolbar and the range
+          handles open against a selection that lives inside this popup — they
+          have to draw over it, exactly as they do over the book page. That used
+          to fall out of DOM order (BooksGrid mounts Annotator after this) while
+          both surfaces were z-50, until #6036 moved the toolbar into its own
+          `z-[43]` band and this popup's z-50 buried it along with the
+          dictionary button (#6145). So this popup gets a band of its own:
+          below the toolbar (z-[43]) and the handles (z-[44]), above the
+          paragraph overlay and the TTS mini player (z-40). The lookup popups
+          opened from the toolbar stay at z-50 and still cover the note.
+
+          `absolute`, never `fixed`: the popup's coordinates are book-cell
+          relative, and the cell is its `relative` ancestor, so insetting the
+          wrapper to the cell makes the stacking context without moving
+          anything. `pointer-events-none` keeps the cell-covering wrapper from
+          swallowing the outside taps the Overlay above dismisses on. */}
+      <div className='pointer-events-none absolute inset-0 z-[42]'>
+        <Popup
+          isOpen={showPopup}
+          width={responsiveWidth}
+          height={responsiveHeight}
+          position={showPopup ? popupPosition! : undefined}
+          trianglePosition={showPopup ? trianglePosition! : undefined}
+          // Scroll along the note's block axis and clip the other one. A note
+          // that wraps can never need a horizontal scrollbar, but leaving that
+          // axis `visible` promotes it to `auto` (CSS resolves `visible` to
+          // `auto` next to a non-`visible` value), so any stray pixel of
+          // cross-axis overflow bought a second scrollbar (#5999).
+          className={clsx(
+            'select-text pointer-events-auto',
+            viewSettings.vertical
+              ? 'overflow-x-auto overflow-y-hidden'
+              : 'overflow-y-auto overflow-x-hidden',
+          )}
+          onDismiss={handleDismissPopup}
+        >
+          {canGoBack && (
+            // The chrome floats over the text rather than pushing it down, so
+            // the strip must not swallow taps meant for the words beneath it.
+            <div
+              className={clsx(
+                'pointer-events-none absolute z-10 flex gap-1',
+                viewSettings.vertical
+                  ? 'bottom-2 end-2 top-2 w-8 flex-col items-end'
+                  : 'end-2 start-2 top-2 h-8 flex-row items-start',
+              )}
+            >
+              <button
+                type='button'
+                onClick={handleBack}
+                aria-label={_('Back')}
+                title={_('Back')}
+                className={clsx(chromeButtonClassName, 'pointer-events-auto')}
+              >
+                <MdArrowBack size={size18} />
+              </button>
+            </div>
+          )}
+          {sourceHref && (
+            // Park it where the note's last line runs out instead of over its
+            // opening words (#5998). Physical sides, not logical ones: the corner
+            // follows the book's own direction, which the popup's `dir` (the UI
+            // language) does not track.
             <button
               type='button'
-              onClick={handleBack}
-              aria-label={_('Back')}
-              title={_('Back')}
-              className={clsx(chromeButtonClassName, 'pointer-events-auto')}
+              onClick={handleGoToSource}
+              aria-label={_('Jump to Location')}
+              title={_('Jump to Location')}
+              className={clsx(
+                chromeButtonClassName,
+                'absolute bottom-2 z-10',
+                viewSettings.vertical || viewSettings.rtl ? 'left-2' : 'right-2',
+              )}
             >
-              <MdArrowBack size={size18} />
+              <MdOutlineArrowOutward size={size18} />
             </button>
-          </div>
-        )}
-        {sourceHref && (
-          // Park it where the note's last line runs out instead of over its
-          // opening words (#5998). Physical sides, not logical ones: the corner
-          // follows the book's own direction, which the popup's `dir` (the UI
-          // language) does not track.
-          <button
-            type='button'
-            onClick={handleGoToSource}
-            aria-label={_('Jump to Location')}
-            title={_('Jump to Location')}
-            className={clsx(
-              chromeButtonClassName,
-              'absolute bottom-2 z-10',
-              viewSettings.vertical || viewSettings.rtl ? 'left-2' : 'right-2',
-            )}
-          >
-            <MdOutlineArrowOutward size={size18} />
-          </button>
-        )}
-        {/* Fill the popup's content box rather than restating its border-box
-            size, which overflowed it by the border on both axes (#5999). */}
-        <div className='footnote-content h-full w-full' ref={footnoteRef}></div>
-      </Popup>
+          )}
+          {/* Fill the popup's content box rather than restating its border-box
+              size, which overflowed it by the border on both axes (#5999). */}
+          <div className='footnote-content h-full w-full' ref={footnoteRef}></div>
+        </Popup>
+      </div>
     </div>
   );
 };

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationPopup.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationPopup.tsx
@@ -83,9 +83,10 @@ const AnnotationPopup: React.FC<AnnotationPopupProps> = ({
     // wins owns those pixels. The handles are grab targets, so they take it —
     // under the toolbar their covered part stops dragging and fires whichever
     // tool button it landed on instead. Hence z-[43], below the handle layer
-    // (z-[44]) but still above the paragraph/TTS chrome (z-40). Every other
-    // popup surface stays at z-50 and above the handles, so the wrapper is
-    // only here to put this one at 43.
+    // (z-[44]) but still above the paragraph/TTS chrome (z-40) and the
+    // footnote popup (z-[42]), whose text this toolbar also opens against
+    // (#6145). Every popup opened *from* the toolbar stays at z-50 and above
+    // the handles, so the wrapper is only here to put this one at 43.
     //
     // `absolute`, never `fixed`: `position` is in the book cell's coordinate
     // space (Annotator subtracts `#gridcell-<bookKey>`'s rect), and the cell


### PR DESCRIPTION
Fixes #6145.

## The bug

Tap a footnote, then double-tap a word inside the popup: the selection toolbar opens *behind* the note, so the dictionary button is neither visible nor tappable.

## Root cause — a regression from #6036

`BooksGrid` mounts `FootnotePopup` before `Annotator` precisely so the toolbar would win the DOM-order tie while both surfaces sat at `z-50` (there was a comment saying so). #6036 moved the toolbar into its own `z-[43]` band, below the range handles, so DOM order stopped deciding anything and the footnote popup's `z-50` buried the toolbar.

## The fix

Give the footnote popup a band of its own: a `pointer-events-none absolute inset-0 z-[42]` wrapper around its `Popup`, the same stacking-context trick #6036 used on `AnnotationPopup`. `absolute`, never `fixed` — the popup's coordinates are book-cell relative and the cell is its `relative` ancestor, so insetting the wrapper to the cell makes the context without moving anything; `pointer-events-none` keeps the cell-covering wrapper from eating the outside taps the dismiss overlay needs.

Resulting order: paragraph overlay / TTS mini player `z-40` < **footnote popup `z-[42]`** < selection toolbar `z-[43]` < range handles `z-[44]` < sidebar `z-[45]` < lookup popups & dialogs `z-50`.

The rule this settles: a surface whose text can be **selected** (the book page, the footnote popup) belongs *below* the selection band; a surface opened *from* the toolbar (dictionary, translator, note editor) stays at `z-50`, above it.

## Tests

New browser test `footnote-popup-toolbar-stacking.browser.test.tsx` renders `FootnotePopup` plus the real `AnnotationPopup` in BooksGrid's order against real CSS and asserts:

1. `elementFromPoint` at the overlap of the two boxes resolves inside the toolbar (with a premise guard that they really overlap);
2. the footnote popup's computed band is below the toolbar's.

Both fail on `main` and pass with the fix.

`pnpm test` (11071), `pnpm test:browser` (463), `pnpm lint`, `pnpm format:check` all green. Verified live in Chrome on the reporter's own book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reader layering so the selection toolbar remains accessible above overlapping footnote popups.
  * Preserved correct interaction behavior, including popup selection and dismissal when tapping outside.

* **Tests**
  * Added browser coverage to verify stacking order and hit testing between footnote popups and annotation toolbars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->