### PR TITLE
fix(proofread): keep selection rules applied after a toggle, edit or reopen (#6148)

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2563,5 +2563,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "افتح موقعًا إلكترونيًا، وقم بتسجيل الدخول إذا لزم الأمر، ثم اختر حفظ الصفحة لحفظه في مكتبتك. يتم أيضًا استيراد الكتب التي تقوم بتنزيلها.",
   "Web URL": "عنوان URL للويب",
   "Loading chapter…": "جارٍ تحميل الفصل…",
-  "Clip Page": "حفظ الصفحة"
+  "Clip Page": "حفظ الصفحة",
+  "Please select text within a single paragraph, or choose another replacement scope.": "يرجى تحديد نص داخل فقرة واحدة، أو اختيار نطاق استبدال آخر."
 }

--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2564,5 +2564,5 @@
   "Web URL": "عنوان URL للويب",
   "Loading chapter…": "جارٍ تحميل الفصل…",
   "Clip Page": "حفظ الصفحة",
-  "Please select text within a single paragraph, or choose another replacement scope.": "يرجى تحديد نص داخل فقرة واحدة، أو اختيار نطاق استبدال آخر."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "يتجاوز هذا التحديد حدود التنسيق أو الفقرة. حدِّد جزءًا أصغر من النص، أو اختر نطاق استبدال آخر."
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "ওয়েব URL",
   "Loading chapter…": "অধ্যায় লোড হচ্ছে…",
   "Clip Page": "ক্লিপ পৃষ্ঠা",
-  "Please select text within a single paragraph, or choose another replacement scope.": "অনুগ্রহ করে একটি অনুচ্ছেদের মধ্যেকার লেখা নির্বাচন করুন, অথবা অন্য একটি প্রতিস্থাপনের পরিসর বেছে নিন।"
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "এই নির্বাচন ফরম্যাটিং বা অনুচ্ছেদের সীমানা অতিক্রম করেছে। ছোট একটি অংশ নির্বাচন করুন, অথবা অন্য একটি প্রতিস্থাপনের পরিসর বেছে নিন।"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "একটি ওয়েবসাইট খুলুন, প্রয়োজনে সাইন ইন করুন, তারপর আপনার লাইব্রেরিতে সংরক্ষণ করতে ক্লিপ পৃষ্ঠা চয়ন করুন৷ আপনার ডাউনলোড করা বইগুলিও আমদানি করা হয়।",
   "Web URL": "ওয়েব URL",
   "Loading chapter…": "অধ্যায় লোড হচ্ছে…",
-  "Clip Page": "ক্লিপ পৃষ্ঠা"
+  "Clip Page": "ক্লিপ পৃষ্ঠা",
+  "Please select text within a single paragraph, or choose another replacement scope.": "অনুগ্রহ করে একটি অনুচ্ছেদের মধ্যেকার লেখা নির্বাচন করুন, অথবা অন্য একটি প্রতিস্থাপনের পরিসর বেছে নিন।"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2264,5 +2264,5 @@
   "Web URL": "དྲ་རྒྱའི་ཁ་བྱང་།",
   "Loading chapter…": "ལེའུ་མངོན་བཞིན་ཡོད།",
   "Clip Page": "ཤོག་ངོས་ཉར་ཚགས།",
-  "Please select text within a single paragraph, or choose another replacement scope.": "ཚིག་ལེའུ་གཅིག་གི་ནང་གི་ཡི་གེ་འདེམས་རོགས། ཡང་ན་ཚབ་བརྗེའི་ཁྱབ་ཁོངས་གཞན་ཞིག་འདེམས་རོགས།"
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "འདེམས་ཟིན་པའི་ཡི་གེ་འདི་བཟོ་བཀོད་དམ་དོན་ཚན་གྱི་མཚམས་བརྒལ་འདུག འདེམས་ཡུལ་ཐུང་བ་ཞིག་འདེམས་རོགས། ཡང་ན་ཚབ་བརྗེའི་གནས་ཚུལ་གཞན་ཞིག་འདེམས་རོགས།"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2263,5 +2263,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "དྲ་ཚིགས་ཁ་ཕྱེ་ནས་དགོས་མཁོ་བྱུང་ན་ཐོ་འགོད་བྱེད་དགོས། དེ་ནས་ཁྱེད་ཀྱི་དཔེ་མཛོད་ནང་དུ་གསོག་འཇོག་བྱེད་པར་ཤོག་ངོས་ཉར་ཚགས། འདེམས། ཁྱེད་ཀྱིས་ཕབ་ལེན་བྱས་པའི་དེབ་རྣམས་ཀྱང་ནང་འདྲེན་བྱེད་ཀྱི་ཡོད།",
   "Web URL": "དྲ་རྒྱའི་ཁ་བྱང་།",
   "Loading chapter…": "ལེའུ་མངོན་བཞིན་ཡོད།",
-  "Clip Page": "ཤོག་ངོས་ཉར་ཚགས།"
+  "Clip Page": "ཤོག་ངོས་ཉར་ཚགས།",
+  "Please select text within a single paragraph, or choose another replacement scope.": "ཚིག་ལེའུ་གཅིག་གི་ནང་གི་ཡི་གེ་འདེམས་རོགས། ཡང་ན་ཚབ་བརྗེའི་ཁྱབ་ཁོངས་གཞན་ཞིག་འདེམས་རོགས།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Öffnen Sie eine Website, melden Sie sich bei Bedarf an und wählen Sie dann Clip-Seite aus, um sie in Ihrer Bibliothek zu speichern. Von Ihnen heruntergeladene Bücher werden ebenfalls importiert.",
   "Web URL": "Web-URL",
   "Loading chapter…": "Kapitel wird geladen…",
-  "Clip Page": "Clip-Seite"
+  "Clip Page": "Clip-Seite",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Bitte wählen Sie Text innerhalb eines einzelnen Absatzes aus oder wählen Sie einen anderen Ersetzungsbereich."
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "Web-URL",
   "Loading chapter…": "Kapitel wird geladen…",
   "Clip Page": "Clip-Seite",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Bitte wählen Sie Text innerhalb eines einzelnen Absatzes aus oder wählen Sie einen anderen Ersetzungsbereich."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Diese Auswahl reicht über Formatierungs- oder Absatzgrenzen hinaus. Wählen Sie einen kleineren Textabschnitt oder einen anderen Ersetzungs-Geltungsbereich."
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "Web-URL",
   "Loading chapter…": "Kapitel wird geladen…",
   "Clip Page": "Clip-Seite",
-  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Diese Auswahl reicht über Formatierungs- oder Absatzgrenzen hinaus. Wählen Sie einen kleineren Textabschnitt oder einen anderen Ersetzungs-Geltungsbereich."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Diese Auswahl reicht über Formatierungs- oder Absatzgrenzen hinaus. Wählen Sie einen kleineren Textabschnitt oder einen anderen Geltungsbereich für die Ersetzung."
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Ανοίξτε έναν ιστότοπο, συνδεθείτε εάν χρειάζεται και, στη συνέχεια, επιλέξτε Κλιπ σελίδας για να τον αποθηκεύσετε στη βιβλιοθήκη σας. Τα βιβλία που κατεβάζετε εισάγονται επίσης.",
   "Web URL": "Διεύθυνση URL Ιστού",
   "Loading chapter…": "Φόρτωση κεφαλαίου…",
-  "Clip Page": "Κλιπ σελίδας"
+  "Clip Page": "Κλιπ σελίδας",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Επιλέξτε κείμενο μέσα σε μία μόνο παράγραφο ή επιλέξτε άλλη εμβέλεια αντικατάστασης."
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "Διεύθυνση URL Ιστού",
   "Loading chapter…": "Φόρτωση κεφαλαίου…",
   "Clip Page": "Κλιπ σελίδας",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Επιλέξτε κείμενο μέσα σε μία μόνο παράγραφο ή επιλέξτε άλλη εμβέλεια αντικατάστασης."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Αυτή η επιλογή εκτείνεται πέρα από όρια μορφοποίησης ή παραγράφου. Επιλέξτε μικρότερο τμήμα κειμένου ή επιλέξτε άλλο εύρος εφαρμογής αντικατάστασης."
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2384,5 +2384,5 @@
   "Web URL": "URL web",
   "Loading chapter…": "Cargando capítulo…",
   "Clip Page": "Recortar página",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Seleccione texto dentro de un solo párrafo o elija otro ámbito de reemplazo."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Esta selección abarca límites de formato o de párrafo. Seleccione un fragmento de texto más corto o elija otro ámbito de reemplazo."
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2383,5 +2383,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Abra un sitio web, inicie sesión si es necesario y luego elija Recortar página para guardarlo en su biblioteca. Los libros que descargas también se importan.",
   "Web URL": "URL web",
   "Loading chapter…": "Cargando capítulo…",
