### PR TITLE
fix(txt): detect Chinese chapters numbered with 两 or uppercase numerals (#6172)

### DIFF
--- a/apps/readest-app/src/__tests__/utils/detect-language.test.ts
+++ b/apps/readest-app/src/__tests__/utils/detect-language.test.ts
@@ -185,6 +185,16 @@ describe('detectLanguage - Result Tests', () => {
         expect(result).toBe('en');
       });
     });
+
+    // franc returns "und" for short CJK headers such as a TXT title line.
+    // Falling back to "en" there means the Chinese chapter regexps never run.
+    // See issue #6172.
+    it('should fall back to script detection when franc cannot classify CJK text', () => {
+      expect(detectLanguage('万国之国')).toBe('zh');
+      expect(detectLanguage('三体')).toBe('zh');
+      expect(detectLanguage('こんにちは')).toBe('ja');
+      expect(detectLanguage('한글 제목')).toBe('ko');
+    });
   });
 
   describe('mixed content', () => {

--- a/apps/readest-app/src/__tests__/utils/txt-converter.test.ts
+++ b/apps/readest-app/src/__tests__/utils/txt-converter.test.ts
@@ -554,3 +554,79 @@ describe('author resolution during conversion (issue #4390)', () => {
     expect(metadata?.author).toBe('月夜银狐');
   });
 });
+
+describe('Chinese chapter numerals beyond 一二三 (issue #6172)', () => {
+  const zhMetadata: TestMetadata = {
+    bookTitle: 'Test',
+    author: '',
+    language: 'zh',
+    identifier: 'test',
+  };
+  const option = { linesBetweenSegments: 8, fallbackParagraphsPerChapter: 100 };
+
+  it('detects headings that spell two as 两', () => {
+    const converter = new TxtToEpubConverter() as unknown as TxtConverterFlowPrivateAPI;
+    const text = [
+      '第两百一十八章 塞浦路斯领主炙手可热',
+      '这是第二百一十八章的内容。',
+      '第两百一十九章 宴会',
+      '这是第二百一十九章的内容。',
+    ].join('\n');
+
+    const chapters = converter.extractChapters(text, zhMetadata, option);
+
+    expect(chapters.map((c) => c.title)).toEqual([
+      '第两百一十八章 塞浦路斯领主炙手可热',
+      '第两百一十九章 宴会',
+    ]);
+  });
+
+  it('detects headings that use uppercase numerals', () => {
+    const converter = new TxtToEpubConverter() as unknown as TxtConverterFlowPrivateAPI;
+    const text = [
+      '第壹章 开篇',
+      '这是第一章的内容。',
+      '第贰章 承接',
+      '这是第二章的内容。',
+      '第拾叁章 收束',
+      '这是第十三章的内容。',
+    ].join('\n');
+
+    const chapters = converter.extractChapters(text, zhMetadata, option);
+
+    expect(chapters.map((c) => c.title)).toEqual(['第壹章 开篇', '第贰章 承接', '第拾叁章 收束']);
+  });
+
+  it('marks uppercase-numeral volume headings as volumes', () => {
+    const converter = new TxtToEpubConverter() as unknown as TxtConverterFlowPrivateAPI;
+    const text = ['第贰卷 远征', '卷首语。', '第壹章 开篇', '这是第一章的内容。'].join('\n');
+
+    const chapters = converter.extractChapters(text, zhMetadata, option);
+
+    expect(chapters.map((c) => [c.title, c.isVolume])).toEqual([
+      ['第贰卷 远征', true],
+      ['第壹章 开篇', false],
+    ]);
+  });
+
+  it('keeps the whole book split when a long run of 第两百N章 chapters follows (issue #6172)', () => {
+    const converter = new TxtToEpubConverter() as unknown as TxtConverterFlowPrivateAPI;
+    // A single undetected heading style glues its chapters into one oversized
+    // part, which isGoodMatches rejects — dropping the TOC for the entire book.
+    const body = Array.from({ length: 40 }, (_, i) => `段落${i + 1}${'正文内容'.repeat(20)}`).join(
+      '\n',
+    );
+    const lines = ['第一章 开篇', '这是第一章的内容。'];
+    for (let i = 0; i < 60; i++) {
+      lines.push(`第两百${i + 1}章 远征`, body);
+    }
+    const text = lines.join('\n');
+
+    const chapters = converter.extractChapters(text, zhMetadata, option);
+
+    expect(chapters.every((c) => c.title.startsWith('第'))).toBe(true);
+    expect(chapters.length).toBe(61);
+    expect(chapters[0]!.title).toBe('第一章 开篇');
+    expect(chapters[60]!.title).toBe('第两百60章 远征');
+  });
+});

