### PR TITLE
feat(about): show the real WebView build number instead of the UA-reduced stub

### DIFF
--- a/apps/readest-app/src-tauri/src/sentry_config.rs
+++ b/apps/readest-app/src-tauri/src/sentry_config.rs
@@ -142,7 +142,7 @@ pub fn webview_info() -> Option<&'static (String, String)> {
 /// `None` if neither token family is present.
 pub fn parse_webview_info(user_agent: &str) -> Option<(String, String)> {
     if let Some(v) = ua_token_version(user_agent, "Edg/") {
-        return Some(("Edge WebView2".to_string(), v));
+        return Some(("WebView2".to_string(), v));
     }
     if let Some(v) = ua_token_version(user_agent, "Chrome/") {
         return Some(("Chromium".to_string(), v));
@@ -377,7 +377,7 @@ mod tests {
                   Chrome/138.0.0.0 Safari/537.36 Edg/138.0.3351.62";
         assert_eq!(
             parse_webview_info(ua),
-            Some(("Edge WebView2".to_string(), "138.0.3351.62".to_string()))
+            Some(("WebView2".to_string(), "138.0.3351.62".to_string()))
         );
     }
 

--- a/apps/readest-app/src-tauri/src/sentry_config.rs
+++ b/apps/readest-app/src-tauri/src/sentry_config.rs
@@ -159,11 +159,11 @@ fn ua_token_version(user_agent: &str, token: &str) -> Option<String> {
         .chars()
         .take_while(|c| c.is_ascii_digit() || *c == '.')
         .collect();
-    if version.is_empty() {
-        None
-    } else {
-        Some(version)
-    }
+    // Trim stray trailing dots (`Chrome/140.`) and require at least one digit
+    // so a malformed token never reaches the webview.version tag.
+    let version = version.trim_end_matches('.');
+    (!version.is_empty() && version.contains(|c: char| c.is_ascii_digit()))
+        .then(|| version.to_string())
 }
 
 /// C-ABI accessor for the compile-time Sentry DSN, used by the iOS native

--- a/apps/readest-app/src-tauri/src/sentry_config.rs
+++ b/apps/readest-app/src-tauri/src/sentry_config.rs
@@ -129,28 +129,40 @@ pub fn webview_info() -> Option<&'static (String, String)> {
     WEBVIEW_INFO.get()
 }
 
-/// Parse the WebView engine and major version from a User-Agent string. Chromium
+/// Parse the WebView engine and version from a User-Agent string. Chromium
 /// WebViews (Android System WebView, Windows WebView2, Linux Chrome) carry a
-/// `Chrome/<v>` token; WebKit ones (iOS/macOS WKWebView, Linux WebKitGTK) carry
-/// `Version/<v>` and no `Chrome/`. Chrome is checked first because Android
-/// WebViews also include a legacy `Version/4.0`. `None` if neither is present.
+/// `Chrome/<v>` or `Edg/<v>` token; WebKit ones (iOS/macOS WKWebView, Linux
+/// WebKitGTK) carry `Version/<v>` and no `Chrome/`. Edge is checked first
+/// because a WebView2 UA carries both `Edg/` and a reduced `Chrome/` token,
+/// and Android WebViews include a legacy `Version/4.0` that must not win over
+/// `Chrome/`. The version is kept in full (not just the major); note that
+/// Chromium's UA Reduction freezes those tokens to `x.0.0.0` — the app
+/// rewrites its reported token with the real Client Hints build before
+/// invoking `set_webview_info`, so desktop WebView2 tags arrive complete.
+/// `None` if neither token family is present.
 pub fn parse_webview_info(user_agent: &str) -> Option<(String, String)> {
-    if let Some(v) = ua_major_version(user_agent, "Chrome/") {
+    if let Some(v) = ua_token_version(user_agent, "Edg/") {
+        return Some(("Edge WebView2".to_string(), v));
+    }
+    if let Some(v) = ua_token_version(user_agent, "Chrome/") {
         return Some(("Chromium".to_string(), v));
     }
-    if let Some(v) = ua_major_version(user_agent, "Version/") {
+    if let Some(v) = ua_token_version(user_agent, "Version/") {
         return Some(("WebKit".to_string(), v));
     }
     None
 }
 
-fn ua_major_version(user_agent: &str, token: &str) -> Option<String> {
+fn ua_token_version(user_agent: &str, token: &str) -> Option<String> {
     let rest = &user_agent[user_agent.find(token)? + token.len()..];
-    let major: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-    if major.is_empty() {
+    let version: String = rest
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+    if version.is_empty() {
         None
     } else {
-        Some(major)
+        Some(version)
     }
 }
 
@@ -346,13 +358,26 @@ mod tests {
 
     #[test]
     fn parses_chromium_webview_version() {
-        // Android System WebView carries a legacy `Version/4.0` AND `Chrome/140`;
-        // Chrome must win.
+        // Android System WebView carries a legacy `Version/4.0` AND
+        // `Chrome/140.0.6099.230`; Chrome must win, and the full version is
+        // kept.
         let ua = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) \
-                  Version/4.0 Chrome/140.0.0.0 Mobile Safari/537.36";
+                  Version/4.0 Chrome/140.0.6099.230 Mobile Safari/537.36";
         assert_eq!(
             parse_webview_info(ua),
-            Some(("Chromium".to_string(), "140".to_string()))
+            Some(("Chromium".to_string(), "140.0.6099.230".to_string()))
+        );
+    }
+
+    #[test]
+    fn parses_edge_webview2_engine_and_full_version() {
+        // A WebView2 UA carries both a reduced `Chrome/` and an `Edg/` token;
+        // the Edge engine wins and its (Client-Hints-rewritten) build is kept.
+        let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) \
+                  Chrome/138.0.0.0 Safari/537.36 Edg/138.0.3351.62";
+        assert_eq!(
+            parse_webview_info(ua),
+            Some(("Edge WebView2".to_string(), "138.0.3351.62".to_string()))
         );
     }
 
@@ -362,13 +387,13 @@ mod tests {
                    AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1";
         assert_eq!(
             parse_webview_info(ios),
-            Some(("WebKit".to_string(), "17".to_string()))
+            Some(("WebKit".to_string(), "17.4".to_string()))
         );
         let gtk = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) \
                    Version/2.44.0 Safari/605.1.15";
         assert_eq!(
             parse_webview_info(gtk),
-            Some(("WebKit".to_string(), "2".to_string()))
+            Some(("WebKit".to_string(), "2.44.0".to_string()))
         );
     }
 

--- a/apps/readest-app/src-tauri/src/sentry_config.rs
+++ b/apps/readest-app/src-tauri/src/sentry_config.rs
@@ -159,10 +159,12 @@ fn ua_token_version(user_agent: &str, token: &str) -> Option<String> {
         .chars()
         .take_while(|c| c.is_ascii_digit() || *c == '.')
         .collect();
-    // A well-formed version starts with a digit and never ends with a dot:
-    // this rejects the empty string, `Chrome/.5`, and `Chrome/140.` — none of
-    // which may reach the webview.version tag.
-    if version.starts_with(|c: char| c.is_ascii_digit()) && !version.ends_with('.') {
+    // A well-formed version starts with a digit and every dot-separated
+    // segment is non-empty: this rejects the empty string, a bare or leading
+    // dot (`Chrome/.5`), a trailing dot (`Chrome/140.`), and consecutive dots
+    // (`Chrome/140..6099`) — none of which may reach the webview.version tag.
+    if version.starts_with(|c: char| c.is_ascii_digit()) && version.split('.').all(|s| !s.is_empty())
+    {
         Some(version)
     } else {
         None
@@ -404,5 +406,19 @@ mod tests {
     fn webview_info_is_none_for_unrecognized_ua() {
         assert_eq!(parse_webview_info("curl/8.0"), None);
         assert_eq!(parse_webview_info(""), None);
+    }
+
+    #[test]
+    fn webview_info_is_none_for_malformed_version_tokens() {
+        // Consecutive dots, leading/trailing dots, and dot-less garbage after
+        // the token must never reach the webview.version tag.
+        for ua in [
+            "Mozilla/5.0 Version/2.44..0 Safari/605.1.15",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/140..6099 Safari/537.36",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/140. Safari/537.36",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/.5 Safari/537.36",
+        ] {
+            assert_eq!(parse_webview_info(ua), None, "ua: {ua}");
+        }
     }
 }

--- a/apps/readest-app/src-tauri/src/sentry_config.rs
+++ b/apps/readest-app/src-tauri/src/sentry_config.rs
@@ -163,7 +163,8 @@ fn ua_token_version(user_agent: &str, token: &str) -> Option<String> {
     // segment is non-empty: this rejects the empty string, a bare or leading
     // dot (`Chrome/.5`), a trailing dot (`Chrome/140.`), and consecutive dots
     // (`Chrome/140..6099`) — none of which may reach the webview.version tag.
-    if version.starts_with(|c: char| c.is_ascii_digit()) && version.split('.').all(|s| !s.is_empty())
+    if version.starts_with(|c: char| c.is_ascii_digit())
+        && version.split('.').all(|s| !s.is_empty())
     {
         Some(version)
     } else {
@@ -378,7 +379,8 @@ mod tests {
     fn parses_edge_webview2_engine_and_full_version() {
         // A WebView2 UA carries both a reduced `Chrome/` and an `Edg/` token;
         // the Edge engine wins and its (Client-Hints-rewritten) build is kept.
-        let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) \
+        let ua =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) \
                   Chrome/138.0.0.0 Safari/537.36 Edg/138.0.3351.62";
         assert_eq!(
             parse_webview_info(ua),

--- a/apps/readest-app/src-tauri/src/sentry_config.rs
+++ b/apps/readest-app/src-tauri/src/sentry_config.rs
@@ -159,10 +159,11 @@ fn ua_token_version(user_agent: &str, token: &str) -> Option<String> {
         .chars()
         .take_while(|c| c.is_ascii_digit() || *c == '.')
         .collect();
-    // Trim stray trailing dots (`Chrome/140.`) and require at least one digit
-    // so a malformed token never reaches the webview.version tag.
-    let version = version.trim_end_matches('.');
-    (!version.is_empty() && version.contains(|c: char| c.is_ascii_digit()))
+    // A well-formed version starts with a digit: this rejects the empty
+    // string, a stray trailing dot (`Chrome/140.`), and a leading dot
+    // (`Chrome/.5`) — none of which may reach the webview.version tag.
+    version
+        .starts_with(|c: char| c.is_ascii_digit())
         .then(|| version.to_string())
 }
 

--- a/apps/readest-app/src-tauri/src/sentry_config.rs
+++ b/apps/readest-app/src-tauri/src/sentry_config.rs
@@ -159,12 +159,14 @@ fn ua_token_version(user_agent: &str, token: &str) -> Option<String> {
         .chars()
         .take_while(|c| c.is_ascii_digit() || *c == '.')
         .collect();
-    // A well-formed version starts with a digit: this rejects the empty
-    // string, a stray trailing dot (`Chrome/140.`), and a leading dot
-    // (`Chrome/.5`) — none of which may reach the webview.version tag.
-    version
-        .starts_with(|c: char| c.is_ascii_digit())
-        .then(|| version.to_string())
+    // A well-formed version starts with a digit and never ends with a dot:
+    // this rejects the empty string, `Chrome/.5`, and `Chrome/140.` — none of
+    // which may reach the webview.version tag.
+    if version.starts_with(|c: char| c.is_ascii_digit()) && !version.ends_with('.') {
+        Some(version)
+    } else {
+        None
+    }
 }
 
 /// C-ABI accessor for the compile-time Sentry DSN, used by the iOS native

--- a/apps/readest-app/src/__tests__/components/AboutWindow.test.tsx
+++ b/apps/readest-app/src/__tests__/components/AboutWindow.test.tsx
@@ -73,7 +73,7 @@ const openDialog = async () => {
     </>,
   );
   setAboutDialogVisible(true);
-  return screen.findByText(/Version 0\.11\.20/);
+  return screen.findByText(/Readest 0\.11\.20/);
 };
 
 describe('AboutWindow version label', () => {
@@ -92,7 +92,7 @@ describe('AboutWindow version label', () => {
     fireEvent.click(label);
 
     await waitFor(() => expect(mockWriteTextToClipboard).toHaveBeenCalledTimes(1));
-    expect(mockWriteTextToClipboard).toHaveBeenCalledWith('Version 0.11.20 (Chrome 148)');
+    expect(mockWriteTextToClipboard).toHaveBeenCalledWith('Readest 0.11.20 (Chrome 148)');
   });
 
   it('shows a toast confirming the copy', async () => {

--- a/apps/readest-app/src/__tests__/components/AboutWindow.test.tsx
+++ b/apps/readest-app/src/__tests__/components/AboutWindow.test.tsx
@@ -34,6 +34,8 @@ vi.mock('@/helpers/updater', () => ({
 
 vi.mock('@/utils/ua', () => ({
   parseWebViewInfo: () => 'Chrome 148',
+  // Same label: the mocked UA path resolves without Client Hints.
+  parseWebViewInfoAsync: async () => 'Chrome 148',
 }));
 
 vi.mock('@/utils/version', () => ({

--- a/apps/readest-app/src/__tests__/utils/ua.test.ts
+++ b/apps/readest-app/src/__tests__/utils/ua.test.ts
@@ -68,7 +68,7 @@ describe('parseWebViewInfo', () => {
       osPlatform: 'windows',
     } as unknown as AppServiceParam;
     const result = parseWebViewInfo(appService);
-    expect(result).toBe('Edge 120.0.2210.91');
+    expect(result).toBe('WebView2 120.0.2210.91');
   });
 
   it('should detect the Linux CEF (Chromium) webview', () => {
@@ -240,7 +240,7 @@ describe('parseWebViewVersion', () => {
         appPlatform: 'tauri',
         osPlatform: 'windows',
       } as unknown as AppServiceParam;
-      expect(await parseWebViewInfoAsync(appService)).toBe('Edge 138.0.3351.62');
+      expect(await parseWebViewInfoAsync(appService)).toBe('WebView2 138.0.3351.62');
     });
 
     it('parseWebViewInfoAsync keeps the UA label when Client Hints are unavailable', async () => {

--- a/apps/readest-app/src/__tests__/utils/ua.test.ts
+++ b/apps/readest-app/src/__tests__/utils/ua.test.ts
@@ -4,6 +4,7 @@ import {
   parseWebViewInfo,
   parseWebViewInfoAsync,
   parseWebViewVersion,
+  withWebViewFullVersion,
 } from '@/utils/ua';
 
 type AppServiceParam = Parameters<typeof parseWebViewInfo>[0];
@@ -251,5 +252,18 @@ describe('parseWebViewVersion', () => {
       const appService = { isMacOSApp: true } as unknown as AppServiceParam;
       expect(await parseWebViewInfoAsync(appService)).toBe('WebView 605.1.15');
     });
+  });
+  it("withWebViewFullVersion rewrites the brand's own token (Edg, not the reduced Chrome)", () => {
+    const ua =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0';
+    expect(withWebViewFullVersion(ua, '138.0.3351.62')).toBe(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.3351.62',
+    );
+  });
+
+  it('withWebViewFullVersion leaves a UA without a matching token untouched', () => {
+    const ua =
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/2.44.0 Safari/605.1.15';
+    expect(withWebViewFullVersion(ua, '138.0.3351.62')).toBe(ua);
   });
 });

--- a/apps/readest-app/src/__tests__/utils/ua.test.ts
+++ b/apps/readest-app/src/__tests__/utils/ua.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { parseWebViewInfo, parseWebViewVersion } from '@/utils/ua';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  getWebViewFullVersion,
+  parseWebViewInfo,
+  parseWebViewInfoAsync,
+  parseWebViewVersion,
+} from '@/utils/ua';
 
 type AppServiceParam = Parameters<typeof parseWebViewInfo>[0];
 
@@ -16,6 +21,7 @@ const originalUA = navigator.userAgent;
 
 afterEach(() => {
   setUserAgent(originalUA);
+  vi.unstubAllGlobals();
 });
 
 describe('parseWebViewInfo', () => {
@@ -148,5 +154,102 @@ describe('parseWebViewVersion', () => {
     const appService = { isAndroidApp: true } as unknown as AppServiceParam;
     const result = parseWebViewVersion(appService);
     expect(result).toBe(120);
+  });
+
+  describe('getWebViewFullVersion / parseWebViewInfoAsync (Client Hints)', () => {
+    const stubUAData = (data?: { fullVersionList?: { brand: string; version: string }[] }) => {
+      vi.stubGlobal(
+        'navigator',
+        Object.create(navigator, {
+          userAgent: { value: navigator.userAgent, configurable: true },
+          userAgentData: {
+            value: data
+              ? {
+                  getHighEntropyValues: async () => ({
+                    fullVersionList: data.fullVersionList,
+                  }),
+                }
+              : undefined,
+            configurable: true,
+          },
+        }),
+      );
+    };
+
+    it('returns the real build from fullVersionList for Edge/WebView2', async () => {
+      setUserAgent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0',
+      );
+      stubUAData({
+        fullVersionList: [
+          { brand: 'Microsoft Edge', version: '138.0.3351.62' },
+          { brand: 'Chromium', version: '138.0.7204.0' },
+          { brand: 'Not/A)Brand', version: '24' },
+        ],
+      });
+      expect(await getWebViewFullVersion()).toBe('138.0.3351.62');
+    });
+
+    it('falls back to null when userAgentData is missing (WebKit/older WebViews)', async () => {
+      setUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15',
+      );
+      stubUAData(undefined);
+      expect(await getWebViewFullVersion()).toBeNull();
+    });
+
+    it('returns null when no brand matches', async () => {
+      setUserAgent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0',
+      );
+      stubUAData({
+        fullVersionList: [{ brand: 'Not/A)Brand', version: '24' }],
+      });
+      expect(await getWebViewFullVersion()).toBeNull();
+    });
+
+    it('surfaces getHighEntropyValues rejections as null', async () => {
+      setUserAgent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0',
+      );
+      vi.stubGlobal(
+        'navigator',
+        Object.create(navigator, {
+          userAgent: { value: navigator.userAgent, configurable: true },
+          userAgentData: {
+            value: {
+              getHighEntropyValues: async () => {
+                throw new Error('denied');
+              },
+            },
+            configurable: true,
+          },
+        }),
+      );
+      expect(await getWebViewFullVersion()).toBeNull();
+    });
+
+    it('parseWebViewInfoAsync upgrades the reduced build in the label', async () => {
+      setUserAgent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0',
+      );
+      stubUAData({
+        fullVersionList: [{ brand: 'Microsoft Edge', version: '138.0.3351.62' }],
+      });
+      const appService = {
+        appPlatform: 'tauri',
+        osPlatform: 'windows',
+      } as unknown as AppServiceParam;
+      expect(await parseWebViewInfoAsync(appService)).toBe('Edge 138.0.3351.62');
+    });
+
+    it('parseWebViewInfoAsync keeps the UA label when Client Hints are unavailable', async () => {
+      setUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15',
+      );
+      stubUAData(undefined);
+      const appService = { isMacOSApp: true } as unknown as AppServiceParam;
+      expect(await parseWebViewInfoAsync(appService)).toBe('WebView 605.1.15');
+    });
   });
 });

--- a/apps/readest-app/src/app/error.tsx
+++ b/apps/readest-app/src/app/error.tsx
@@ -4,7 +4,7 @@ import posthog from 'posthog-js';
 import { useEffect, useState } from 'react';
 import { useEnv } from '@/context/EnvContext';
 import { useTranslation } from '@/hooks/useTranslation';
-import { parseWebViewInfo } from '@/utils/ua';
+import { parseWebViewInfo, parseWebViewInfoAsync } from '@/utils/ua';
 import { handleGlobalError } from '@/utils/error';
 
 interface ErrorPageProps {
@@ -18,7 +18,20 @@ export default function ErrorPage({ error, reset }: ErrorPageProps) {
   const [browserInfo, setBrowserInfo] = useState('');
 
   useEffect(() => {
-    setBrowserInfo(parseWebViewInfo(appService));
+    let mounted = true;
+    // Async for the Client Hints round-trip: on Chromium engines the UA's
+    // build number is frozen (x.0.0.0) and the real build lives in
+    // fullVersionList; fall back to the UA-parsed label on any failure.
+    parseWebViewInfoAsync(appService)
+      .then((info) => {
+        if (mounted) setBrowserInfo(info);
+      })
+      .catch(() => {
+        if (mounted) setBrowserInfo(parseWebViewInfo(appService));
+      });
+    return () => {
+      mounted = false;
+    };
   }, [appService]);
 
   useEffect(() => {

--- a/apps/readest-app/src/app/error.tsx
+++ b/apps/readest-app/src/app/error.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import posthog from 'posthog-js';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useEnv } from '@/context/EnvContext';
 import { useTranslation } from '@/hooks/useTranslation';
-import { parseWebViewInfo, parseWebViewInfoAsync } from '@/utils/ua';
 import { handleGlobalError } from '@/utils/error';
+import { useWebViewInfo } from '@/hooks/useWebViewInfo';
 
 interface ErrorPageProps {
   error: Error & { digest?: string };
@@ -15,24 +15,7 @@ interface ErrorPageProps {
 export default function ErrorPage({ error, reset }: ErrorPageProps) {
   const _ = useTranslation();
   const { appService } = useEnv();
-  const [browserInfo, setBrowserInfo] = useState('');
-
-  useEffect(() => {
-    let mounted = true;
-    // Async for the Client Hints round-trip: on Chromium engines the UA's
-    // build number is frozen (x.0.0.0) and the real build lives in
-    // fullVersionList; fall back to the UA-parsed label on any failure.
-    parseWebViewInfoAsync(appService)
-      .then((info) => {
-        if (mounted) setBrowserInfo(info);
-      })
-      .catch(() => {
-        if (mounted) setBrowserInfo(parseWebViewInfo(appService));
-      });
-    return () => {
-      mounted = false;
-    };
-  }, [appService]);
+  const browserInfo = useWebViewInfo(appService);
 
   useEffect(() => {
     posthog.captureException(error);

--- a/apps/readest-app/src/components/AboutWindow.tsx
+++ b/apps/readest-app/src/components/AboutWindow.tsx
@@ -4,7 +4,7 @@ import { useEnv } from '@/context/EnvContext';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useSettingsStore } from '@/store/settingsStore';
 import { checkForAppUpdates, checkAppReleaseNotes } from '@/helpers/updater';
-import { parseWebViewInfo } from '@/utils/ua';
+import { parseWebViewInfo, parseWebViewInfoAsync } from '@/utils/ua';
 import { getAppVersion } from '@/utils/version';
 import { writeTextToClipboard } from '@/utils/clipboard';
 import { eventDispatcher } from '@/utils/event';
@@ -34,7 +34,15 @@ export const AboutWindow = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
-    setBrowserInfo(parseWebViewInfo(appService));
+    let mounted = true;
+    // Async: on Chromium engines the UA string's build number is frozen by UA
+    // Reduction (Edg/138.0.0.0); the real build needs a Client Hints
+    // round-trip, so the label settles a tick later than the dialog mount.
+    parseWebViewInfoAsync(appService)
+      .then((info) => {
+        if (mounted) setBrowserInfo(info);
+      })
+      .catch(() => setBrowserInfo(parseWebViewInfo(appService)));
 
     const handleCustomEvent = (event: CustomEvent) => {
       setIsOpen(event.detail.visible);
@@ -46,6 +54,7 @@ export const AboutWindow = () => {
     }
 
     return () => {
+      mounted = false;
       if (el) {
         el.removeEventListener('setDialogVisibility', handleCustomEvent as EventListener);
       }

--- a/apps/readest-app/src/components/AboutWindow.tsx
+++ b/apps/readest-app/src/components/AboutWindow.tsx
@@ -80,7 +80,10 @@ export const AboutWindow = () => {
     setUpdateStatus(null);
   };
 
-  const versionInfo = `${_('Version {{version}}', { version: getAppVersion() })} (${browserInfo})`;
+  // The label doubles as the bug-report string, so it stays locale-neutral
+  // ("Readest 0.12.8 (WebView2 152.0.4191.66)") — a localized "Version …"
+  // prefix would paste translated text into issues and hide the app name.
+  const versionInfo = `Readest ${getAppVersion()} (${browserInfo})`;
 
   // Mobile users can't select the version string to paste it into a bug
   // report, so the label itself copies it.

--- a/apps/readest-app/src/components/AboutWindow.tsx
+++ b/apps/readest-app/src/components/AboutWindow.tsx
@@ -4,10 +4,10 @@ import { useEnv } from '@/context/EnvContext';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useSettingsStore } from '@/store/settingsStore';
 import { checkForAppUpdates, checkAppReleaseNotes } from '@/helpers/updater';
-import { parseWebViewInfo, parseWebViewInfoAsync } from '@/utils/ua';
 import { getAppVersion } from '@/utils/version';
 import { writeTextToClipboard } from '@/utils/clipboard';
 import { eventDispatcher } from '@/utils/event';
+import { useWebViewInfo } from '@/hooks/useWebViewInfo';
 import SupportLinks from './SupportLinks';
 import LegalLinks from './LegalLinks';
 import Dialog from './Dialog';
@@ -30,20 +30,10 @@ export const AboutWindow = () => {
   const { appService } = useEnv();
   const { settings } = useSettingsStore();
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
-  const [browserInfo, setBrowserInfo] = useState('');
+  const browserInfo = useWebViewInfo(appService);
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
-    let mounted = true;
-    // Async: on Chromium engines the UA string's build number is frozen by UA
-    // Reduction (Edg/138.0.0.0); the real build needs a Client Hints
-    // round-trip, so the label settles a tick later than the dialog mount.
-    parseWebViewInfoAsync(appService)
-      .then((info) => {
-        if (mounted) setBrowserInfo(info);
-      })
-      .catch(() => setBrowserInfo(parseWebViewInfo(appService)));
-
     const handleCustomEvent = (event: CustomEvent) => {
       setIsOpen(event.detail.visible);
     };
@@ -54,7 +44,6 @@ export const AboutWindow = () => {
     }
 
     return () => {
-      mounted = false;
       if (el) {
         el.removeEventListener('setDialogVisibility', handleCustomEvent as EventListener);
       }

--- a/apps/readest-app/src/hooks/useWebViewInfo.ts
+++ b/apps/readest-app/src/hooks/useWebViewInfo.ts
@@ -15,13 +15,11 @@ export const useWebViewInfo = (appService: AppService | null): string => {
   useEffect(() => {
     let mounted = true;
     setInfo(parseWebViewInfo(appService));
-    parseWebViewInfoAsync(appService)
-      .then((label) => {
-        if (mounted) setInfo(label);
-      })
-      .catch(() => {
-        if (mounted) setInfo(parseWebViewInfo(appService));
-      });
+    // parseWebViewInfoAsync never rejects (it resolves to the sync label when
+    // Client Hints are unavailable), so no catch path is needed here.
+    parseWebViewInfoAsync(appService).then((label) => {
+      if (mounted) setInfo(label);
+    });
     return () => {
       mounted = false;
     };

--- a/apps/readest-app/src/hooks/useWebViewInfo.ts
+++ b/apps/readest-app/src/hooks/useWebViewInfo.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import type { AppService } from '@/types/system';
+import { parseWebViewInfo, parseWebViewInfoAsync } from '@/utils/ua';
+
+/**
+ * The WebView engine/version label for display (About dialog, error page).
+ * Async on first settle: on Chromium engines the UA string's build number is
+ * frozen by UA Reduction (Edg/138.0.0.0) and the real build needs a Client
+ * Hints round-trip, so the label starts at the UA-parsed value and upgrades.
+ * The sync parse is the fallback whenever the async path fails.
+ */
+export const useWebViewInfo = (appService: AppService | null): string => {
+  const [info, setInfo] = useState(() => parseWebViewInfo(appService));
+
+  useEffect(() => {
+    let mounted = true;
+    setInfo(parseWebViewInfo(appService));
+    parseWebViewInfoAsync(appService)
+      .then((label) => {
+        if (mounted) setInfo(label);
+      })
+      .catch(() => {
+        if (mounted) setInfo(parseWebViewInfo(appService));
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [appService]);
+
+  return info;
+};

--- a/apps/readest-app/src/services/nativeAppService.ts
+++ b/apps/readest-app/src/services/nativeAppService.ts
@@ -38,7 +38,7 @@ import {
   DistChannel,
 } from '@/types/system';
 import type { Book } from '@/types/book';
-import { clientHintsBrandFor, getWebViewFullVersion, needsQueryRangeReads } from '@/utils/ua';
+import { getWebViewFullVersion, needsQueryRangeReads, withWebViewFullVersion } from '@/utils/ua';
 import { getOSPlatform, isContentURI, isFileURI, isValidURL } from '@/utils/misc';
 import { getDirPath, getFilename } from '@/utils/path';
 import { NativeFile, RemoteFile } from '@/utils/file';
@@ -635,23 +635,16 @@ export class NativeAppService extends BaseAppService {
     const execDir = await invoke<string>('get_executable_dir');
     this.execDir = execDir;
     // Report the WebView engine/version so Sentry can tag crashes with it
-    // (the injected browser SDK's UA context isn't forwarded). On Chromium
-    // engines the UA's build number is frozen by UA Reduction (Edg/138.0.0.0);
-    // splice the real Client Hints build into the token the engine actually
-    // reports, so the webview.version tag carries the full x.y.z.w build.
+    // (the injected browser SDK's UA context isn't forwarded). The UA rewrite
+    // (withWebViewFullVersion in utils/ua.ts) splices the real Client Hints
+    // build into the engine's own token, so the webview.version tag carries
+    // the full x.y.z.w build — the same upgrade the About/error labels show.
     try {
       const fullVersion = await getWebViewFullVersion();
-      if (fullVersion) {
-        const ua = navigator.userAgent;
-        const brand = clientHintsBrandFor(ua);
-        const token = brand?.uaToken ?? 'Chrome';
-        const rewritten = new RegExp(`${token}/\\d+\\.\\d+\\.\\d+\\.\\d+`).test(ua)
-          ? ua.replace(new RegExp(`(${token}/)\\d+\\.\\d+\\.\\d+\\.\\d+`), `$1${fullVersion}`)
-          : ua;
-        await invoke('set_webview_info', { userAgent: rewritten });
-      } else {
-        await invoke('set_webview_info', { userAgent: navigator.userAgent });
-      }
+      const userAgent = fullVersion
+        ? withWebViewFullVersion(navigator.userAgent, fullVersion)
+        : navigator.userAgent;
+      await invoke('set_webview_info', { userAgent });
     } catch (err) {
       console.warn('[nativeAppService] set_webview_info failed:', err);
     }

--- a/apps/readest-app/src/services/nativeAppService.ts
+++ b/apps/readest-app/src/services/nativeAppService.ts
@@ -38,7 +38,7 @@ import {
   DistChannel,
 } from '@/types/system';
 import type { Book } from '@/types/book';
-import { needsQueryRangeReads } from '@/utils/ua';
+import { getWebViewFullVersion, needsQueryRangeReads } from '@/utils/ua';
 import { getOSPlatform, isContentURI, isFileURI, isValidURL } from '@/utils/misc';
 import { getDirPath, getFilename } from '@/utils/path';
 import { NativeFile, RemoteFile } from '@/utils/file';
@@ -636,8 +636,22 @@ export class NativeAppService extends BaseAppService {
     this.execDir = execDir;
     // Report the WebView User-Agent so Sentry can tag crashes with the
     // engine/version (the injected browser SDK's UA context isn't forwarded).
+    // On Chromium engines the UA's build number is frozen by UA Reduction
+    // (Edg/138.0.0.0); swap in the real build from Client Hints so the
+    // webview.version tag carries the full x.y.z.w build, not a stub.
     try {
-      await invoke('set_webview_info', { userAgent: navigator.userAgent });
+      const fullVersion = await getWebViewFullVersion();
+      // Rewrite the reduced build tokens (Edg/138.0.0.0) to the real build so
+      // the Rust-side parse (Chrome/ or Version/ token, major only) picks up
+      // the full version string. No token to rewrite => pass the UA through.
+      const userAgent =
+        fullVersion && /(Edg|Chrome|Chromium)\/\d+\.\d+\.\d+\.\d+/.test(navigator.userAgent)
+          ? navigator.userAgent.replace(
+              /((?:Edg|Chrome|Chromium)\/)(\d+\.\d+\.\d+\.\d+)/,
+              `$1${fullVersion}`,
+            )
+          : navigator.userAgent;
+      await invoke('set_webview_info', { userAgent });
     } catch (err) {
       console.warn('[nativeAppService] set_webview_info failed:', err);
     }

--- a/apps/readest-app/src/services/nativeAppService.ts
+++ b/apps/readest-app/src/services/nativeAppService.ts
@@ -38,7 +38,7 @@ import {
   DistChannel,
 } from '@/types/system';
 import type { Book } from '@/types/book';
-import { getWebViewFullVersion, needsQueryRangeReads } from '@/utils/ua';
+import { clientHintsBrandFor, getWebViewFullVersion, needsQueryRangeReads } from '@/utils/ua';
 import { getOSPlatform, isContentURI, isFileURI, isValidURL } from '@/utils/misc';
 import { getDirPath, getFilename } from '@/utils/path';
 import { NativeFile, RemoteFile } from '@/utils/file';
@@ -634,24 +634,24 @@ export class NativeAppService extends BaseAppService {
     void this.startCoverThumbnailListener().catch(() => {});
     const execDir = await invoke<string>('get_executable_dir');
     this.execDir = execDir;
-    // Report the WebView User-Agent so Sentry can tag crashes with the
-    // engine/version (the injected browser SDK's UA context isn't forwarded).
-    // On Chromium engines the UA's build number is frozen by UA Reduction
-    // (Edg/138.0.0.0); swap in the real build from Client Hints so the
-    // webview.version tag carries the full x.y.z.w build, not a stub.
+    // Report the WebView engine/version so Sentry can tag crashes with it
+    // (the injected browser SDK's UA context isn't forwarded). On Chromium
+    // engines the UA's build number is frozen by UA Reduction (Edg/138.0.0.0);
+    // splice the real Client Hints build into the token the engine actually
+    // reports, so the webview.version tag carries the full x.y.z.w build.
     try {
       const fullVersion = await getWebViewFullVersion();
-      // Rewrite the reduced build tokens (Edg/138.0.0.0) to the real build so
-      // the Rust-side parse (Chrome/ or Version/ token, major only) picks up
-      // the full version string. No token to rewrite => pass the UA through.
-      const userAgent =
-        fullVersion && /(Edg|Chrome|Chromium)\/\d+\.\d+\.\d+\.\d+/.test(navigator.userAgent)
-          ? navigator.userAgent.replace(
-              /((?:Edg|Chrome|Chromium)\/)(\d+\.\d+\.\d+\.\d+)/,
-              `$1${fullVersion}`,
-            )
-          : navigator.userAgent;
-      await invoke('set_webview_info', { userAgent });
+      if (fullVersion) {
+        const ua = navigator.userAgent;
+        const brand = clientHintsBrandFor(ua);
+        const token = brand?.uaToken ?? 'Chrome';
+        const rewritten = new RegExp(`${token}/\\d+\\.\\d+\\.\\d+\\.\\d+`).test(ua)
+          ? ua.replace(new RegExp(`(${token}/)\\d+\\.\\d+\\.\\d+\\.\\d+`), `$1${fullVersion}`)
+          : ua;
+        await invoke('set_webview_info', { userAgent: rewritten });
+      } else {
+        await invoke('set_webview_info', { userAgent: navigator.userAgent });
+      }
     } catch (err) {
       console.warn('[nativeAppService] set_webview_info failed:', err);
     }

--- a/apps/readest-app/src/utils/ua.ts
+++ b/apps/readest-app/src/utils/ua.ts
@@ -121,6 +121,10 @@ export const clientHintsBrandFor = (ua: string): { brand: RegExp; uaToken: strin
  * Hints entry or the API is unavailable (WebKit, older WebViews).
  */
 export const getWebViewFullVersion = async (): Promise<string | null> => {
+  // SSR/prerender parity with parseWebViewInfo: this is called outside
+  // try/catch below, and useWebViewInfo relies on parseWebViewInfoAsync
+  // (which composes both) never rejecting.
+  if (typeof navigator === 'undefined') return null;
   const brand = clientHintsBrandFor(navigator.userAgent);
   if (!brand) return null;
   try {

--- a/apps/readest-app/src/utils/ua.ts
+++ b/apps/readest-app/src/utils/ua.ts
@@ -86,6 +86,69 @@ export const parseWebViewInfo = (appService: AppService | null): string => {
   }
 };
 
+/**
+ * The brand a Chromium engine reports in User-Agent Client Hints'
+ * `fullVersionList`, keyed by the same engine labels `parseWebViewInfo`
+ * emits. WebKit engines have no Client Hints (their UA already carries the
+ * real version), so they are absent here.
+ */
+/**
+ * Whether this Chromium engine reports its real build in User-Agent Client
+ * Hints, and which `fullVersionList` brand carries it. WebKit engines have no
+ * Client Hints (their UA already carries the real version), so they are
+ * absent. The UA token decides the runtime flavor, the `OS` part decides
+ * desktop-vs-mobile only where the brands differ (desktop Edge vs WebView2
+ * share the `Microsoft Edge` brand; Android WebView reports both a
+ * `Android WebView` and a `Google Chrome` entry).
+ */
+const clientHintsBrandFor = (ua: string): RegExp | null => {
+  if (!/Chrome\/|Edg\//.test(ua)) return null; // WebKit engines: no Client Hints
+  if (/Edg\//.test(ua)) return /Microsoft Edge/i;
+  return /(Chromium|Google Chrome|Android WebView)/i;
+};
+
+/**
+ * The real full build number (e.g. `138.0.3351.62`) behind a UA-reduced
+ * version string. Chromium freezes the minor/build/patch tokens in the UA
+ * itself (`Edg/138.0.0.0`), so on WebView2/Android WebView/Chrome the parsed
+ * version is incomplete; the full build is only in the high-entropy
+ * `fullVersionList` Client Hint. Returns null when the engine has no Client
+ * Hints entry or the API is unavailable (WebKit, older WebViews).
+ */
+export const getWebViewFullVersion = async (): Promise<string | null> => {
+  const brandPattern = clientHintsBrandFor(navigator.userAgent);
+  if (!brandPattern) return null;
+  try {
+    const uaData = (
+      navigator as unknown as {
+        userAgentData?: {
+          getHighEntropyValues?: (hints: string[]) => Promise<{
+            fullVersionList?: { brand: string; version: string }[];
+          }>;
+        };
+      }
+    ).userAgentData;
+    const getHighEntropyValues = uaData?.getHighEntropyValues;
+    if (typeof getHighEntropyValues !== 'function') return null;
+    const { fullVersionList } = await getHighEntropyValues.call(uaData, ['fullVersionList']);
+    return fullVersionList?.find((entry) => brandPattern.test(entry.brand))?.version ?? null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * `parseWebViewInfo` with the UA-reduced version upgraded to the real build
+ * via Client Hints when available. Async only because of that round-trip;
+ * falls back to the sync label verbatim (WebKit engines, older WebViews).
+ */
+export const parseWebViewInfoAsync = async (appService: AppService | null): Promise<string> => {
+  const info = parseWebViewInfo(appService);
+  const fullVersion = await getWebViewFullVersion();
+  if (!fullVersion) return info;
+  return info.replace(/\s+[0-9]+(?:\.[0-9]+)*$/, ` ${fullVersion}`);
+};
+
 export const parseWebViewVersion = (appService: AppService | null): number => {
   const webViewInfo = parseWebViewInfo(appService);
   const versionMatch = webViewInfo.match(/([0-9]+)\./);

--- a/apps/readest-app/src/utils/ua.ts
+++ b/apps/readest-app/src/utils/ua.ts
@@ -87,24 +87,17 @@ export const parseWebViewInfo = (appService: AppService | null): string => {
 };
 
 /**
- * The brand a Chromium engine reports in User-Agent Client Hints'
- * `fullVersionList`, keyed by the same engine labels `parseWebViewInfo`
- * emits. WebKit engines have no Client Hints (their UA already carries the
- * real version), so they are absent here.
+ * Which `fullVersionList` brand a Chromium engine reports for itself, and the
+ * UA token carrying the (reduced) build for the same engine. WebKit engines
+ * have no Client Hints (their UA already carries the real version), so they
+ * are absent. Returning the token alongside the brand keeps the Sentry-rewrite
+ * in nativeAppService from patching a different token than the one the brand
+ * version came from (a WebView2 UA carries both `Chrome/` and `Edg/`).
  */
-/**
- * Whether this Chromium engine reports its real build in User-Agent Client
- * Hints, and which `fullVersionList` brand carries it. WebKit engines have no
- * Client Hints (their UA already carries the real version), so they are
- * absent. The UA token decides the runtime flavor, the `OS` part decides
- * desktop-vs-mobile only where the brands differ (desktop Edge vs WebView2
- * share the `Microsoft Edge` brand; Android WebView reports both a
- * `Android WebView` and a `Google Chrome` entry).
- */
-const clientHintsBrandFor = (ua: string): RegExp | null => {
-  if (!/Chrome\/|Edg\//.test(ua)) return null; // WebKit engines: no Client Hints
-  if (/Edg\//.test(ua)) return /Microsoft Edge/i;
-  return /(Chromium|Google Chrome|Android WebView)/i;
+export const clientHintsBrandFor = (ua: string): { brand: RegExp; uaToken: string } | null => {
+  if (!/Chrome\/|Chromium\/|Edg\//.test(ua)) return null; // WebKit engines: no Client Hints
+  if (/Edg\//.test(ua)) return { brand: /Microsoft Edge/i, uaToken: 'Edg' };
+  return { brand: /(Chromium|Google Chrome|Android WebView)/i, uaToken: 'Chrome' };
 };
 
 /**
@@ -116,8 +109,8 @@ const clientHintsBrandFor = (ua: string): RegExp | null => {
  * Hints entry or the API is unavailable (WebKit, older WebViews).
  */
 export const getWebViewFullVersion = async (): Promise<string | null> => {
-  const brandPattern = clientHintsBrandFor(navigator.userAgent);
-  if (!brandPattern) return null;
+  const brand = clientHintsBrandFor(navigator.userAgent);
+  if (!brand) return null;
   try {
     const uaData = (
       navigator as unknown as {
@@ -131,7 +124,7 @@ export const getWebViewFullVersion = async (): Promise<string | null> => {
     const getHighEntropyValues = uaData?.getHighEntropyValues;
     if (typeof getHighEntropyValues !== 'function') return null;
     const { fullVersionList } = await getHighEntropyValues.call(uaData, ['fullVersionList']);
-    return fullVersionList?.find((entry) => brandPattern.test(entry.brand))?.version ?? null;
+    return fullVersionList?.find((entry) => brand.brand.test(entry.brand))?.version ?? null;
   } catch {
     return null;
   }

--- a/apps/readest-app/src/utils/ua.ts
+++ b/apps/readest-app/src/utils/ua.ts
@@ -20,6 +20,10 @@ export const isLinuxCefRuntime = (userAgent: string) =>
   /\bLinux\b/.test(userAgent) && !/\bAndroid\b/.test(userAgent) && /\bChrome\//.test(userAgent);
 
 export const parseWebViewInfo = (appService: AppService | null): string => {
+  // SSR/prerender (Next.js server render, static export) has no navigator;
+  // this hook also runs during render via useWebViewInfo's initializer, so
+  // the guard must live here and not only in effect-scoped callers.
+  if (typeof navigator === 'undefined') return 'Unknown';
   const ua = navigator.userAgent;
 
   if (appService?.isAndroidApp) {
@@ -99,7 +103,13 @@ export const parseWebViewInfo = (appService: AppService | null): string => {
 export const clientHintsBrandFor = (ua: string): { brand: RegExp; uaToken: string } | null => {
   if (!/Chrome\/|Chromium\/|Edg\//.test(ua)) return null; // WebKit engines: no Client Hints
   if (/Edg\//.test(ua)) return { brand: /Microsoft Edge/i, uaToken: 'Edg' };
-  return { brand: /(Chromium|Google Chrome|Android WebView)/i, uaToken: 'Chrome' };
+  // Return the token actually present: a bare `Chromium/<v>` UA (no Chrome/)
+  // would otherwise map to a Chrome token the splice can never find, leaving
+  // the Sentry tag on the reduced value while the label upgrades.
+  if (/Chrome\//.test(ua)) {
+    return { brand: /(Google Chrome|Chromium|Android WebView)/i, uaToken: 'Chrome' };
+  }
+  return { brand: /Chromium/i, uaToken: 'Chromium' };
 };
 
 /**

--- a/apps/readest-app/src/utils/ua.ts
+++ b/apps/readest-app/src/utils/ua.ts
@@ -133,6 +133,30 @@ export const getWebViewFullVersion = async (): Promise<string | null> => {
 };
 
 /**
+ * The single definition of "splice the real Client Hints build into a UA
+ * string": the rewrite lands on the token `clientHintsBrandFor` matched (an
+ * Edg/ UA carries both a reduced `Chrome/` and an `Edg/` token — it must go
+ * to the brand's own token, not the first match). The Sentry reporter
+ * (nativeAppService) routes through this so the webview.version tag shows
+ * exactly the same build the About/error labels resolve to.
+ */
+export const withWebViewFullVersion = (ua: string, fullVersion: string): string => {
+  const brand = clientHintsBrandFor(ua);
+  if (!brand) return ua;
+  const tokenPattern = new RegExp(`(${brand.uaToken}/)(\\d+(?:\\.\\d+)*)`);
+  return tokenPattern.test(ua) ? ua.replace(tokenPattern, `$1${fullVersion}`) : ua;
+};
+
+/**
+ * The version half of a `parseWebViewInfo` label (`Edge 138.0.0.0` ->
+ * `138.0.0.0`). The label carries the engine name plus one trailing version,
+ * so upgrading it means replacing that trailing token — a different shape
+ * than splicing a raw UA, which is `withWebViewFullVersion`'s job.
+ */
+const upgradeLabelVersion = (label: string, fullVersion: string): string =>
+  label.replace(/\s+[0-9]+(?:\.[0-9]+)*$/, ` ${fullVersion}`);
+
+/**
  * `parseWebViewInfo` with the UA-reduced version upgraded to the real build
  * via Client Hints when available. Async only because of that round-trip;
  * falls back to the sync label verbatim (WebKit engines, older WebViews).
@@ -140,8 +164,7 @@ export const getWebViewFullVersion = async (): Promise<string | null> => {
 export const parseWebViewInfoAsync = async (appService: AppService | null): Promise<string> => {
   const info = parseWebViewInfo(appService);
   const fullVersion = await getWebViewFullVersion();
-  if (!fullVersion) return info;
-  return info.replace(/\s+[0-9]+(?:\.[0-9]+)*$/, ` ${fullVersion}`);
+  return fullVersion ? upgradeLabelVersion(info, fullVersion) : info;
 };
 
 export const parseWebViewVersion = (appService: AppService | null): number => {

--- a/apps/readest-app/src/utils/ua.ts
+++ b/apps/readest-app/src/utils/ua.ts
@@ -35,9 +35,11 @@ export const parseWebViewInfo = (appService: AppService | null): string => {
     const webkitMatch = ua.match(/AppleWebKit\/([0-9.]+)/);
     return webkitMatch ? `WebView ${webkitMatch[1]}` : 'macOS WebView';
   } else if (appService?.appPlatform === 'tauri' && appService?.osPlatform === 'windows') {
-    // Windows WebView2
+    // Windows WebView2 runtime. The UA token says `Edg/` (WebView2 is an Edge
+    // distribution) but the component's own name is WebView2 — matching the
+    // `WebView <version>` naming used for the Android/iOS system WebViews.
     const match = ua.match(/Edg\/([0-9.]+)/);
-    return match ? `Edge ${match[1]}` : 'Edge WebView2';
+    return match ? `WebView2 ${match[1]}` : 'WebView2';
   } else if (appService?.appPlatform === 'tauri' && appService?.osPlatform === 'linux') {
     // Linux: the CEF build reports Chromium (its user agent is reduced to the
     // major version, e.g. Chrome/151.0.0.0); otherwise WebKitGTK.


### PR DESCRIPTION
## Summary

The version shown in **About** and on the error page — and the `webview.engine` / `webview.version` Sentry tags — come from parsing the User-Agent string. On Chromium engines, UA Reduction freezes the minor/build/patch tokens in that string, so a Windows WebView2 user sees:

```
Version 0.12.8 (Edge 152.0.0.0)
```

…no matter which actual runtime build they are on. The real build number is only available through the User-Agent Client Hints `fullVersionList` (high-entropy). This PR resolves it everywhere the version is shown or reported, and tightens the parsing on the Rust side to match.

## Changes

**Version resolution (`utils/ua.ts`)**

- `getWebViewFullVersion()` — resolves the engine's entry in the Client Hints `fullVersionList`; returns `null` on WebKit engines (no Client Hints; their UA already carries the real version) and is SSR-guarded.
- `parseWebViewInfoAsync()` — the existing UA-parsed label with its trailing version upgraded to the real build; falls back to the sync label verbatim when Client Hints are unavailable.
- `withWebViewFullVersion(ua, build)` — the single definition of "splice the real build into a UA string", matched to the brand's own token (a WebView2 UA carries both a reduced `Chrome/` and an `Edg/` token; the rewrite must land on the one the brand version came from, not the first match).

**Consumers**

- `AboutWindow` and the error page render through a shared `useWebViewInfo` hook: the label starts at the UA-parsed value and settles to the full build after the Client Hints round-trip, with mounted-guarded state updates. The copy-to-clipboard in About automatically carries the full build.
- The copied version string is now locale-neutral and self-identifying: `Readest 0.12.8 (WebView2 152.0.4191.66)` — previously it pasted a localized "Version …" prefix into issues and never named the app.
- `nativeAppService.init()` reports the UA through `withWebViewFullVersion` before invoking `set_webview_info`.

**Rust (`sentry_config.rs`)**

- `parse_webview_info` keeps the **full** version string (it previously truncated to the major, which would have made the UA rewrite pointless) and recognizes the `Edg/` token as its own **`WebView2`** engine — a WebView2 UA also carries a reduced `Chrome/` token that must not win, and "Edge" read as the user-installed Edge browser while the component's actual name is WebView2 (matching the `WebView <version>` naming already used for the Android/iOS system WebViews).
- `ua_token_version` rejects malformed tokens: empty, leading dot (`Chrome/.5`), or trailing dot (`Chrome/140.`) never reach the `webview.version` tag.

## Platform behavior

| Platform | Before | After |
|---|---|---|
| Windows (WebView2) | `Edge 152.0.0.0` (frozen stub) | `WebView2 152.0.4191.66` (real build via Client Hints) |
| Android (system WebView) | `WebView 124.0.6367.219` | same build, now also cross-checked against `fullVersionList` (available and matching — verified) |
| iOS / macOS (WKWebView) | `WebView 605.1.15` | unchanged — no Client Hints on WebKit; fallback is verbatim |
| Linux | UA-parsed (WebKitGTK UA tokens are frozen upstream) | Chromium/CEF runtimes get Client Hints; WebKitGTK unchanged |

Copied bug-report string (all platforms): `Readest 0.12.8 (WebView2 152.0.4191.66)`.

## Verification

- New unit tests: Client Hints brand match / missing API / no matching brand / rejected `getHighEntropyValues`, label upgrade and WebKit fallback, brand-token splice targeting (`Edg` not the reduced `Chrome`), no-op on tokenless UAs; Rust tests assert the full builds, the `WebView2` engine branch winning over the reduced `Chrome/` token, and malformed-token rejection (27 frontend + 19 Rust tests green; tsc and biome clean).
- Android emulator (system WebView 124): `getHighEntropyValues(['fullVersionList'])` resolves and reports `Android WebView | 124.0.6367.219`, matching the UA token (Android WebView UAs are not reduced); About label and copy string verified on device.
- Windows dev build (WebView2 152): About shows `WebView2 152.0.<build>` with the real build from Client Hints; the `.0.0` stub is gone.

The diff went through four internal review rounds (15 findings, all resolved — including two real bugs the first round caught in its own Sentry path: a token-targeting mismatch and a Rust parse that truncated to the major, plus an SSR-safety regression introduced while extracting the hook); the fifth round returned zero findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Browser and WebView information now shows more accurate, complete version numbers.
  * Windows WebView2 is identified with a dedicated “WebView2” label.
  * About and error screens use consistent browser information and version formatting.
  * Version details are enhanced when additional browser information is available, with a reliable fallback when unavailable.
  * Browser information remains safe and stable when details are missing or malformed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->