-  "Clip Page": "Recortar página"
+  "Clip Page": "Recortar página",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Seleccione texto dentro de un solo párrafo o elija otro ámbito de reemplazo."
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "آدرس وب",
   "Loading chapter…": "در حال بارگیری فصل…",
   "Clip Page": "صفحه کلیپ",
-  "Please select text within a single paragraph, or choose another replacement scope.": "لطفاً متنی را در یک پاراگراف واحد انتخاب کنید یا محدودهٔ جایگزینی دیگری برگزینید."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "این انتخاب از مرزهای قالب‌بندی یا پاراگراف عبور می‌کند. بخش کوتاه‌تری از متن را انتخاب کنید یا دامنهٔ جایگزینی دیگری برگزینید."
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "وب سایتی را باز کنید، در صورت نیاز وارد شوید، سپس صفحه کلیپ را انتخاب کنید تا آن را در کتابخانه خود ذخیره کنید. کتاب هایی که دانلود می کنید نیز وارد می شوند.",
   "Web URL": "آدرس وب",
   "Loading chapter…": "در حال بارگیری فصل…",
-  "Clip Page": "صفحه کلیپ"
+  "Clip Page": "صفحه کلیپ",
+  "Please select text within a single paragraph, or choose another replacement scope.": "لطفاً متنی را در یک پاراگراف واحد انتخاب کنید یا محدودهٔ جایگزینی دیگری برگزینید."
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2384,5 +2384,5 @@
   "Web URL": "URL Web",
   "Loading chapter…": "Chargement du chapitre…",
   "Clip Page": "Capturer la page",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Veuillez sélectionner du texte à l’intérieur d’un seul paragraphe ou choisir une autre portée de remplacement."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Cette sélection franchit des limites de mise en forme ou de paragraphe. Sélectionnez un fragment de texte plus court ou choisissez une autre portée de remplacement."
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2383,5 +2383,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Ouvrez un site Web, connectez-vous si nécessaire, puis choisissez Capturer la page pour l'enregistrer dans votre bibliothèque. Les livres que vous téléchargez sont également importés.",
   "Web URL": "URL Web",
   "Loading chapter…": "Chargement du chapitre…",
-  "Clip Page": "Capturer la page"
+  "Clip Page": "Capturer la page",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Veuillez sélectionner du texte à l’intérieur d’un seul paragraphe ou choisir une autre portée de remplacement."
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2383,5 +2383,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "פתח אתר, היכנס במידת הצורך ולאחר מכן בחר דף קליפ כדי לשמור אותו בספרייה שלך. גם ספרים שאתה מוריד מיובאים.",
   "Web URL": "כתובת אתר אינטרנט",
   "Loading chapter…": "טוען פרק…",
-  "Clip Page": "דף קליפ"
+  "Clip Page": "דף קליפ",
+  "Please select text within a single paragraph, or choose another replacement scope.": "יש לבחור טקסט בתוך פסקה אחת, או לבחור טווח החלפה אחר."
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2384,5 +2384,5 @@
   "Web URL": "כתובת אתר אינטרנט",
   "Loading chapter…": "טוען פרק…",
   "Clip Page": "דף קליפ",
-  "Please select text within a single paragraph, or choose another replacement scope.": "יש לבחור טקסט בתוך פסקה אחת, או לבחור טווח החלפה אחר."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "הבחירה חוצה גבולות של עיצוב או פסקה. יש לבחור קטע טקסט קצר יותר, או לבחור טווח החלפה אחר."
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "वेब यूआरएल",
   "Loading chapter…": "अध्याय लोड हो रहा है…",
   "Clip Page": "क्लिप पेज",
-  "Please select text within a single paragraph, or choose another replacement scope.": "कृपया एक ही अनुच्छेद के भीतर का पाठ चुनें, या कोई दूसरा प्रतिस्थापन दायरा चुनें।"
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "यह चयन फ़ॉर्मैटिंग या पैराग्राफ की सीमाओं को पार करता है। छोटा पाठ चुनें, या कोई दूसरा प्रतिस्थापन क्षेत्र चुनें।"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "एक वेबसाइट खोलें, यदि आवश्यक हो तो साइन इन करें, फिर इसे अपनी लाइब्रेरी में सहेजने के लिए क्लिप पेज चुनें। आपके द्वारा डाउनलोड की जाने वाली पुस्तकें भी आयातित होती हैं।",
   "Web URL": "वेब यूआरएल",
   "Loading chapter…": "अध्याय लोड हो रहा है…",
-  "Clip Page": "क्लिप पेज"
+  "Clip Page": "क्लिप पेज",
+  "Please select text within a single paragraph, or choose another replacement scope.": "कृपया एक ही अनुच्छेद के भीतर का पाठ चुनें, या कोई दूसरा प्रतिस्थापन दायरा चुनें।"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "Web URL",
   "Loading chapter…": "Fejezet betöltése…",
   "Clip Page": "Oldal mentése",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Egyetlen bekezdésen belüli szöveget jelöljön ki, vagy válasszon másik cserehatókört."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "A kijelölés formázási vagy bekezdéshatárokon nyúlik át. Jelöljön ki rövidebb szövegrészt, vagy válasszon másik cserehatókört."
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Nyisson meg egy webhelyet, jelentkezzen be, ha szükséges, majd válassza a Oldal mentése lehetőséget, hogy elmentse a könyvtárába. A letöltött könyveket is importálja a rendszer.",
   "Web URL": "Web URL",
   "Loading chapter…": "Fejezet betöltése…",
-  "Clip Page": "Oldal mentése"
+  "Clip Page": "Oldal mentése",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Egyetlen bekezdésen belüli szöveget jelöljön ki, vagy válasszon másik cserehatókört."
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2263,5 +2263,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Buka situs web, masuk jika perlu, lalu pilih Halaman Klip untuk menyimpannya ke perpustakaan Anda. Buku yang Anda unduh juga diimpor.",
   "Web URL": "URL web",
   "Loading chapter…": "Memuat bab…",
-  "Clip Page": "Halaman Klip"
+  "Clip Page": "Halaman Klip",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Pilih teks dalam satu paragraf, atau pilih cakupan penggantian lain."
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2264,5 +2264,5 @@
   "Web URL": "URL web",
   "Loading chapter…": "Memuat bab…",
   "Clip Page": "Halaman Klip",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Pilih teks dalam satu paragraf, atau pilih cakupan penggantian lain."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Pilihan ini melintasi batas pemformatan atau paragraf. Pilih potongan teks yang lebih pendek, atau pilih cakupan penggantian lain."
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2384,5 +2384,5 @@
   "Web URL": "URL Web",
   "Loading chapter…": "Caricamento capitolo…",
   "Clip Page": "Ritaglia pagina",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Seleziona il testo all’interno di un solo paragrafo oppure scegli un altro ambito di sostituzione."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Questa selezione attraversa confini di formattazione o di paragrafo. Seleziona una porzione di testo più breve oppure scegli un altro ambito di sostituzione."
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2383,5 +2383,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Apri un sito Web, accedi se necessario, quindi scegli Ritaglia pagina per salvarlo nella tua libreria. Vengono importati anche i libri scaricati.",
   "Web URL": "URL Web",
   "Loading chapter…": "Caricamento capitolo…",
-  "Clip Page": "Ritaglia pagina"
+  "Clip Page": "Ritaglia pagina",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Seleziona il testo all’interno di un solo paragrafo oppure scegli un altro ambito di sostituzione."
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2263,5 +2263,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Web サイトを開き、必要に応じてサインインし、ページをクリップ を選択してライブラリに保存します。ダウンロードした書籍もインポートされます。",
   "Web URL": "ウェブURL",
   "Loading chapter…": "章を読み込んでいます…",
-  "Clip Page": "ページをクリップ"
+  "Clip Page": "ページをクリップ",
+  "Please select text within a single paragraph, or choose another replacement scope.": "1つの段落内のテキストを選択するか、別の置換範囲を選んでください。"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2264,5 +2264,5 @@
   "Web URL": "ウェブURL",
   "Loading chapter…": "章を読み込んでいます…",
   "Clip Page": "ページをクリップ",
-  "Please select text within a single paragraph, or choose another replacement scope.": "1つの段落内のテキストを選択するか、別の置換範囲を選んでください。"
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "この選択範囲は書式や段落の境界をまたいでいます。より短い範囲を選択するか、別の置換の適用範囲を選んでください。"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "ვებ URL",
   "Loading chapter…": "იტვირთება თავი…",
   "Clip Page": "გვერდის შენახვა",
