### PR TITLE
feat(reader): hide the image viewer controls on tap

### DIFF
--- a/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
@@ -20,7 +20,7 @@ vi.mock('@/context/EnvContext', () => ({
 // ZoomControls reaches into the theme store and Tauri window APIs; stub it out.
 vi.mock('@/app/reader/components/ZoomControls', () => ({
   __esModule: true,
-  default: () => null,
+  default: () => <div data-testid='zoom-controls' />,
 }));
 
 afterEach(cleanup);
@@ -252,6 +252,65 @@ describe('ImageViewer', () => {
           vi.advanceTimersByTime(500);
         });
         expect(img.style.width).toBe('4096px');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  // #6154: the close/save/zoom buttons sit over the top-right corner of the
+  // artwork, where they can cover the image itself. They are chrome, so the
+  // tap that already clears the caption and the arrows clears them too.
+  describe('top-right controls', () => {
+    const zoomControls = (container: HTMLElement) =>
+      container.querySelector('[data-testid="zoom-controls"]');
+
+    it('toggles the controls when the image is tapped', () => {
+      const { container } = render(
+        <ImageViewer src='blob:test-image' onClose={vi.fn()} gridInsets={gridInsets} />,
+      );
+      const img = container.querySelector('img')!;
+      expect(zoomControls(container)).toBeTruthy();
+
+      fireEvent.click(img);
+      expect(zoomControls(container)).toBeNull();
+
+      fireEvent.click(img);
+      expect(zoomControls(container)).toBeTruthy();
+    });
+
+    // The zoom badge and the arrows hide themselves 2s after a zoom, so their
+    // state no longer matches the chrome's. A single tap must still hide
+    // everything rather than bring the auto-hidden pieces back.
+    it('hides every chrome element with one tap after the zoom badge timed out', () => {
+      vi.useFakeTimers();
+      try {
+        const { container } = render(
+          <ImageViewer
+            src='blob:test-image'
+            caption='A caption'
+            onClose={vi.fn()}
+            onNext={vi.fn()}
+            gridInsets={gridInsets}
+          />,
+        );
+        const img = container.querySelector('img')!;
+
+        act(() => {
+          fireEvent.doubleClick(img);
+        });
+        act(() => {
+          vi.advanceTimersByTime(2000);
+        });
+        expect(container.querySelector('[aria-label="Zoom level"]')).toBeNull();
+
+        act(() => {
+          fireEvent.click(img);
+        });
+        expect(zoomControls(container)).toBeNull();
+        expect(container.querySelector('.image-caption')).toBeNull();
+        expect(container.querySelector('[aria-label="Next Image"]')).toBeNull();
+        expect(container.querySelector('[aria-label="Zoom level"]')).toBeNull();
       } finally {
         vi.useRealTimers();
       }

--- a/apps/readest-app/src/app/reader/components/ImageViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/ImageViewer.tsx
@@ -74,9 +74,10 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
   const [isDragging, setIsDragging] = useState(false);
   const [isWheelZooming, setIsWheelZooming] = useState(false);
   const [showZoomLabel, setShowZoomLabel] = useState(true);
-  // Unlike the zoom badge the caption does not time out — it is content, not
-  // chrome — so tapping the image is what gets it off the artwork.
-  const [showCaption, setShowCaption] = useState(true);
+  // Chrome drawn over the artwork — the top-right controls and the caption —
+  // never times out on its own, so tapping the image is what gets it off the
+  // image (#5232, #6154).
+  const [showChrome, setShowChrome] = useState(true);
   const lastTouchDistance = useRef<number>(0);
   const dragStart = useRef({ x: 0, y: 0 });
   const wasDragging = useRef(false);
@@ -553,8 +554,12 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
       return;
     }
 
-    setShowZoomLabel((prev) => !prev);
-    setShowCaption((prev) => !prev);
+    // Driven off a single next value so one tap always clears everything: the
+    // zoom badge and the arrows hide themselves 2s after a zoom, and toggling
+    // them independently would bring those back instead.
+    const next = !showChrome;
+    setShowChrome(next);
+    setShowZoomLabel(next);
   };
 
   const cursorStyle = scale > 1 ? (isDragging ? 'grabbing' : 'grab') : 'default';
@@ -588,15 +593,17 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
           }
         }}
       />
-      <ZoomControls
-        gridInsets={gridInsets}
-        canShare={canShare}
-        onClose={onClose}
-        onSave={handleSaveImage}
-        onZoomIn={handleZoomIn}
-        onZoomOut={handleZoomOut}
-        onReset={handleReset}
-      />
+      {showChrome && (
+        <ZoomControls
+          gridInsets={gridInsets}
+          canShare={canShare}
+          onClose={onClose}
+          onSave={handleSaveImage}
+          onZoomIn={handleZoomIn}
+          onZoomOut={handleZoomOut}
+          onReset={handleReset}
+        />
+      )}
 
       {onPrevious && showZoomLabel && (
         <button
@@ -680,7 +687,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
 
       {/* Sibling of the click-to-close container above, so reading (or
           scrolling) the description never dismisses the viewer. */}
-      {caption && showCaption && (
+      {caption && showChrome && (
         <div
           // The description comes from the book, whose language need not match
           // the UI's, so let the text pick its own direction.


### PR DESCRIPTION
Closes #6154.

### Problem

In the full-screen image viewer the close / share / zoom-in / zoom-out / reset buttons are pinned to the top-right corner and are always drawn. On a phone-shaped image they sit right on top of the artwork, and the only way to see what they cover is to zoom in and pan that part of the image to the centre.

The other chrome in the viewer — the caption and the previous/next arrows — already gets out of the way when you tap the image.

### Change

The top-right controls now follow the same tap toggle: one tap on the image hides them along with the caption, the arrows and the zoom badge; a second tap brings everything back.

The tap toggle is driven off a single `showChrome` value instead of flipping each piece independently. The zoom badge and the arrows hide themselves two seconds after a zoom, so with independent flips the tap meant to clear the screen would have brought those two back instead.

The viewer is still dismissable while the chrome is hidden — tap outside the image, Escape on desktop, Back on Android — and `TableViewer`, the other `ZoomControls` consumer, is untouched.

### Verification

- `pnpm test` — full unit suite
- `pnpm lint`
- Two new tests in `src/__tests__/components/ImageViewer.test.tsx`: the tap toggle itself, and that one tap still clears every chrome element after the zoom badge has timed out (both fail on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved image viewer controls so tapping the image consistently toggles the visibility of captions, zoom controls, navigation controls, and the zoom indicator.
  * Zoom controls now automatically hide after zooming, with subsequent taps correctly hiding all on-screen controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->