### PR TITLE
fix(ci): bundle libxkbcommon-x11 in the CEF AppImage

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -162,11 +162,15 @@ jobs:
       # bundle lacks comes from the host at run time and fails against the
       # bundled glibc on any newer distro (NSS: FATAL crypto/nss_util.cc).
       # quick-sharun's DEPLOY_CHROMIUM deploys NSS and, via DEPLOY_PIPEWIRE,
-      # pulse — with the pinned pkgforge script the CLI above uses. Two gaps
+      # pulse — with the pinned pkgforge script the CLI above uses. Three gaps
       # remain, passed as appimage.files under /usr/lib, which the bundler
       # hands to quick-sharun as arguments: Debian keeps the NSS modules in
       # <triple>/nss/ where the Arch-layout globs miss them, and nothing
-      # deploys libspeechd. The npm cli-cef could do none of this: its
+      # deploys libspeechd. winit dlopens libxkbcommon-x11 by soname when it
+      # opens its X11 event loop (the CEF runtime forces X11 even on Wayland),
+      # and quick-sharun's Chromium rule would deploy it, but the runner image
+      # has no copy to deploy; without it every launch panics before the first
+      # log line (#6144). The npm cli-cef could do none of this: its
       # quick-sharun fork drops the `eval` that rebuilds the deploy array
       # (FabianLars/Anylinux-AppImages@3e280d1b), so every DEPLOY_* extra is
       # silently skipped.
@@ -174,14 +178,15 @@ jobs:
         if: matrix.config.release == 'linux'
         run: |
           set -euo pipefail
-          sudo apt-get install -y libnss3 libpulse0 libspeechd2
+          sudo apt-get install -y libnss3 libpulse0 libspeechd2 libxkbcommon-x11-0
           nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
           lib_dir=${nss_dir%/nss}
           sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
           # +=: tauri.conf.json already ships the AppRun hook entry.
           conf=apps/readest-app/src-tauri/tauri.conf.json
           jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
-              "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2")
+              "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2"),
+              "/usr/lib/libxkbcommon-x11.so.0": ($d + "/libxkbcommon-x11.so.0")
             }' "$conf" > "$conf.tmp" && mv "$conf.tmp" "$conf"
 
       - name: create .env.local file for Next.js
@@ -303,7 +308,7 @@ jobs:
           set -euo pipefail
           lib=target/release/bundle/appimage/Readest.AppDir/lib
           for so in libsoftokn3.so libfreeblpriv3.so libnssckbi.so libsqlite3.so.0 \
-                    libpulse.so.0 libspeechd.so.2; do
+                    libpulse.so.0 libspeechd.so.2 libxkbcommon-x11.so.0; do
             [ -e "$lib/$so" ] || { echo "::error::$so is missing from the AppImage bundle"; exit 1; }
           done
           # libpulse finds its private half through a host RUNPATH; lib.path

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,11 +402,15 @@ jobs:
       # bundle lacks comes from the host at run time and fails against the
       # bundled glibc on any newer distro (NSS: FATAL crypto/nss_util.cc).
       # quick-sharun's DEPLOY_CHROMIUM deploys NSS and, via DEPLOY_PIPEWIRE,
-      # pulse — with the pinned pkgforge script the CLI above uses. Two gaps
+      # pulse — with the pinned pkgforge script the CLI above uses. Three gaps
       # remain, passed as appimage.files under /usr/lib, which the bundler
       # hands to quick-sharun as arguments: Debian keeps the NSS modules in
       # <triple>/nss/ where the Arch-layout globs miss them, and nothing
-      # deploys libspeechd. The npm cli-cef could do none of this: its
+      # deploys libspeechd. winit dlopens libxkbcommon-x11 by soname when it
+      # opens its X11 event loop (the CEF runtime forces X11 even on Wayland),
+      # and quick-sharun's Chromium rule would deploy it, but the runner image
+      # has no copy to deploy; without it every launch panics before the first
+      # log line (#6144). The npm cli-cef could do none of this: its
       # quick-sharun fork drops the `eval` that rebuilds the deploy array
       # (FabianLars/Anylinux-AppImages@3e280d1b), so every DEPLOY_* extra is
       # silently skipped.
@@ -414,14 +418,15 @@ jobs:
         if: matrix.config.release == 'linux'
         run: |
           set -euo pipefail
-          sudo apt-get install -y libnss3 libpulse0 libspeechd2
+          sudo apt-get install -y libnss3 libpulse0 libspeechd2 libxkbcommon-x11-0
           nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
           lib_dir=${nss_dir%/nss}
           sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
           # +=: tauri.conf.json already ships the AppRun hook entry.
           conf=apps/readest-app/src-tauri/tauri.conf.json
           jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
-              "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2")
+              "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2"),
+              "/usr/lib/libxkbcommon-x11.so.0": ($d + "/libxkbcommon-x11.so.0")
             }' "$conf" > "$conf.tmp" && mv "$conf.tmp" "$conf"
 
       - name: create .env.local file for Next.js
@@ -560,7 +565,7 @@ jobs:
           set -euo pipefail
           lib=target/release/bundle/appimage/Readest.AppDir/lib
           for so in libsoftokn3.so libfreeblpriv3.so libnssckbi.so libsqlite3.so.0 \