-  "Please select text within a single paragraph, or choose another replacement scope.": "აირჩიეთ ტექსტი ერთი აბზაცის ფარგლებში, ან აირჩიეთ ჩანაცვლების სხვა არეალი."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "მონიშნული ტექსტი სცილდება ფორმატირების ან აბზაცის საზღვრებს. მონიშნეთ უფრო მოკლე ფრაგმენტი, ან აირჩიეთ ჩანაცვლების სხვა არეალი."
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "გახსენით ვებსაიტი, შედით სისტემაში საჭიროების შემთხვევაში, შემდეგ აირჩიეთ გვერდის შენახვა თქვენს ბიბლიოთეკაში შესანახად. თქვენ მიერ გადმოწერილი წიგნები ასევე იმპორტირებულია.",
   "Web URL": "ვებ URL",
   "Loading chapter…": "იტვირთება თავი…",
-  "Clip Page": "გვერდის შენახვა"
+  "Clip Page": "გვერდის შენახვა",
+  "Please select text within a single paragraph, or choose another replacement scope.": "აირჩიეთ ტექსტი ერთი აბზაცის ფარგლებში, ან აირჩიეთ ჩანაცვლების სხვა არეალი."
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2263,5 +2263,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "웹사이트를 열고 필요한 경우 로그인한 다음 페이지 클립를 선택하여 라이브러리에 저장하세요. 다운로드한 책도 가져옵니다.",
   "Web URL": "웹 URL",
   "Loading chapter…": "챕터 로드 중…",
-  "Clip Page": "페이지 클립"
+  "Clip Page": "페이지 클립",
+  "Please select text within a single paragraph, or choose another replacement scope.": "한 문단 안에서 텍스트를 선택하거나 다른 바꾸기 범위를 선택하세요."
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2264,5 +2264,5 @@
   "Web URL": "웹 URL",
   "Loading chapter…": "챕터 로드 중…",
   "Clip Page": "페이지 클립",
-  "Please select text within a single paragraph, or choose another replacement scope.": "한 문단 안에서 텍스트를 선택하거나 다른 바꾸기 범위를 선택하세요."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "이 선택 영역이 서식 또는 단락 경계를 넘습니다. 더 짧은 텍스트를 선택하거나 다른 바꾸기 적용 범위를 선택하세요."
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2263,5 +2263,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Buka tapak web, log masuk jika perlu, kemudian pilih Halaman Klip untuk menyimpannya ke pustaka anda. Buku yang anda muat turun juga diimport.",
   "Web URL": "URL web",
   "Loading chapter…": "Memuatkan bab…",
-  "Clip Page": "Halaman Klip"
+  "Clip Page": "Halaman Klip",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Sila pilih teks dalam satu perenggan, atau pilih skop penggantian lain."
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2264,5 +2264,5 @@
   "Web URL": "URL web",
   "Loading chapter…": "Memuatkan bab…",
   "Clip Page": "Halaman Klip",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Sila pilih teks dalam satu perenggan, atau pilih skop penggantian lain."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Pilihan ini merentasi sempadan pemformatan atau perenggan. Pilih petikan teks yang lebih pendek, atau pilih skop penggantian lain."
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Open een website, log indien nodig in en kies vervolgens Clippagina om deze in uw bibliotheek op te slaan. Boeken die u downloadt, worden ook geïmporteerd.",
   "Web URL": "Web-URL",
   "Loading chapter…": "Hoofdstuk laden…",
-  "Clip Page": "Clippagina"
+  "Clip Page": "Clippagina",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Selecteer tekst binnen één alinea of kies een ander vervangingsbereik."
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "Web-URL",
   "Loading chapter…": "Hoofdstuk laden…",
   "Clip Page": "Clippagina",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Selecteer tekst binnen één alinea of kies een ander vervangingsbereik."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Deze selectie loopt over opmaak- of alineagrenzen heen. Selecteer een kleiner stuk tekst of kies een ander vervangingsbereik."
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2443,5 +2443,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Otwórz stronę internetową, zaloguj się w razie potrzeby, a następnie wybierz Przytnij stronę, aby zapisać ją w swojej bibliotece. Pobrane książki również zostaną zaimportowane.",
   "Web URL": "Adres internetowy",
   "Loading chapter…": "Ładowanie rozdziału…",
-  "Clip Page": "Przytnij stronę"
+  "Clip Page": "Przytnij stronę",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Zaznacz tekst w obrębie jednego akapitu lub wybierz inny zakres zamiany."
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2444,5 +2444,5 @@
   "Web URL": "Adres internetowy",
   "Loading chapter…": "Ładowanie rozdziału…",
   "Clip Page": "Przytnij stronę",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Zaznacz tekst w obrębie jednego akapitu lub wybierz inny zakres zamiany."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "To zaznaczenie wykracza poza granice formatowania lub akapitu. Zaznacz krótszy fragment tekstu albo wybierz inny zakres zamiany."
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2383,5 +2383,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Abra um site, faça login se necessário e escolha Recortar página para salvá-lo em sua biblioteca. Os livros que você baixa também são importados.",
   "Web URL": "URL da Web",
   "Loading chapter…": "Carregando capítulo…",
-  "Clip Page": "Recortar página"
+  "Clip Page": "Recortar página",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Selecione texto dentro de um único parágrafo ou escolha outro escopo de substituição."
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2384,5 +2384,5 @@
   "Web URL": "URL da Web",
   "Loading chapter…": "Carregando capítulo…",
   "Clip Page": "Recortar página",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Selecione texto dentro de um único parágrafo ou escolha outro escopo de substituição."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Esta seleção abrange limites de formatação ou de parágrafo. Selecione um trecho de texto menor ou escolha outro escopo de substituição."
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2384,5 +2384,5 @@
   "Web URL": "URL da Web",
   "Loading chapter…": "Carregando capítulo…",
   "Clip Page": "Recortar página",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Selecione texto dentro de um único parágrafo ou escolha outro âmbito de substituição."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Esta seleção abrange limites de formatação ou de parágrafo. Selecione um trecho de texto mais curto ou escolha outro âmbito de substituição."
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2383,5 +2383,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Abra um site, faça login se necessário e escolha Recortar página para salvá-lo em sua biblioteca. Os livros que você baixa também são importados.",
   "Web URL": "URL da Web",
   "Loading chapter…": "Carregando capítulo…",
-  "Clip Page": "Recortar página"
+  "Clip Page": "Recortar página",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Selecione texto dentro de um único parágrafo ou escolha outro âmbito de substituição."
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2384,5 +2384,5 @@
   "Web URL": "Adresa URL web",
   "Loading chapter…": "Se încarcă capitolul…",
   "Clip Page": "Salvează pagina",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Selectați text dintr-un singur paragraf sau alegeți alt domeniu de înlocuire."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Această selecție depășește limite de formatare sau de paragraf. Selectați o porțiune de text mai scurtă sau alegeți alt domeniu de aplicare a înlocuirii."
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2383,5 +2383,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Deschideți un site web, conectați-vă dacă este necesar, apoi alegeți Salvează pagina pentru a-l salva în bibliotecă. Cărțile pe care le descărcați sunt de asemenea importate.",
   "Web URL": "Adresa URL web",
   "Loading chapter…": "Se încarcă capitolul…",
-  "Clip Page": "Salvează pagina"
+  "Clip Page": "Salvează pagina",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Selectați text dintr-un singur paragraf sau alegeți alt domeniu de înlocuire."
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2444,5 +2444,5 @@
   "Web URL": "URL-адрес веб-страницы",
   "Loading chapter…": "Загрузка главы…",
   "Clip Page": "Сохранить страницу",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Выделите текст в пределах одного абзаца или выберите другую область замены."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Это выделение пересекает границы форматирования или абзаца. Выделите более короткий фрагмент текста или выберите другую область применения замены."
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2443,5 +2443,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Откройте веб-сайт, при необходимости войдите в систему, затем выберите Сохранить страницу, чтобы сохранить его в своей библиотеке. Скачиваемые вами книги также импортируются.",
   "Web URL": "URL-адрес веб-страницы",
   "Loading chapter…": "Загрузка главы…",
-  "Clip Page": "Сохранить страницу"
+  "Clip Page": "Сохранить страницу",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Выделите текст в пределах одного абзаца или выберите другую область замены."
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "වෙබ් URL",
   "Loading chapter…": "පරිච්ඡේදය පූරණය වෙමින්…",
   "Clip Page": "ක්ලිප් පිටුව",