--- a/apps/readest-app/src/utils/lang.ts
+++ b/apps/readest-app/src/utils/lang.ts
@@ -148,9 +148,15 @@ export const inferLangFromScript = (text: string, lang: string): string => {
 
 export const detectLanguage = (content: string): string => {
   try {
-    const iso6393Lang = franc(content.substring(0, 1000));
-    const iso6391Lang = code6393to6391(iso6393Lang) || 'en';
-    return iso6391Lang;
+    const sample = content.substring(0, 1000);
+    const iso6393Lang = franc(sample);
+    const iso6391Lang = code6393to6391(iso6393Lang);
+    if (iso6391Lang) return iso6391Lang;
+    // franc returns "und" for short CJK text such as a TXT title line. Defaulting
+    // to English there sends the caller down the wrong path (e.g. TXT chapter
+    // detection never applies the Chinese regexps), so read the script instead.
+    // See issue #6172.
+    return inferLangFromScript(sample, '') || 'en';
   } catch {
     console.warn('Language detection failed, defaulting to en.');
     return 'en';

--- a/apps/readest-app/src/utils/txt.ts
+++ b/apps/readest-app/src/utils/txt.ts
@@ -121,6 +121,17 @@ const escapeXml = (str: string) => {
     .replace(/'/g, '&apos;');
 };
 
+// Characters that can spell a chapter number after 第. Beyond the plain
+// 一二三…, 两/兩 is the colloquial "two" web novels use for hundreds
+// (第两百一十八章) and 壹贰叁… are the uppercase numerals of classical and formal
+// editions. A numeral style left out here does not merely lose its own
+// headings: its chapters glue into one oversized part that isGoodMatches
+// rejects, dropping the TOC for the entire book. See issue #6172.
+const CJK_NUMBER_DIGITS = '零〇一二两兩三四五六七八九十壹贰貳叁叄參肆伍陆陸柒捌玖拾0-9';
+const CJK_NUMBER_UNITS = '百千万萬佰仟';
+const CJK_NUMBER_CHARS = `${CJK_NUMBER_DIGITS}${CJK_NUMBER_UNITS}`;
+const CJK_VOLUME_HEADING = new RegExp(`第[${CJK_NUMBER_CHARS}]+(卷|本|册|部)`);
+
 export class TxtToEpubConverter {
   public async convert(options: Txt2EpubOptions): Promise<ConversionResult> {
     if (options.file.size <= LARGE_TXT_THRESHOLD_BYTES) {
@@ -606,7 +617,7 @@ export class TxtToEpubConverter {
 
       let isVolume = false;
       if (language === 'zh') {
-        isVolume = /第[零〇一二三四五六七八九十百千万0-9]+(卷|本|册|部)/.test(title);
+        isVolume = CJK_VOLUME_HEADING.test(title);
       } else {
         isVolume = /\b(Part|Volume|Book)\b/i.test(title);
       }
@@ -728,7 +739,7 @@ export class TxtToEpubConverter {
       // volume wraps chapters), and the regexps array is a fallback chain — the
       // first regex that splits "well enough" wins — so separate entries would
       // recognize one tier and silently drop the other.
-      const cjkNumber = '第[ 　零〇一二三四五六七八九十0-9][ 　零〇一二三四五六七八九十百千万0-9]*';
+      const cjkNumber = `第[ 　${CJK_NUMBER_DIGITS}][ 　${CJK_NUMBER_CHARS}]*`;
       // Tier 1 — chapter units. Real headings; a title may attach directly
       // (第一章天地初开) or after a separator.
       const chapterUnit = String.raw`[章节回讲篇话](?:[：:、 　\(\)0-9]*[^\n-]{0,36})`;


### PR DESCRIPTION
Fixes #6172.

## The bug

《万国之国》 (10MB, 638 chapters) imports with no TOC at all: 532 sections titled `1`..`532`, zero detected headings.

82 of its chapters spell *two* as `第两百N章`. `两` was missing from the `cjkNumber` character class in `src/utils/txt.ts`, so none of them matched.

The interesting part is why 82 unmatched headings cost the book all 638. Those chapters run contiguously, so they glued into a single **445,438-char** part, and `isGoodMatches` rejects any split holding a part over 100k. The whole split result was discarded and every chapter fell through to paragraph chunking. **One unrecognized numeral style does not lose its own chapters, it loses the book.**

Separately, `detectLanguage` returned `'en'` whenever franc says `"und"`, which it does for short CJK text such as a TXT title line (`franc('万国之国') === 'und'`). For those files the Chinese regexps never ran at all.

## The fix

- Pull the numeral characters into shared `CJK_NUMBER_DIGITS` / `CJK_NUMBER_UNITS` constants, so `cjkNumber` and the `isVolume` test stop keeping separate hand-copied classes that can drift apart.
- Add `两兩` plus the uppercase numerals `壹贰貳叁叄參肆伍陆陸柒捌玖拾萬佰仟` used by classical literature and formal editions.
- `detectLanguage` falls through to the existing `inferLangFromScript` before defaulting to English — but only when franc failed to classify, so franc-classified text is never overridden (the existing "mostly English with some 中文" case still resolves to `en`).

## Verification on the reporter's actual file

| | before | after |
|---|---|---|
| chapters | 532 | 645 |
| detected headings | 0 | 644 |
| longest part | 445,438 | 17,990 |
| 两 chapters in TOC | 0 | 81 / 82 |

No false positives — the only non-`第` entries are the book's own `万国之国` / `简介：` front matter. The missing 82nd, `第两百五十四 鹰巢的威胁（下）`, has no `章` in the source file; that is a typo in the book, and matching a bare `第N` with no unit would be far too loose.

## Tests

5 regression tests, all verified failing before the fix:

- `txt-converter.test.ts` — `两` headings, uppercase-numeral headings, uppercase-numeral volume headings, and one that reproduces the oversized-part TOC wipeout end to end
- `detect-language.test.ts` — script fallback for short CJK that franc cannot classify

`pnpm test` 11083 passed / 0 failed · `pnpm lint` clean · `pnpm format:check` clean.

## Not addressed here

The `isGoodMatches` fragility itself. Any future unmatched heading style will wipe a whole book's TOC the same way, because one long part vetoes the entire split rather than just its own region. That threshold affects every TXT import, so it belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved language detection for short Chinese, Japanese, and Korean text.
  * Expanded recognition of Chinese chapter and volume headings, including formal numerals and additional number formats.
  * Improved chapter splitting and table-of-contents generation for supported Chinese heading styles.

* **Tests**
  * Added coverage for script-based language detection and expanded Chinese chapter-heading formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->