-                    libpulse.so.0 libspeechd.so.2; do
+                    libpulse.so.0 libspeechd.so.2 libxkbcommon-x11.so.0; do
             [ -e "$lib/$so" ] || { echo "::error::$so is missing from the AppImage bundle"; exit 1; }
           done
           # libpulse finds its private half through a host RUNPATH; lib.path

--- a/.github/workflows/try-appimage.yml
+++ b/.github/workflows/try-appimage.yml
@@ -84,25 +84,30 @@ jobs:
       # bundle lacks comes from the host at run time and fails against the
       # bundled glibc on any newer distro (NSS: FATAL crypto/nss_util.cc).
       # quick-sharun's DEPLOY_CHROMIUM deploys NSS and, via DEPLOY_PIPEWIRE,
-      # pulse — with the pinned pkgforge script the CLI above uses. Two gaps
+      # pulse — with the pinned pkgforge script the CLI above uses. Three gaps
       # remain, passed as appimage.files under /usr/lib, which the bundler
       # hands to quick-sharun as arguments: Debian keeps the NSS modules in
       # <triple>/nss/ where the Arch-layout globs miss them, and nothing
-      # deploys libspeechd. The npm cli-cef could do none of this: its
+      # deploys libspeechd. winit dlopens libxkbcommon-x11 by soname when it
+      # opens its X11 event loop (the CEF runtime forces X11 even on Wayland),
+      # and quick-sharun's Chromium rule would deploy it, but the runner image
+      # has no copy to deploy; without it every launch panics before the first
+      # log line (#6144). The npm cli-cef could do none of this: its
       # quick-sharun fork drops the `eval` that rebuilds the deploy array
       # (FabianLars/Anylinux-AppImages@3e280d1b), so every DEPLOY_* extra is
       # silently skipped.
       - name: stage CEF AppImage runtime libraries (linux only)
         run: |
           set -euo pipefail
-          sudo apt-get install -y libnss3 libpulse0 libspeechd2
+          sudo apt-get install -y libnss3 libpulse0 libspeechd2 libxkbcommon-x11-0
           nss_dir=$(dirname "$(ls /usr/lib/*-linux-gnu/nss/libsoftokn3.so)")
           lib_dir=${nss_dir%/nss}
           sudo cp -f --remove-destination "$nss_dir"/*.so "$lib_dir/"
           # +=: tauri.conf.json already ships the AppRun hook entry.
           conf=apps/readest-app/src-tauri/tauri.conf.json
           jq --arg d "$lib_dir" '.bundle.linux.appimage.files += {
-              "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2")
+              "/usr/lib/libspeechd.so.2": ($d + "/libspeechd.so.2"),
+              "/usr/lib/libxkbcommon-x11.so.0": ($d + "/libxkbcommon-x11.so.0")
             }' "$conf" > "$conf.tmp" && mv "$conf.tmp" "$conf"
 
       - name: create .env.local file for Next.js
@@ -139,7 +144,7 @@ jobs:
           set -euo pipefail
           lib=target/release/bundle/appimage/Readest.AppDir/lib
           for so in libsoftokn3.so libfreeblpriv3.so libnssckbi.so libsqlite3.so.0 \
-                    libpulse.so.0 libspeechd.so.2; do
+                    libpulse.so.0 libspeechd.so.2 libxkbcommon-x11.so.0; do
             [ -e "$lib/$so" ] || { echo "::error::$so is missing from the AppImage bundle"; exit 1; }
           done
           # libpulse finds its private half through a host RUNPATH; lib.path


### PR DESCRIPTION
## Problem

The 0.12.8 Linux AppImage panics on every launch before its first log line (reported in #6144):

```
thread 'main' panicked at .../xkbcommon-dl-0.4.2/src/x11.rs:59:28:
Library libxkbcommon-x11.so could not be loaded.
```

winit-x11 0.31 opens its event loop with `Context::from_x11_xkb`, which dlopens `libxkbcommon-x11.so.0` through xkbcommon-dl and panics when the loader cannot find it. The CEF runtime forces X11 (`ozone-platform=x11`, `with_x11()`) even under Wayland, so every AppImage user hits this path. sharun never falls back to host libraries, and the bundle has no copy.

## Why it was missing

The pinned quick-sharun revision does list `libxkbcommon-x11.so*` under the Chromium deploy set (`DEPLOY_COMMON_LIBS`), but the ubuntu-22.04 runner has no `libxkbcommon-x11-0` package installed and the globs skip what they cannot find without failing. `STRACE_MODE=0` means the run-and-trace discovery that would have caught the dlopen is off.

## Fix

In the three workflows that build the CEF AppImage (release, nightly, try-appimage):

- install `libxkbcommon-x11-0` on the runner,
- stage `/usr/lib/libxkbcommon-x11.so.0` explicitly through `appimage.files`, the same way `libspeechd.so.2` is staged,
- add `libxkbcommon-x11.so.0` to the bundle verification step so a missing copy fails the build instead of shipping.

Workflow-only change; no app code touched.

## Notes

The other half of #6144 (the Arch `extra` package dying with SIGSEGV after CEF's request-context log) is a separate failure: that binary gets past winit init, and the same package launches fine on stock Arch in a container. It still needs a backtrace from the reporter.

Refs #6144

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Linux AppImage launches that could fail before startup due to a missing X11 runtime library.
  - Bundled the required library in nightly, test, and release AppImages.
  - Added validation to ensure the library is included in generated Linux packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->