-  "Please select text within a single paragraph, or choose another replacement scope.": "කරුණාකර තනි ඡේදයක් තුළ ඇති පෙළ තෝරන්න, නැතහොත් වෙනත් ප්‍රතිස්ථාපන විෂය පථයක් තෝරන්න."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "මෙම තේරීම හැඩතල හෝ ඡේද මායිම් ඉක්මවා යයි. කෙටි පෙළ කොටසක් තෝරන්න, නැතහොත් වෙනත් ප්‍රතිස්ථාපන පරාසයක් තෝරන්න."
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "වෙබ් අඩවියක් විවෘත කරන්න, අවශ්‍ය නම් පුරනය වන්න, ඉන්පසු එය ඔබගේ පුස්තකාලයට සුරැකීමට ක්ලිප් පිටුව තෝරන්න. ඔබ බාගත කරන පොත් ද ආනයනය කරනු ලැබේ.",
   "Web URL": "වෙබ් URL",
   "Loading chapter…": "පරිච්ඡේදය පූරණය වෙමින්…",
-  "Clip Page": "ක්ලිප් පිටුව"
+  "Clip Page": "ක්ලිප් පිටුව",
+  "Please select text within a single paragraph, or choose another replacement scope.": "කරුණාකර තනි ඡේදයක් තුළ ඇති පෙළ තෝරන්න, නැතහොත් වෙනත් ප්‍රතිස්ථාපන විෂය පථයක් තෝරන්න."
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2444,5 +2444,5 @@
   "Web URL": "Spletni URL",
   "Loading chapter…": "Nalaganje poglavja …",
   "Clip Page": "Stran posnetka",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Izberite besedilo znotraj enega odstavka ali izberite drug obseg zamenjave."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Ta izbira sega čez meje oblikovanja ali odstavka. Izberite krajši del besedila ali izberite drug obseg zamenjave."
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2443,5 +2443,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Odprite spletno mesto, po potrebi se prijavite in izberite Stran posnetka, da ga shranite v knjižnico. Uvožene so tudi knjige, ki jih prenesete.",
   "Web URL": "Spletni URL",
   "Loading chapter…": "Nalaganje poglavja …",
-  "Clip Page": "Stran posnetka"
+  "Clip Page": "Stran posnetka",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Izberite besedilo znotraj enega odstavka ali izberite drug obseg zamenjave."
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Öppna en webbplats, logga in om det behövs och välj sedan Klippsida för att spara den i ditt bibliotek. Böcker du laddar ner importeras också.",
   "Web URL": "Webb-URL",
   "Loading chapter…": "Laddar kapitel…",
-  "Clip Page": "Klippsida"
+  "Clip Page": "Klippsida",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Markera text inom ett enda stycke eller välj ett annat ersättningsomfång."
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "Webb-URL",
   "Loading chapter…": "Laddar kapitel…",
   "Clip Page": "Klippsida",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Markera text inom ett enda stycke eller välj ett annat ersättningsomfång."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Markeringen sträcker sig över formaterings- eller styckegränser. Markera en kortare textbit eller välj en annan omfattning för ersättningen."
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "இணையதளத்தைத் திறந்து, தேவைப்பட்டால் உள்நுழைந்து, அதை உங்கள் நூலகத்தில் சேமிக்க கிளிப் பக்கம் என்பதைத் தேர்ந்தெடுக்கவும். நீங்கள் பதிவிறக்கும் புத்தகங்களும் இறக்குமதி செய்யப்படுகின்றன.",
   "Web URL": "இணைய URL",
   "Loading chapter…": "அத்தியாயத்தை ஏற்றுகிறது…",
-  "Clip Page": "கிளிப் பக்கம்"
+  "Clip Page": "கிளிப் பக்கம்",
+  "Please select text within a single paragraph, or choose another replacement scope.": "ஒரே பத்திக்குள் உள்ள உரையைத் தேர்ந்தெடுக்கவும், அல்லது வேறு மாற்று வரம்பைத் தேர்வுசெய்யவும்."
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "இணைய URL",
   "Loading chapter…": "அத்தியாயத்தை ஏற்றுகிறது…",
   "Clip Page": "கிளிப் பக்கம்",
-  "Please select text within a single paragraph, or choose another replacement scope.": "ஒரே பத்திக்குள் உள்ள உரையைத் தேர்ந்தெடுக்கவும், அல்லது வேறு மாற்று வரம்பைத் தேர்வுசெய்யவும்."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "இந்தத் தேர்வு வடிவமைப்பு அல்லது பத்தி எல்லைகளைத் தாண்டுகிறது. சிறிய உரைப் பகுதியைத் தேர்ந்தெடுக்கவும், அல்லது வேறு மாற்று வளயத்தைத் தேர்வுசெய்யவும்."
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2264,5 +2264,5 @@
   "Web URL": "URL ของเว็บ",
   "Loading chapter…": "กำลังโหลดบท…",
   "Clip Page": "หน้าคลิป",
-  "Please select text within a single paragraph, or choose another replacement scope.": "โปรดเลือกข้อความภายในย่อหน้าเดียว หรือเลือกขอบเขตการแทนที่อื่น"
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "การเลือกนี้คร่อมขอบเขตของการจัดรูปแบบหรือย่อหน้า เลือกข้อความที่สั้นลง หรือเลือกขอบเขตการแทนที่อื่น"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2263,5 +2263,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "เปิดเว็บไซต์ ลงชื่อเข้าใช้หากจำเป็น จากนั้นเลือก หน้าคลิป เพื่อบันทึกลงในห้องสมุดของคุณ หนังสือที่คุณดาวน์โหลดจะถูกนำเข้าด้วย",
   "Web URL": "URL ของเว็บ",
   "Loading chapter…": "กำลังโหลดบท…",
-  "Clip Page": "หน้าคลิป"
+  "Clip Page": "หน้าคลิป",
+  "Please select text within a single paragraph, or choose another replacement scope.": "โปรดเลือกข้อความภายในย่อหน้าเดียว หรือเลือกขอบเขตการแทนที่อื่น"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Bir web sitesi açın, gerekiyorsa oturum açın ve ardından kitaplığınıza kaydetmek için Sayfayı Kırp öğesini seçin. İndirdiğiniz kitaplar da içe aktarılır.",
   "Web URL": "Web URL'si",
   "Loading chapter…": "Bölüm yükleniyor…",
-  "Clip Page": "Sayfayı Kırp"
+  "Clip Page": "Sayfayı Kırp",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Lütfen tek bir paragraf içindeki metni seçin veya başka bir değiştirme kapsamı seçin."
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "Web URL'si",
   "Loading chapter…": "Bölüm yükleniyor…",
   "Clip Page": "Sayfayı Kırp",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Lütfen tek bir paragraf içindeki metni seçin veya başka bir değiştirme kapsamı seçin."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Bu seçim biçimlendirme veya paragraf sınırlarını aşıyor. Daha kısa bir metin parçası seçin ya da başka bir değiştirme kapsamı belirleyin."
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2443,5 +2443,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Відкрийте веб-сайт, увійдіть, якщо потрібно, а потім виберіть Сторінка кліпу, щоб зберегти його у своїй бібліотеці. Книги, які ви завантажуєте, також імпортуються.",
   "Web URL": "Веб-адреса",
   "Loading chapter…": "Завантаження розділу…",
-  "Clip Page": "Сторінка кліпу"
+  "Clip Page": "Сторінка кліпу",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Виберіть текст у межах одного абзацу або оберіть іншу область заміни."
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2444,5 +2444,5 @@
   "Web URL": "Веб-адреса",
   "Loading chapter…": "Завантаження розділу…",
   "Clip Page": "Сторінка кліпу",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Виберіть текст у межах одного абзацу або оберіть іншу область заміни."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Це виділення перетинає межі форматування або абзацу. Виділіть коротший фрагмент тексту або оберіть іншу область застосування заміни."
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2323,5 +2323,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Veb-saytni oching, agar kerak bo'lsa tizimga kiring, keyin uni kutubxonangizga saqlash uchun Sahifani saqlash ni tanlang. Siz yuklab olgan kitoblar ham import qilinadi.",
   "Web URL": "Veb URL",
   "Loading chapter…": "Bob yuklanmoqda…",
-  "Clip Page": "Sahifani saqlash"
+  "Clip Page": "Sahifani saqlash",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Iltimos, bitta xatboshi ichidagi matnni tanlang yoki boshqa almashtirish doirasini tanlang."
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2324,5 +2324,5 @@
   "Web URL": "Veb URL",
   "Loading chapter…": "Bob yuklanmoqda…",
   "Clip Page": "Sahifani saqlash",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Iltimos, bitta xatboshi ichidagi matnni tanlang yoki boshqa almashtirish doirasini tanlang."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Bu tanlov formatlash yoki xatboshi chegaralaridan chiqib ketadi. Qisqaroq matn qismini tanlang yoki boshqa almashtirish qamrovini tanlang."
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2263,5 +2263,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "Mở một trang web, đăng nhập nếu cần, sau đó chọn Trang Clip để lưu vào thư viện của bạn. Sách bạn tải xuống cũng được nhập.",
   "Web URL": "URL web",
   "Loading chapter…": "Đang tải chương…",
-  "Clip Page": "Trang Clip"
+  "Clip Page": "Trang Clip",
+  "Please select text within a single paragraph, or choose another replacement scope.": "Vui lòng chọn văn bản trong cùng một đoạn, hoặc chọn phạm vi thay thế khác."
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2264,5 +2264,5 @@
   "Web URL": "URL web",
   "Loading chapter…": "Đang tải chương…",
   "Clip Page": "Trang Clip",
-  "Please select text within a single paragraph, or choose another replacement scope.": "Vui lòng chọn văn bản trong cùng một đoạn, hoặc chọn phạm vi thay thế khác."
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "Vùng chọn này vượt qua ranh giới định dạng hoặc đoạn văn. Hãy chọn một đoạn văn bản ngắn hơn, hoặc chọn phạm vi thay thế khác."
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2264,5 +2264,5 @@
   "Web URL": "网址",
   "Loading chapter…": "正在加载章节…",
   "Clip Page": "剪藏页面",
-  "Please select text within a single paragraph, or choose another replacement scope.": "请选择同一段落内的文本，或改用其他替换范围。"
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "所选内容跨越了格式或段落边界。请选择更短的文本，或改用其他替换作用范围。"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2263,5 +2263,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "打开网站，根据需要登录，然后选择 剪藏页面 将其保存到您的库中。您下载的书籍也会导入。",
   "Web URL": "网址",
   "Loading chapter…": "正在加载章节…",
-  "Clip Page": "剪藏页面"
+  "Clip Page": "剪藏页面",
+  "Please select text within a single paragraph, or choose another replacement scope.": "请选择同一段落内的文本，或改用其他替换范围。"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2263,5 +2263,6 @@
   "Open a website, sign in if needed, then choose Clip Page to save it to your library. Books you download are also imported.": "打開網站，根據需要登錄，然後選擇 剪藏頁面 將其儲存到您的庫中。您下載的書籍也會匯入。",
   "Web URL": "網址",
   "Loading chapter…": "正在載入章節…",
-  "Clip Page": "剪藏頁面"
+  "Clip Page": "剪藏頁面",
+  "Please select text within a single paragraph, or choose another replacement scope.": "請選擇同一段落內的文字，或改用其他替換範圍。"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2264,5 +2264,5 @@
   "Web URL": "網址",
   "Loading chapter…": "正在載入章節…",
   "Clip Page": "剪藏頁面",
-  "Please select text within a single paragraph, or choose another replacement scope.": "請選擇同一段落內的文字，或改用其他替換範圍。"
+  "This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.": "所選內容跨越了格式或段落邊界。請選擇更短的文字，或改用其他替換適用範圍。"
 }

--- a/apps/readest-app/src/__tests__/components/ProofreadPopup.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ProofreadPopup.test.tsx
@@ -416,6 +416,34 @@ describe('ProofreadPopup Component', () => {
       expect(p.childNodes.length).toBe(3);
     });
 
+    it('splices the same trimmed text the rule will persist', async () => {
+      // The rule stores the trimmed replacement, so an untrimmed live edit
+      // would show text this session that no later replay reproduces.
+      const p = document.createElement('p');
+      p.innerHTML = 'Hello <em>brave</em> world';
+      const tail = p.lastChild as Text;
+      const range = rangeOver(p, tail, 1, 6);
+
+      renderWithProviders(
+        <ProofreadPopup
+          {...defaultProps}
+          selection={{ ...defaultProps.selection, text: 'world', range }}
+        />,
+      );
+
+      fireEvent.change(screen.getByPlaceholderText('Enter text...'), {
+        target: { value: '  planet  ' },
+      });
+      fireEvent.click(screen.getByText('Apply'));
+
+      await waitFor(() => {
+        expect(mockOnConfirm).toHaveBeenCalledWith(
+          expect.objectContaining({ replacement: 'planet' }),
+        );
+      });
+      expect(p.innerHTML).toBe('Hello <em>brave</em> planet');
+    });
+
     it('refuses a selection rule the transformer could never replay', async () => {
       const toast = vi.spyOn(eventDispatcher, 'dispatch');
       const p = document.createElement('p');

--- a/apps/readest-app/src/__tests__/components/ProofreadPopup.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ProofreadPopup.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { EnvProvider } from '@/context/EnvContext';
 import ProofreadPopup from '@/app/reader/components/annotator/ProofreadPopup';
+import { useReaderStore } from '@/store/readerStore';
+import { eventDispatcher } from '@/utils/event';
 
 vi.mock('@/services/environment', async () => {
   const actual = await vi.importActual('@/services/environment');
@@ -29,6 +31,19 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
+// A real Range over one text node -- the shape a selection rule needs, since
+// the transformer replays it by splicing inside a single node.
+const singleNodeRange = (text: string, start: number, end: number): Range => {
+  const p = document.createElement('p');
+  const node = document.createTextNode(text);
+  p.appendChild(node);
+  document.body.appendChild(p);
+  const range = document.createRange();
+  range.setStart(node, start);
+  range.setEnd(node, end);
+  return range;
+};
+
 function renderWithProviders(ui: React.ReactNode) {
   return render(<EnvProvider>{ui}</EnvProvider>);
 }
@@ -46,14 +61,7 @@ describe('ProofreadPopup Component', () => {
       text: 'test word',
       cfi: 'epubcfi(/6/2[chapter1]!/4/1:0)',
       index: 0,
-      range: {
-        deleteContents: vi.fn(),
-        insertNode: vi.fn(),
-        startContainer: document.createTextNode('test word here'),
-        endContainer: document.createTextNode('test word here'),
-        startOffset: 5,
-        endOffset: 9,
-      } as unknown as Range,
+      range: singleNodeRange('test word here', 5, 9),
       page: 1,
     },
     position: { point: { x: 100, y: 100 } },
@@ -66,6 +74,9 @@ describe('ProofreadPopup Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Applying a selection rule now edits the text node for real, so every
+    // test needs its own range instead of sharing one across the file.
+    defaultProps.selection.range = singleNodeRange('test word here', 5, 9);
   });
 
   afterEach(() => {
@@ -167,14 +178,7 @@ describe('ProofreadPopup Component', () => {
         ...defaultProps.selection,
         text: 'word',
         cfi: 'epubcfi(/6/4[chap01ref]!/4/2/1:0)',
-        range: {
-          deleteContents: vi.fn(),
-          insertNode: vi.fn(),
-          startContainer: document.createTextNode('test word here'),
-          endContainer: document.createTextNode('test word here'),
-          startOffset: 5,
-          endOffset: 9,
-        } as unknown as Range,
+        range: singleNodeRange('test word here', 5, 9),
       },
     });
 
@@ -332,6 +336,112 @@ describe('ProofreadPopup Component', () => {
 
       fireEvent.click(button);
       expect(mockOnManage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Section Anchoring', () => {
+    // The transformer matches a selection rule against the spine item href it
+    // is handed on every section load (foliate's `detail.name`). `progress`
+    // carries the TOC href instead, which points at the nearest preceding nav
+    // entry -- the same file only when every spine item has its own TOC entry.
+    // Storing the TOC href left the rule unmatched on reload, so it applied
+    // once (the popup edits the live DOM) and never again (#6148).
+    it('anchors a selection rule to the spine href, not the TOC href', async () => {
+      const restore = useReaderStore.getState();
+      useReaderStore.setState({
+        getProgress: () => ({ sectionHref: 'OEBPS/Text/contents.xhtml' }) as never,
+        getView: () => ({ book: { sections: [{ id: 'OEBPS/Text/ch1.xhtml' }] } }) as never,
+      });
+      try {
+        renderWithProviders(
+          <ProofreadPopup
+            {...defaultProps}
+            selection={{ ...defaultProps.selection, text: 'word', index: 0 }}
+          />,
+        );
+
+        fireEvent.change(screen.getByPlaceholderText('Enter text...'), {
+          target: { value: 'replacement' },
+        });
+        fireEvent.click(screen.getByText('Apply'));
+
+        await waitFor(() => {
+          expect(mockOnConfirm).toHaveBeenCalledWith(
+            expect.objectContaining({
+              scope: 'selection',
+              sectionHref: 'OEBPS/Text/ch1.xhtml',
+            }),
+          );
+        });
+      } finally {
+        useReaderStore.setState(restore);
+      }
+    });
+  });
+
+  describe('Live Document Edit', () => {
+    const rangeOver = (host: HTMLElement, node: Text, start: number, end: number) => {
+      document.body.appendChild(host);
+      const range = document.createRange();
+      range.setStart(node, start);
+      range.setEnd(node, end);
+      return range;
+    };
+
+    it('splices the replacement in place and leaves neighbouring markup alone', async () => {
+      const p = document.createElement('p');
+      p.innerHTML = 'Hello <em>brave</em> world';
+      const tail = p.lastChild as Text; // ' world'
+      const range = rangeOver(p, tail, 1, 6);
+      expect(range.toString()).toBe('world');
+
+      renderWithProviders(
+        <ProofreadPopup
+          {...defaultProps}
+          selection={{ ...defaultProps.selection, text: 'world', range }}
+        />,
+      );
+
+      fireEvent.change(screen.getByPlaceholderText('Enter text...'), {
+        target: { value: 'planet' },
+      });
+      fireEvent.click(screen.getByText('Apply'));
+
+      await waitFor(() => {
+        expect(mockOnConfirm).toHaveBeenCalled();
+      });
+      expect(p.innerHTML).toBe('Hello <em>brave</em> planet');
+      // deleteContents() + insertNode() also split the text node in two, which
+      // shifts the text-node indices every later CFI in the section counts on.
+      expect(p.childNodes.length).toBe(3);
+    });
+
+    it('refuses a selection rule the transformer could never replay', async () => {
+      const toast = vi.spyOn(eventDispatcher, 'dispatch');
+      const p = document.createElement('p');
+      p.innerHTML = 'Hello <em>brave</em> world';
+      document.body.appendChild(p);
+      const range = document.createRange();
+      range.setStart(p.firstChild as Text, 0);
+      range.setEnd(p.lastChild as Text, 6);
+
+      renderWithProviders(
+        <ProofreadPopup
+          {...defaultProps}
+          selection={{ ...defaultProps.selection, text: 'Hello brave world', range }}
+        />,
+      );
+
+      fireEvent.change(screen.getByPlaceholderText('Enter text...'), {
+        target: { value: 'hi' },
+      });
+      fireEvent.click(screen.getByText('Apply'));
+
+      await waitFor(() => {
+        expect(toast).toHaveBeenCalledWith('toast', expect.objectContaining({ type: 'warning' }));
+      });
+      expect(mockOnConfirm).not.toHaveBeenCalled();
+      expect(p.innerHTML).toBe('Hello <em>brave</em> world');
     });
   });
 });

--- a/apps/readest-app/src/__tests__/components/ProofreadRules.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ProofreadRules.test.tsx
@@ -248,6 +248,66 @@ describe('ProofreadRulesManager', () => {
     expect(screen.getByText('book-hit')).toBeTruthy();
   });
 
+  it('gives a selection rule its own jump action and leaves the scope chip inert', async () => {
+    // The jump used to live on the `Selection` chip, which looks exactly like
+    // the inert Regex/Case sensitive chips beside it, so nobody found it
+    // (#6148). It is an action, so it belongs with edit/delete.
+    (useSettingsStore.setState as unknown as (state: unknown) => void)({
+      settings: { ...DEFAULT_SYSTEM_SETTINGS, globalViewSettings: { proofreadRules: [] } },
+    });
+
+    const selectionRule: ProofreadRule = {
+      id: 's1',
+      scope: 'selection',
+      pattern: 'only-once',
+      replacement: 'single-hit',
+      enabled: true,
+      isRegex: false,
+      caseSensitive: true,
+      order: 1,
+      wholeWord: true,
+      cfi: 'epubcfi(/6/14!/4/2,/1:0,/1:4)',
+      sectionHref: 'OEBPS/Text/ch1.xhtml',
+    };
+
+    (useReaderStore.setState as unknown as (state: unknown) => void)({
+      viewStates: { book1: { viewSettings: { proofreadRules: [selectionRule] } } },
+    });
+    (useBookDataStore.setState as unknown as (state: unknown) => void)({
+      booksData: {
+        book1: {
+          id: 'book1',
+          book: null,
+          file: null,
+          config: { viewSettings: { proofreadRules: [selectionRule] } },
+          bookDoc: null,
+          isFixedLayout: false,
+        },
+      },
+    });
+    useSidebarStore.setState({ sideBarBookKey: 'book1' });
+
+    const dispatch = vi.spyOn(eventDispatcher, 'dispatch');
+
+    renderWithProviders(<ProofreadRulesManager />);
+    await Promise.resolve();
+    await act(async () => setProofreadRulesVisibility(true));
+
+    const dialog = await screen.findByRole('dialog');
+    const chip = within(dialog).getByText('Selection');
+    expect(chip.tagName).toBe('SPAN');
+
+    const jump = within(dialog).getByLabelText('Jump to Location');
+    await act(async () => {
+      fireEvent.click(jump);
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      'navigate',
+      expect.objectContaining({ bookKey: 'book1', cfi: selectionRule.cfi }),
+    );
+  });
+
   it('hides tombstoned (deleted) book rules from the list', async () => {
     (useSettingsStore.setState as unknown as (state: unknown) => void)({
       settings: { ...DEFAULT_SYSTEM_SETTINGS, globalViewSettings: { proofreadRules: [] } },

--- a/apps/readest-app/src/__tests__/components/proofread-rule-row-clearance.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/proofread-rule-row-clearance.browser.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { Toggle } from '@/components/primitives/toggle';
+import { RiEditLine, RiDeleteBin7Line } from 'react-icons/ri';
+import { MdOutlineArrowOutward } from 'react-icons/md';
+
+await import('@/styles/globals.css');
+
+afterEach(cleanup);
+
+/**
+ * The rule row parks its action cluster absolutely and reserves the width with
+ * end padding on the pattern text. A selection rule carries one extra button
+ * (Jump to Location), so the two have to be measured, not guessed.
+ */
+const Row: React.FC<{ withJump: boolean }> = ({ withJump }) => (
+  <div className='relative flex items-start justify-between gap-3 p-3' style={{ width: 380 }}>
+    <div className='flex min-w-0 flex-1 flex-col gap-1.5'>
+      <div
+        data-testid='pattern'
+        className={`break-words font-medium leading-snug ${withJump ? 'pe-36' : 'pe-28'}`}
+      >
+        a-very-long-pattern-that-would-run-under-the-buttons
+      </div>
+    </div>
+    <div data-testid='actions' className='absolute end-2 top-2 flex items-center gap-1'>
+      <Toggle className='toggle-sm' checked readOnly />
+      {withJump && (
+        <button className='btn btn-ghost btn-sm h-8 w-8 p-0'>
+          <MdOutlineArrowOutward className='h-4 w-4' />
+        </button>
+      )}
+      <button className='btn btn-ghost btn-sm h-8 w-8 p-0'>
+        <RiEditLine className='h-4 w-4' />
+      </button>
+      <button className='btn btn-ghost btn-sm h-8 w-8 p-0'>
+        <RiDeleteBin7Line className='h-4 w-4' />
+      </button>
+    </div>
+  </div>
+);
+
+describe('proofread rule row', () => {
+  for (const withJump of [false, true]) {
+    it(`reserves enough room for the action cluster (jump button: ${withJump})`, () => {
+      const { getByTestId } = render(<Row withJump={withJump} />);
+      const pattern = getByTestId('pattern').getBoundingClientRect();
+      const actions = getByTestId('actions').getBoundingClientRect();
+      const padding = parseFloat(getComputedStyle(getByTestId('pattern')).paddingRight);
+      const contentRight = pattern.right - padding;
+
+      expect(contentRight, 'the pattern text must stop before the buttons').toBeLessThanOrEqual(
+        actions.left,
+      );
+    });
+  }
+});

--- a/apps/readest-app/src/__tests__/utils/replacement.test.ts
+++ b/apps/readest-app/src/__tests__/utils/replacement.test.ts
@@ -89,6 +89,7 @@ describe('proofreadTransformer', () => {
     rules: ProofreadRule[] | undefined,
     content: string,
     sectionHref?: string,
+    sectionCfi?: string,
   ): TransformContext => {
     const viewSettings = {
       proofreadRules: rules,
@@ -101,6 +102,7 @@ describe('proofreadTransformer', () => {
       content,
       isFixedLayout: false,
       sectionHref,
+      sectionCfi,
       transformers: ['proofread'],
     };
   };
@@ -356,6 +358,51 @@ describe('proofreadTransformer', () => {
   });
 
   describe('selection scope', () => {
+    // A rule's sectionHref is the TOC href captured at the reading position,
+    // which names the nearest preceding nav entry -- a different file whenever
+    // the spine item has no TOC entry of its own. The rule's own CFI names its
+    // spine item, so the section match rides on that when the book has spine
+    // CFIs (#6148).
+    const selectionRule = (over: Partial<ProofreadRule> = {}): ProofreadRule => ({
+      id: '1',
+      scope: 'selection',
+      pattern: 'test',
+      replacement: 'REPLACED',
+      enabled: true,
+      isRegex: false,
+      caseSensitive: true,
+      order: 1,
+      wholeWord: true,
+      sectionHref: 'chapter1.html',
+      cfi: 'epubcfi(/6/14!/4/2,/1:0,/1:4)',
+      ...over,
+    });
+
+    test('applies a rule whose stale sectionHref names another file in the same spine item', async () => {
+      const ctx = createMockContext(
+        [selectionRule({ sectionHref: 'contents.html' })],
+        '<html><body><p>test content</p></body></html>',
+        'chapter7.html',
+        'epubcfi(/6/14)',
+      );
+      const result = await proofreadTransformer.transform(ctx);
+
+      expect(result).toContain('REPLACED');
+    });
+
+    test('skips a rule anchored in a different spine item even when the href matches', async () => {
+      const ctx = createMockContext(
+        [selectionRule()],
+        '<html><body><p>test content</p></body></html>',
+        'chapter1.html',
+        'epubcfi(/6/16)',
+      );
+      const result = await proofreadTransformer.transform(ctx);
+
+      expect(result).toContain('test content');
+      expect(result).not.toContain('REPLACED');
+    });
+
     test('should skip selection rules without matching sectionHref', async () => {
       const rules: ProofreadRule[] = [
         {

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -308,6 +308,7 @@ const FoliateViewer: React.FC<{
               userLocale: getLocale(),
               content: data,
               sectionHref: detail.name,
+              sectionCfi: bookData.bookDoc?.sections?.find((s) => s.id === detail.name)?.cfi,
               transformers: [
                 'epubSwitch',
                 'style',

--- a/apps/readest-app/src/app/reader/components/ProofreadRules.tsx
+++ b/apps/readest-app/src/app/reader/components/ProofreadRules.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React, { useEffect, useState } from 'react';
 import { RiEditLine, RiDeleteBin7Line } from 'react-icons/ri';
-import { MdDragIndicator } from 'react-icons/md';
+import { MdDragIndicator, MdOutlineArrowOutward } from 'react-icons/md';
 import {
   DndContext,
   closestCenter,
@@ -197,6 +197,7 @@ const RuleItem: React.FC<{
   }
 
   const isDisabled = rule.enabled === false;
+  const canNavigate = scope === 'selection' && !!rule.cfi;
   const scopeLabel =
     scope === 'selection' ? _('Selection') : scope === 'book' ? _('Book') : _('Library');
 
@@ -205,7 +206,10 @@ const RuleItem: React.FC<{
       <div className='flex min-w-0 flex-1 flex-col gap-1.5'>
         <div
           className={clsx(
-            'break-words pe-28 font-medium leading-snug',
+            'break-words font-medium leading-snug',
+            // Reserve the width of the absolutely-positioned action cluster,
+            // which is one button wider on selection rules.
+            canNavigate ? 'pe-36' : 'pe-28',
             isDisabled && 'text-base-content/60',
           )}
         >
@@ -226,17 +230,7 @@ const RuleItem: React.FC<{
           )}
         </div>
         <div className='flex flex-wrap items-center gap-1.5'>
-          {scope === 'selection' ? (
-            <button
-              type='button'
-              onClick={navigateToSelection}
-              className='badge badge-sm badge-ghost eink-bordered hover:bg-base-300 shrink-0 transition-colors duration-150'
-            >
-              {scopeLabel}
-            </button>
-          ) : (
-            <RuleChip>{scopeLabel}</RuleChip>
-          )}
+          <RuleChip>{scopeLabel}</RuleChip>
           {rule.isRegex && <RuleChip>{_('Regex')}</RuleChip>}
           {rule.caseSensitive !== false && <RuleChip>{_('Case sensitive')}</RuleChip>}
           {rule.onlyForTTS && <RuleChip>{_('Only for TTS')}</RuleChip>}
@@ -249,6 +243,20 @@ const RuleItem: React.FC<{
           onChange={onToggle}
           aria-label={isDisabled ? _('Enable rule') : _('Disable rule')}
         />
+        {canNavigate && (
+          // A selection rule is anchored to one spot in the book, so it gets
+          // its own action alongside edit/delete. It used to ride on the
+          // `Selection` chip, which reads as a label like every chip beside
+          // it, so nobody found it (#6148).
+          <button
+            className='btn btn-ghost btn-sm h-8 w-8 p-0'
+            onClick={navigateToSelection}
+            aria-label={_('Jump to Location')}
+            title={_('Jump to Location')}
+          >
+            <MdOutlineArrowOutward className='h-4 w-4' />
+          </button>
+        )}
         <button
           className='btn btn-ghost btn-sm h-8 w-8 p-0'
           onClick={onEdit}

--- a/apps/readest-app/src/app/reader/components/annotator/ProofreadPopup.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/ProofreadPopup.tsx
@@ -23,6 +23,11 @@ const toggleClassName = (isDarkMode: boolean) =>
     !isDarkMode && 'checked:![--tglbg:theme(colors.base-100)] [--tglbg:theme(colors.base-300)]',
   );
 
+// The precondition `applyReplacementSingle` puts on a selection rule: both
+// ends of the CFI must land in the same text node.
+const isSingleTextNodeRange = (range: Range) =>
+  range.startContainer === range.endContainer && range.startContainer?.nodeType === Node.TEXT_NODE;
+
 interface ProofreadPopupProps {
   bookKey: string;
   selection?: TextSelection;
@@ -92,19 +97,44 @@ const ProofreadPopup: React.FC<ProofreadPopupProps> = ({
       }
 
       if (scope === 'selection') {
-        range.deleteContents();
-        if (replacementText) {
-          const textNode = document.createTextNode(replacementText);
-          range.insertNode(textNode);
+        // On every later load the rule is replayed by `applyReplacementSingle`,
+        // which resolves the CFI and splices the replacement into ONE text
+        // node -- it can do nothing with a selection that spans elements. So
+        // refuse that selection here instead of creating a rule that only ever
+        // works the one time the popup edits the live DOM.
+        if (!isSingleTextNodeRange(range)) {
+          eventDispatcher.dispatch('toast', {
+            type: 'warning',
+            message: _(
+              'Please select text within a single paragraph, or choose another replacement scope.',
+            ),
+            timeout: 5000,
+          });
+          return;
         }
+        // Splice the text in place rather than deleteContents() + insertNode():
+        // deleting across the selection strips any markup it touches and splits
+        // the node into three, and the transformer's own replay does neither.
+        const textNode = range.startContainer as Text;
+        const text = textNode.textContent ?? '';
+        textNode.textContent =
+          text.slice(0, range.startOffset) + replacementText + text.slice(range.endOffset);
       }
+
+      // Anchor to the spine item href, which is what every section load hands
+      // the proofread transformer (foliate's `detail.name`). `progress` carries
+      // the TOC href, which resolves to the nearest preceding nav entry and so
+      // names a different file whenever a spine item has no TOC entry of its
+      // own -- the rule then never matched on reload (#6148).
+      const sectionHref =
+        getView(bookKey)?.book?.sections?.[selection.index]?.id ?? progress?.sectionHref;
 
       const options: CreateProofreadRuleOptions = {
         scope,
         pattern: selection.text,
         replacement: replacementText.trim(),
         cfi: selection.cfi,
-        sectionHref: progress?.sectionHref,
+        sectionHref,
         isRegex,
         enabled: true,
         caseSensitive,

--- a/apps/readest-app/src/app/reader/components/annotator/ProofreadPopup.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/ProofreadPopup.tsx
@@ -81,6 +81,9 @@ const ProofreadPopup: React.FC<ProofreadPopupProps> = ({
     if (!selection) return;
 
     const range = selection?.range;
+    // The rule persists the trimmed text, so the live edit has to use the same
+    // value or this session shows something the replay will never reproduce.
+    const replacement = replacementText.trim();
 
     if (range) {
       // A regex pattern defines its own boundaries, so the whole-word
@@ -106,7 +109,7 @@ const ProofreadPopup: React.FC<ProofreadPopupProps> = ({
           eventDispatcher.dispatch('toast', {
             type: 'warning',
             message: _(
-              'Please select text within a single paragraph, or choose another replacement scope.',
+              'This selection spans formatting or paragraph boundaries. Select a smaller piece of text, or choose another replacement scope.',
             ),
             timeout: 5000,
           });
@@ -118,7 +121,7 @@ const ProofreadPopup: React.FC<ProofreadPopupProps> = ({
         const textNode = range.startContainer as Text;
         const text = textNode.textContent ?? '';
         textNode.textContent =
-          text.slice(0, range.startOffset) + replacementText + text.slice(range.endOffset);
+          text.slice(0, range.startOffset) + replacement + text.slice(range.endOffset);
       }
 
       // Anchor to the spine item href, which is what every section load hands
@@ -132,7 +135,7 @@ const ProofreadPopup: React.FC<ProofreadPopupProps> = ({
       const options: CreateProofreadRuleOptions = {
         scope,
         pattern: selection.text,
-        replacement: replacementText.trim(),
+        replacement,
         cfi: selection.cfi,
         sectionHref,
         isRegex,

--- a/apps/readest-app/src/services/transformers/proofread.ts
+++ b/apps/readest-app/src/services/transformers/proofread.ts
@@ -1,5 +1,5 @@
 import * as CFI from 'foliate-js/epubcfi.js';
-import type { Transformer } from './types';
+import type { Transformer, TransformContext } from './types';
 import { ProofreadRule } from '@/types/book';
 import { useSettingsStore } from '@/store/settingsStore';
 
@@ -193,6 +193,27 @@ function applyReplacementSingle(
   }
 }
 
+// Spine step of a CFI: everything before the first indirection (`!`), or the
+// whole path for a section CFI, which has none. `sections[i].cfi` is
+// `epubcfi(/6/14)` and a selection made in it is `epubcfi(/6/14!/4/2,...)`.
+const cfiSpineStep = (cfi?: string): string | undefined =>
+  cfi?.match(/^epubcfi\((.*?)(?:!|\)$)/)?.[1];
+
+/**
+ * Whether a selection-scoped rule belongs to the section being transformed.
+ * The rule's own CFI names its spine item, so prefer that: `sectionHref` holds
+ * the TOC href at the reading position, which resolves to the nearest
+ * preceding nav entry and therefore names a different file whenever a spine
+ * item has no TOC entry of its own (#6148). Formats without spine CFIs
+ * (markdown, where section ids are the spine index) fall back to the href.
+ */
+const inThisSection = (rule: ProofreadRule, ctx: TransformContext): boolean => {
+  const ruleSpine = cfiSpineStep(rule.cfi);
+  const ctxSpine = cfiSpineStep(ctx.sectionCfi);
+  if (ruleSpine && ctxSpine) return ruleSpine === ctxSpine;
+  return ctx.sectionHref?.split('#')[0] === rule.sectionHref?.split('#')[0];
+};
+
 function getTextNodes(doc: Document): Text[] {
   const walker = document.createTreeWalker(doc.body || doc.documentElement, NodeFilter.SHOW_TEXT, {
     acceptNode: (node) => {
@@ -251,11 +272,7 @@ export const proofreadTransformer: Transformer = {
     const ordered = [...byScope.selection, ...byScope.book, ...byScope.library];
 
     for (const rule of ordered) {
-      if (rule.scope === 'selection') {
-        const ruleBase = rule.sectionHref?.split('#')[0];
-        const ctxBase = ctx.sectionHref?.split('#')[0];
-        if (ctxBase !== ruleBase) continue;
-      }
+      if (rule.scope === 'selection' && !inThisSection(rule, ctx)) continue;
       if (rule.scope === 'selection') {
         applyReplacementSingle(doc, rule);
       } else {

--- a/apps/readest-app/src/services/transformers/types.ts
+++ b/apps/readest-app/src/services/transformers/types.ts
@@ -10,6 +10,11 @@ export type TransformContext = {
   height?: number;
   content: string;
   sectionHref?: string;
+  // Spine CFI of the section being transformed (`sections[i].cfi`), when the
+  // format has one. Selection-scoped proofread rules match against this rather
+  // than `sectionHref`, which is the TOC href at the reading position and so
+  // names a different file whenever a spine item has no TOC entry (#6148).
+  sectionCfi?: string;
   transformers: string[];
   reversePunctuationTransform?: boolean;
 };

--- a/apps/readest-app/src/utils/md.ts
+++ b/apps/readest-app/src/utils/md.ts
@@ -197,9 +197,10 @@ export async function makeMarkdownBook(file: File): Promise<BookDoc> {
         data: str,
         type: 'application/xhtml+xml',
       };
-      // Readonly, mirroring foliate's Loader.createURL dispatch. Selection
-      // scoped proofread rules compare their TOC-style sectionHref
-      // ("<index>#<anchor>") against this name via split('#')[0].
+      // Readonly, mirroring foliate's Loader.createURL dispatch. Markdown
+      // sections carry no spine CFI, so selection-scoped proofread rules fall
+      // back to matching their sectionHref against this name; both are the
+      // section index ("<index>", or "<index>#<anchor>" via split('#')[0]).
       Object.defineProperty(detail, 'name', { value: String(index) });
       transformTarget.dispatchEvent(new CustomEvent('data', { detail }));
       const out = await detail.data;


### PR DESCRIPTION
Closes #6148.

## The bug

A proofread rule with scope **current selection** applied once and never again. Toggling it off and on, editing it, or reopening the book all lost it.

It only ever looked right at creation. `ProofreadPopup` edits the live document before saving the rule, so what you see right after Apply is that DOM edit, not the transformer. Every later render goes through `proofreadTransformer`, and that path had never worked for selection scope.

## Root cause

The two sides named the section differently:

| side | value | what it is |
|---|---|---|
| `ProofreadPopup` (write) | `progress.sectionHref` | foliate's `tocItem.href` — the nearest **preceding** nav entry |
| `proofreadTransformer` (read) | `ctx.sectionHref` | foliate's `detail.name` from `Loader.createURL` — the **spine item** href |

They coincide only when every spine item has its own TOC entry. Measured across the fixtures already in this repo:

- `sample-table-layout.epub` — 10 of 12 sections mismatch
- `sample-alice.epub` — 2 of 16 (index 15 is `OPS/feedbooks.xml`, whose TOC entry is `OPS/main11.xml`)
- the first spine item mismatches in almost every book, because covers have no TOC entry

## The fix

Match on the CFI the rule already carries. `TransformContext` gains `sectionCfi` (from `sections[i].cfi`, wired in `FoliateViewer`), and the section test compares its spine step (`epubcfi(/6/32!…` vs `epubcfi(/6/32)`) against the rule's.

**This repairs rules users have already saved**, so nothing has to be recreated. Formats with no spine CFI — markdown books, whose section ids are the spine index — keep the href comparison. `ProofreadPopup` now stores the spine href too, so the field means what its name says.

## Two more defects on the same surface

- **`deleteContents()` lost markup.** The live edit used `deleteContents()` + `insertNode()`, which stripped markup the range touched and split the text node in three, shifting the text-node indices every later CFI in that section depends on. It now splices the replacement inside the one text node, exactly as `applyReplacementSingle` replays it. A selection spanning elements is refused with a toast, since that function needs both ends in the same text node and could never replay such a rule — it only ever "worked" via the live DOM edit, which is the illusion this issue is about.
- **The jump affordance was invisible.** #6109 made the `Selection` scope chip the jump target, but it renders like the inert Regex / Case sensitive chips beside it. The chip is inert again and the jump is its own button next to edit/delete, reusing `MdOutlineArrowOutward` and the existing `Jump to Location` string. The row reserves the action cluster with end padding, so the third button needs `pe-36` — measured in a browser test, not guessed.

## Verification

```
pnpm test          919 files, 11077 passed, 16 skipped, 0 failed
pnpm test:browser   59 files,   466 passed,  1 skipped, 0 failed
pnpm lint          tsc + biome clean
```

Every new test was confirmed to fail against the pre-fix code: the two transformer cases, both popup cases, the panel case, and the `pe-28`/`pe-36` clearance measurement.

End to end in real Chromium (throwaway test, not committed): alice section 15, whose TOC href names a different file, goes from `applied: false` to `applied: true`.

One new UI string, translated across all 34 locales in its own commit; extraction added no other keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated “Jump to Location” control for selection-based proofreading rules.
  - Improved navigation and rule matching across book sections, including books with incomplete section metadata.

- **Bug Fixes**
  - Prevented replacements when selected text spans formatting or paragraph boundaries, with clearer guidance.
  - Improved replacement consistency while preserving surrounding formatting.

- **Localization**
  - Updated the selection-scope warning message across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->